### PR TITLE
TAGTOA Pay: expand supported payment methods

### DIFF
--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -30,14 +30,29 @@ class TagtoaDemoSeeder extends Seeder
             ['alias' => 'demo'],
             ['title' => 'Payez TAGTOA Demo', 'default_currency' => 'HTG', 'is_active' => true]
         );
-        PaymentMethod::firstOrCreate(
-            ['payment_page_id' => $pay->id, 'type' => 'moncash'],
-            ['label' => 'MonCash', 'account_holder' => 'TAGTOA Demo', 'account_number' => '+509 0000 0000', 'requires_proof' => true, 'is_active' => true, 'sort' => 1]
-        );
-        PaymentMethod::firstOrCreate(
-            ['payment_page_id' => $pay->id, 'type' => 'natcash'],
-            ['label' => 'NatCash', 'account_holder' => 'TAGTOA Demo', 'account_number' => '+509 1111 1111', 'requires_proof' => true, 'is_active' => true, 'sort' => 2]
-        );
+        $demoMethods = [
+            ['moncash',     '+509 3000 0000'],
+            ['natcash',     '+509 4000 0000'],
+            ['unibank',     'Unibank • 011-xxxxxxx'],
+            ['sogebank',    'Sogebank • 021-xxxxxxx'],
+            ['bnc',         'BNC • 031-xxxxxxx'],
+            ['zelle',       'pay@tagtoa.com'],
+            ['cashapp',     '$tagtoa'],
+            ['paypal',      'paypal@tagtoa.com'],
+            ['card',        'VISA / Mastercard'],
+            ['usdt',        'TRC20 • Txxxxxxxxxxxxxxxx'],
+            ['btc',         'bc1qxxxxxxxxxxxxxxxx'],
+            ['eth',         '0xXXXXXXXXXXXXXXXX'],
+            ['cash',        'Sou plas'],
+            ['tagtoa_card', 'Carte TAGTOA'],
+        ];
+        $needsProof = ['moncash', 'natcash', 'unibank', 'sogebank', 'bnc', 'zelle', 'cashapp', 'paypal', 'usdt', 'btc', 'eth'];
+        foreach ($demoMethods as $i => [$type, $acct]) {
+            PaymentMethod::firstOrCreate(
+                ['payment_page_id' => $pay->id, 'type' => $type],
+                ['account_holder' => 'TAGTOA Demo', 'account_number' => $acct, 'requires_proof' => in_array($type, $needsProof, true), 'is_active' => true, 'sort' => $i]
+            );
+        }
 
         // 2) LOYALTY — programme + 1 carte
         $program = Program::firstOrCreate(

--- a/Modules/Tagtoa/app/Models/Pay/PaymentMethod.php
+++ b/Modules/Tagtoa/app/Models/Pay/PaymentMethod.php
@@ -33,7 +33,7 @@ class PaymentMethod extends Model
     public function getMetaAttribute(): array
     {
         return PaymentPage::METHODS[$this->type]
-            ?? ['label' => ucfirst($this->type), 'icon' => 'fa-money-check-dollar', 'region' => 'other'];
+            ?? ['label' => ucfirst($this->type), 'icon' => 'fa-solid fa-money-check-dollar', 'region' => 'other'];
     }
 
     public function getDisplayLabelAttribute(): string

--- a/Modules/Tagtoa/app/Models/Pay/PaymentPage.php
+++ b/Modules/Tagtoa/app/Models/Pay/PaymentPage.php
@@ -22,16 +22,37 @@ class PaymentPage extends Model
 
     protected $casts = ['is_active' => 'boolean', 'views' => 'integer'];
 
-    /** Méthodes supportées : label + icône + région (pour le regroupement UI). */
+    /** Méthodes supportées : label + icône (classe FA complète) + région (groupe UI). */
     public const METHODS = [
-        'moncash'  => ['label' => 'MonCash',          'icon' => 'fa-mobile-screen-button', 'region' => 'haiti'],
-        'natcash'  => ['label' => 'NatCash',          'icon' => 'fa-mobile-screen-button', 'region' => 'haiti'],
-        'cash'     => ['label' => 'Cash',             'icon' => 'fa-money-bill-wave',       'region' => 'local'],
-        'zelle'    => ['label' => 'Zelle',            'icon' => 'fa-dollar-sign',          'region' => 'diaspora'],
-        'paypal'   => ['label' => 'PayPal',           'icon' => 'fa-paypal',               'region' => 'intl'],
-        'card'     => ['label' => 'Carte bancaire',   'icon' => 'fa-credit-card',          'region' => 'intl'],
-        'bank'     => ['label' => 'Virement bancaire','icon' => 'fa-building-columns',     'region' => 'intl'],
-        'usdt'     => ['label' => 'USDT / Crypto',    'icon' => 'fa-bitcoin-sign',         'region' => 'intl'],
+        // Haïti — mobile money
+        'moncash'     => ['label' => 'MonCash',                  'icon' => 'fa-solid fa-mobile-screen-button', 'region' => 'haiti'],
+        'natcash'     => ['label' => 'NatCash',                  'icon' => 'fa-solid fa-mobile-screen-button', 'region' => 'haiti'],
+        'lajancash'   => ['label' => 'LajanCash',               'icon' => 'fa-solid fa-mobile-screen-button', 'region' => 'haiti'],
+        // Haïti — virements bancaires
+        'unibank'     => ['label' => 'Virement Unibank',        'icon' => 'fa-solid fa-building-columns',      'region' => 'haiti'],
+        'sogebank'    => ['label' => 'Virement Sogebank',       'icon' => 'fa-solid fa-building-columns',      'region' => 'haiti'],
+        'bnc'         => ['label' => 'Virement BNC',            'icon' => 'fa-solid fa-building-columns',      'region' => 'haiti'],
+        'capitalbank' => ['label' => 'Virement Capital Bank',   'icon' => 'fa-solid fa-building-columns',      'region' => 'haiti'],
+        'buh'         => ['label' => 'Virement BUH',            'icon' => 'fa-solid fa-building-columns',      'region' => 'haiti'],
+        // Cash
+        'cash'        => ['label' => 'Cash',                     'icon' => 'fa-solid fa-money-bill-wave',       'region' => 'local'],
+        'cod'         => ['label' => 'Cash on Delivery',        'icon' => 'fa-solid fa-box-open',              'region' => 'local'],
+        // Diaspora / international
+        'zelle'       => ['label' => 'Zelle',                    'icon' => 'fa-solid fa-dollar-sign',           'region' => 'diaspora'],
+        'cashapp'     => ['label' => 'Cash App',                'icon' => 'fa-solid fa-dollar-sign',           'region' => 'diaspora'],
+        'venmo'       => ['label' => 'Venmo',                    'icon' => 'fa-solid fa-dollar-sign',           'region' => 'diaspora'],
+        'paypal'      => ['label' => 'PayPal',                   'icon' => 'fa-brands fa-paypal',               'region' => 'intl'],
+        'card'        => ['label' => 'Carte (VISA/Mastercard)', 'icon' => 'fa-solid fa-credit-card',           'region' => 'intl'],
+        'bank_intl'   => ['label' => 'Virement international',   'icon' => 'fa-solid fa-building-columns',       'region' => 'intl'],
+        'wise'        => ['label' => 'Wise',                     'icon' => 'fa-solid fa-money-bill-transfer',   'region' => 'intl'],
+        // Crypto
+        'usdt'        => ['label' => 'USDT (Tether)',           'icon' => 'fa-solid fa-dollar-sign',           'region' => 'crypto'],
+        'btc'         => ['label' => 'Bitcoin (BTC)',          'icon' => 'fa-brands fa-bitcoin',              'region' => 'crypto'],
+        'eth'         => ['label' => 'Ethereum (ETH)',         'icon' => 'fa-brands fa-ethereum',             'region' => 'crypto'],
+        'binance'     => ['label' => 'Binance Pay',            'icon' => 'fa-solid fa-coins',                 'region' => 'crypto'],
+        'crypto'      => ['label' => 'Autre crypto',           'icon' => 'fa-solid fa-coins',                 'region' => 'crypto'],
+        // TAGTOA
+        'tagtoa_card' => ['label' => 'Carte TAGTOA',           'icon' => 'fa-solid fa-id-card',               'region' => 'tagtoa'],
     ];
 
     public static function generateAlias(string $base): string

--- a/Modules/Tagtoa/resources/views/pay/show.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/show.blade.php
@@ -69,7 +69,7 @@
         <div class="methods" id="methods">
             @foreach($methods as $m)
                 <button type="button" class="m" data-id="{{ $m->id }}" onclick="pick(this,{{ $m->id }})">
-                    <span class="m-ic"><i class="fa-solid {{ $m->icon }}"></i></span>
+                    <span class="m-ic"><i class="{{ $m->icon }}"></i></span>
                     <span class="m-tx"><b>{{ $m->display_label }}</b><span>{{ $m->account_number ?: ($m->account_holder ?: __('Voir détails')) }}</span></span>
                     <span class="m-ck"><i class="fa-solid fa-check"></i></span>
                 </button>


### PR DESCRIPTION
Expand the choosable payment methods on a TAGTOA Pay page: Haiti mobile money
(MonCash/NatCash/LajanCash), Haiti bank transfers (Unibank, Sogebank, BNC,
Capital Bank, BUH), Cash/COD, diaspora & international (Zelle, Cash App, Venmo,
PayPal, Card VISA/Mastercard, international transfer, Wise), crypto (USDT, BTC,
ETH, Binance, other), and Carte TAGTOA. Brand icons supported. Demo seeder
seeds a representative set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_