### PR TITLE
TAGTOA: fix /tagtoa 404 (move hub to /tagtoa/home)

### DIFF
--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -90,7 +90,7 @@
     <aside class="sb" id="sb">
         <div class="brand"><span class="logo">⚡</span><b>TAGTOA</b></div>
         <nav class="nav">
-            <a href="{{ url('/tagtoa') }}" class="{{ request()->is('tagtoa') ? 'on' : '' }}"><i class="fa-solid fa-grip"></i> {{ __('Accueil') }}</a>
+            <a href="{{ url('/tagtoa/home') }}" class="{{ request()->is('tagtoa/home') ? 'on' : '' }}"><i class="fa-solid fa-grip"></i> {{ __('Accueil') }}</a>
             <span class="sep">{{ __('Modules') }}</span>
             <a href="{{ url('/tagtoa/pay') }}" class="{{ request()->is('tagtoa/pay*') ? 'on' : '' }}"><i class="fa-solid fa-money-bill-transfer"></i> {{ __('Paiements') }}</a>
             <a href="{{ url('/tagtoa/loyalty') }}" class="{{ request()->is('tagtoa/loyalty*') ? 'on' : '' }}"><i class="fa-solid fa-id-card"></i> {{ __('Fidélité') }}</a>

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -38,7 +38,10 @@ Route::get('/event/ticket/{code}', [EventPublic::class, 'ticket'])->name('tagtoa
 // pour getLogInTenantId()). Retirer/adapter si votre groupe diffère.
 Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant'])->prefix('tagtoa')->group(function () {
 
-    Route::get('/', [HubController::class, 'index'])->name('tagtoa.hub');
+    // Accueil sur /tagtoa/home (le segment unique /tagtoa entre en conflit avec
+    // la route vcard {alias} de Biztap). /tagtoa redirige vers /tagtoa/home.
+    Route::get('/', fn () => redirect('/tagtoa/home'));
+    Route::get('/home', [HubController::class, 'index'])->name('tagtoa.hub');
 
     // PAY
     Route::prefix('pay')->name('tagtoa.pay.dashboard.')->group(function () {


### PR DESCRIPTION
Bare `/tagtoa` (1 segment) collides with Biztap's vcard `{alias}` catch-all,
causing 404. Move the hub to `/tagtoa/home` and redirect `/tagtoa` → `/tagtoa/home`.
Other dashboard URLs (`/tagtoa/pay`, etc.) are 2-segment and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_