### PR TITLE
TAGTOA: allow super_admin on dashboard (fix 403)

### DIFF
--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -36,7 +36,7 @@ Route::get('/event/ticket/{code}', [EventPublic::class, 'ticket'])->name('tagtoa
 // Middleware aligné sur le back-office Biztap (confirmé dans routes/web.php) :
 // auth + valid.user + role:admin + multi_tenant (initialise le tenant courant
 // pour getLogInTenantId()). Retirer/adapter si votre groupe diffère.
-Route::middleware(['auth', 'valid.user', 'role:admin', 'multi_tenant'])->prefix('tagtoa')->group(function () {
+Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant'])->prefix('tagtoa')->group(function () {
 
     Route::get('/', [HubController::class, 'index'])->name('tagtoa.hub');
 


### PR DESCRIPTION
Dashboard required `role:admin`, returning 403 for the platform owner
(`super_admin`). Allow `role:admin|super_admin` so the owner can access/test while
merchants (admin) keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_