### PR TITLE
TAGTOA: MENU module (digital menu for restaurants, clubs, lounges, hotels)

### DIFF
--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -7,6 +7,7 @@ use Modules\Tagtoa\App\Models\Event\Event;
 use Modules\Tagtoa\App\Models\Links\Link;
 use Modules\Tagtoa\App\Models\Links\LinkPage;
 use Modules\Tagtoa\App\Models\Loyalty\Program;
+use Modules\Tagtoa\App\Models\Menu\Menu;
 use Modules\Tagtoa\App\Models\Pay\PaymentMethod;
 use Modules\Tagtoa\App\Models\Pay\PaymentPage;
 use Modules\Tagtoa\App\Models\Pos\Product;
@@ -90,7 +91,45 @@ class TagtoaDemoSeeder extends Seeder
         );
         $event->ticketTypes()->firstOrCreate(['name' => 'Standard'], ['price' => 0, 'quantity' => 200, 'is_active' => true]);
 
-        // 5) POS — caisse démo + produits
+        // 5) MENU — menu digital démo (lounge/restaurant) + catégories + produits
+        $menu = Menu::firstOrCreate(
+            ['alias' => 'demo-menu'],
+            [
+                'name' => 'TAGTOA Lounge Demo', 'type' => 'lounge',
+                'tagline' => 'Cuisine créole • Cocktails • Ambiance lounge',
+                'description' => 'Scannez, commandez, payez. Le menu digital TAGTOA.',
+                'currency' => 'HTG', 'whatsapp' => '+509 3000 0000',
+                'pay_page_id' => $pay->id, 'accent_color' => '#0055FF', 'theme' => 'dark',
+                'show_prices' => true, 'ordering_enabled' => true, 'is_active' => true,
+            ]
+        );
+        $menuData = [
+            ['Entrées', '🥗', [
+                ['Accra de morue', 250, '🧆', 'Beignets de morue épicés', 'Populaire'],
+                ['Pikliz maison', 100, '🌶️', 'Chou et carottes pimentés', null],
+            ]],
+            ['Plats', '🍽️', [
+                ['Griot + bannann peze', 650, '🍖', 'Porc mariné, banane plantain', 'Populaire'],
+                ['Poisson gros sel', 800, '🐟', 'Poisson frit, riz djon-djon', null],
+                ['Tassot kabrit', 750, '🥩', 'Cabri frit, sauce ti-malice', 'Nouveau'],
+            ]],
+            ['Boissons', '🍹', [
+                ['Prestige', 150, '🍺', 'Bière nationale', null],
+                ['Rhum Barbancourt', 300, '🥃', '5 étoiles, sur glace', null],
+                ['Jus de fruits frais', 150, '🧃', 'Chadèque, corossol, grenadia', null],
+            ]],
+        ];
+        foreach ($menuData as $ci => [$catName, $icon, $items]) {
+            $cat = $menu->categories()->firstOrCreate(['name' => $catName], ['icon' => $icon, 'sort' => $ci, 'is_active' => true]);
+            foreach ($items as $ii => [$name, $price, $emoji, $desc, $badge]) {
+                $cat->items()->firstOrCreate(
+                    ['name' => $name],
+                    ['menu_id' => $menu->id, 'price' => $price, 'emoji' => $emoji, 'description' => $desc, 'badge' => $badge, 'is_available' => true, 'sort' => $ii]
+                );
+            }
+        }
+
+        // 6) POS — caisse démo + produits
         $terminal = Terminal::firstOrCreate(['name' => 'Caisse Demo'], ['currency' => 'HTG', 'is_active' => true]);
         foreach ([
             ['Café', 100, '☕', '#0055FF'],

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000060_create_tagtoa_menus_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000060_create_tagtoa_menus_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA MENU — menu digital (restaurant, club, lounge, hôtel, bar, café…).
+ * Le commerçant vend produits & services via NFC/QR. Table préfixée tagtoa_*.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_menus', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('vcard_id')->nullable()->index();
+            $table->string('tenant_id')->nullable()->index();
+            $table->string('name');
+            $table->string('alias')->unique();
+            $table->string('type', 30)->default('restaurant'); // restaurant|bar|cafe|club|lounge|hotel|other
+            $table->string('tagline')->nullable();
+            $table->text('description')->nullable();
+            $table->string('logo_path')->nullable();
+            $table->string('cover_path')->nullable();
+            $table->string('currency', 8)->default('HTG');
+            $table->string('whatsapp', 40)->nullable();      // commande via WhatsApp
+            $table->string('phone', 40)->nullable();
+            $table->string('address')->nullable();
+            $table->unsignedBigInteger('pay_page_id')->nullable(); // lien TAGTOA Pay
+            $table->string('accent_color', 16)->default('#0055FF');
+            $table->string('theme', 20)->default('light');    // light|dark
+            $table->boolean('show_prices')->default(true);
+            $table->boolean('ordering_enabled')->default(true); // commande WhatsApp
+            $table->boolean('is_active')->default(true);
+            $table->unsignedInteger('views')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_menus');
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000061_create_tagtoa_menu_categories_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000061_create_tagtoa_menu_categories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA MENU — catégories (ex. Entrées, Plats, Boissons, Services).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_menu_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('menu_id')->constrained('tagtoa_menus')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('icon', 16)->nullable(); // emoji
+            $table->unsignedTinyInteger('sort')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_menu_categories');
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000062_create_tagtoa_menu_items_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000062_create_tagtoa_menu_items_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA MENU — produits & services vendus (un item appartient à une catégorie).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_menu_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('menu_id')->constrained('tagtoa_menus')->cascadeOnDelete();
+            $table->foreignId('category_id')->constrained('tagtoa_menu_categories')->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->decimal('price', 12, 2)->default(0);
+            $table->string('image_path')->nullable();
+            $table->string('emoji', 16)->nullable();
+            $table->string('badge', 30)->nullable(); // ex. Nouveau, Promo, Populaire
+            $table->boolean('is_available')->default(true);
+            $table->boolean('is_featured')->default(false);
+            $table->unsignedTinyInteger('sort')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_menu_items');
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Menu/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Menu/DashboardController.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\Menu;
+
+use App\Http\Controllers\Controller;
+use App\Models\Vcard;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Models\Menu\Menu;
+use Modules\Tagtoa\App\Models\Pay\PaymentPage;
+use Modules\Tagtoa\App\Support\Tenant;
+
+/**
+ * TAGTOA MENU — dashboard propriétaire (CRUD menu + catégories + items).
+ */
+class DashboardController extends Controller
+{
+    public function index(): View
+    {
+        $menus = Menu::where('tenant_id', Tenant::id())
+            ->withCount(['items', 'categories'])
+            ->latest()->paginate(12);
+
+        return view('tagtoa::menu.index', compact('menus'));
+    }
+
+    public function create(): View
+    {
+        return view('tagtoa::menu.form', [
+            'menu'     => new Menu(['theme' => 'light', 'accent_color' => '#0055FF', 'currency' => Tenant::currency()]),
+            'vcards'   => $this->vcards(),
+            'payPages' => $this->payPages(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $this->validateMenu($request);
+        $menu = new Menu($data);
+        $menu->tenant_id = Tenant::id();
+        $menu->alias = $data['alias'] ?: Menu::generateAlias($data['name'] ?? 'menu');
+        $this->handleUploads($menu, $request);
+        $menu->save();
+        $this->syncContent($menu, $request);
+
+        return redirect()->route('tagtoa.menu.dashboard.edit', $menu->id)
+            ->with('success', __('Menu créé. Ajoutez vos catégories et produits.'));
+    }
+
+    public function edit(int $id): View
+    {
+        $menu = $this->own($id, ['categories.items']);
+
+        return view('tagtoa::menu.form', [
+            'menu'     => $menu,
+            'vcards'   => $this->vcards(),
+            'payPages' => $this->payPages(),
+        ]);
+    }
+
+    public function update(Request $request, int $id): RedirectResponse
+    {
+        $menu = $this->own($id);
+        $data = $this->validateMenu($request, $menu->id);
+        $data['alias'] = $data['alias'] ?: $menu->alias;
+        $menu->fill($data);
+        $this->handleUploads($menu, $request);
+        $menu->save();
+        $this->syncContent($menu, $request);
+
+        return back()->with('success', __('Menu mis à jour.'));
+    }
+
+    public function destroy(int $id): RedirectResponse
+    {
+        $this->own($id)->delete();
+
+        return redirect()->route('tagtoa.menu.dashboard.index')->with('success', __('Menu supprimé.'));
+    }
+
+    /* ---------- helpers ---------- */
+
+    protected function own(int $id, array $with = []): Menu
+    {
+        return Menu::with($with)->where('tenant_id', Tenant::id())->findOrFail($id);
+    }
+
+    protected function handleUploads(Menu $menu, Request $request): void
+    {
+        if ($request->hasFile('logo')) {
+            $menu->logo_path = $request->file('logo')->store('tagtoa/menu-logos', 'public');
+        }
+        if ($request->hasFile('cover')) {
+            $menu->cover_path = $request->file('cover')->store('tagtoa/menu-covers', 'public');
+        }
+    }
+
+    protected function validateMenu(Request $request, ?int $ignoreId = null): array
+    {
+        $ownVcardIds = $this->vcards()->pluck('id')->all();
+        $ownPayIds   = $this->payPages()->pluck('id')->all();
+
+        return $request->validate([
+            'vcard_id'         => ['nullable', 'integer', Rule::in($ownVcardIds)],
+            'name'             => ['required', 'string', 'max:160'],
+            'alias'            => ['nullable', 'string', 'max:120', 'alpha_dash', 'unique:tagtoa_menus,alias'.($ignoreId ? ','.$ignoreId : '')],
+            'type'             => ['nullable', Rule::in(array_keys(Menu::TYPES))],
+            'tagline'          => ['nullable', 'string', 'max:160'],
+            'description'      => ['nullable', 'string', 'max:600'],
+            'currency'         => ['nullable', 'string', 'max:8'],
+            'whatsapp'         => ['nullable', 'string', 'max:40'],
+            'phone'            => ['nullable', 'string', 'max:40'],
+            'address'          => ['nullable', 'string', 'max:200'],
+            'pay_page_id'      => ['nullable', 'integer', Rule::in($ownPayIds)],
+            'accent_color'     => ['nullable', 'string', 'max:16'],
+            'theme'            => ['nullable', Rule::in(Menu::THEMES)],
+            'show_prices'      => ['nullable', 'boolean'],
+            'ordering_enabled' => ['nullable', 'boolean'],
+            'is_active'        => ['nullable', 'boolean'],
+            'logo'             => ['nullable', 'image', 'max:2048'],
+            'cover'            => ['nullable', 'image', 'max:4096'],
+        ]);
+    }
+
+    /** Synchronise catégories + items depuis le formulaire imbriqué (cats[][items][]). */
+    protected function syncContent(Menu $menu, Request $request): void
+    {
+        $cats = $request->input('cats', []);
+        $keepCats = [];
+
+        DB::transaction(function () use ($menu, $cats, &$keepCats) {
+            foreach (array_values($cats) as $ci => $c) {
+                if (empty($c['name'])) {
+                    continue;
+                }
+                $catAttrs = [
+                    'name'      => $c['name'],
+                    'icon'      => $c['icon'] ?? null,
+                    'sort'      => $ci,
+                    'is_active' => true,
+                ];
+                $cat = ! empty($c['id']) ? $menu->categories()->whereKey($c['id'])->first() : null;
+                $cat ? $cat->update($catAttrs) : $cat = $menu->categories()->create($catAttrs);
+                $keepCats[] = $cat->id;
+
+                $keepItems = [];
+                foreach (array_values($c['items'] ?? []) as $ii => $it) {
+                    if (empty($it['name'])) {
+                        continue;
+                    }
+                    $itemAttrs = [
+                        'menu_id'      => $menu->id,
+                        'name'         => $it['name'],
+                        'description'  => $it['description'] ?? null,
+                        'price'        => round((float) ($it['price'] ?? 0), 2),
+                        'emoji'        => $it['emoji'] ?? null,
+                        'badge'        => $it['badge'] ?? null,
+                        'is_featured'  => ! empty($it['is_featured']),
+                        'is_available' => ! isset($it['is_available']) ? true : (bool) $it['is_available'],
+                        'sort'         => $ii,
+                    ];
+                    $item = ! empty($it['id']) ? $cat->items()->whereKey($it['id'])->first() : null;
+                    $item ? $item->update($itemAttrs) : $item = $cat->items()->create($itemAttrs);
+                    $keepItems[] = $item->id;
+                }
+                $cat->items()->whereNotIn('id', $keepItems ?: [0])->delete();
+            }
+            $menu->categories()->whereNotIn('id', $keepCats ?: [0])->delete();
+        });
+    }
+
+    protected function vcards()
+    {
+        try {
+            return Vcard::query()->where('tenant_id', Tenant::id())->orderBy('name')->get(['id', 'name']);
+        } catch (\Throwable $e) {
+            return collect();
+        }
+    }
+
+    protected function payPages()
+    {
+        return PaymentPage::where('tenant_id', Tenant::id())->get(['id', 'title', 'alias']);
+    }
+}

--- a/Modules/Tagtoa/app/Http/Controllers/Menu/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Menu/PublicController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\Menu;
+
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Models\Menu\Menu;
+
+/**
+ * TAGTOA MENU — page publique (NFC / QR), pas d'auth.
+ */
+class PublicController extends Controller
+{
+    public function show(string $alias): View
+    {
+        $menu = Menu::where('alias', $alias)->where('is_active', true)
+            ->with(['payPage', 'activeCategories.availableItems'])
+            ->firstOrFail();
+
+        $menu->incrementQuietly('views');
+
+        // Catégories non vides uniquement.
+        $categories = $menu->activeCategories->filter(fn ($c) => $c->availableItems->isNotEmpty())->values();
+
+        return view('tagtoa::menu.show', ['menu' => $menu, 'categories' => $categories]);
+    }
+}

--- a/Modules/Tagtoa/app/Models/Menu/Category.php
+++ b/Modules/Tagtoa/app/Models/Menu/Category.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Menu;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * TAGTOA MENU — catégorie (Entrées, Plats, Boissons, Services…).
+ */
+class Category extends Model
+{
+    protected $table = 'tagtoa_menu_categories';
+
+    protected $fillable = ['menu_id', 'name', 'icon', 'sort', 'is_active'];
+
+    protected $casts = ['is_active' => 'boolean', 'sort' => 'integer'];
+
+    public function menu(): BelongsTo
+    {
+        return $this->belongsTo(Menu::class, 'menu_id');
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(Item::class, 'category_id')->orderBy('sort');
+    }
+
+    public function availableItems(): HasMany
+    {
+        return $this->items()->where('is_available', true);
+    }
+}

--- a/Modules/Tagtoa/app/Models/Menu/Item.php
+++ b/Modules/Tagtoa/app/Models/Menu/Item.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Menu;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * TAGTOA MENU — produit ou service vendu (appartient à une catégorie).
+ */
+class Item extends Model
+{
+    protected $table = 'tagtoa_menu_items';
+
+    protected $fillable = [
+        'menu_id', 'category_id', 'name', 'description', 'price', 'image_path',
+        'emoji', 'badge', 'is_available', 'is_featured', 'sort',
+    ];
+
+    protected $casts = [
+        'price'        => 'decimal:2',
+        'is_available' => 'boolean',
+        'is_featured'  => 'boolean',
+        'sort'         => 'integer',
+    ];
+
+    public function menu(): BelongsTo
+    {
+        return $this->belongsTo(Menu::class, 'menu_id');
+    }
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class, 'category_id');
+    }
+
+    public function getImageUrlAttribute(): ?string
+    {
+        return $this->image_path ? Storage::url($this->image_path) : null;
+    }
+}

--- a/Modules/Tagtoa/app/Models/Menu/Menu.php
+++ b/Modules/Tagtoa/app/Models/Menu/Menu.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Menu;
+
+use App\Models\Vcard;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Modules\Tagtoa\App\Models\Pay\PaymentPage;
+
+/**
+ * TAGTOA MENU — menu digital d'un établissement (tagtoa.com/menu/{alias}).
+ * Restaurants, clubs, lounges, hôtels, bars, cafés : vente de produits & services
+ * via NFC/QR, avec commande WhatsApp et lien de paiement TAGTOA Pay optionnel.
+ */
+class Menu extends Model
+{
+    protected $table = 'tagtoa_menus';
+
+    /** Types d'établissement : label + icône FA. */
+    public const TYPES = [
+        'restaurant' => ['label' => 'Restaurant', 'icon' => 'fa-solid fa-utensils'],
+        'cafe'       => ['label' => 'Café',        'icon' => 'fa-solid fa-mug-hot'],
+        'bar'        => ['label' => 'Bar',         'icon' => 'fa-solid fa-martini-glass'],
+        'club'       => ['label' => 'Club',        'icon' => 'fa-solid fa-record-vinyl'],
+        'lounge'     => ['label' => 'Lounge',      'icon' => 'fa-solid fa-couch'],
+        'hotel'      => ['label' => 'Hôtel',       'icon' => 'fa-solid fa-hotel'],
+        'other'      => ['label' => 'Autre',       'icon' => 'fa-solid fa-store'],
+    ];
+
+    public const THEMES = ['light', 'dark'];
+
+    protected $fillable = [
+        'vcard_id', 'tenant_id', 'name', 'alias', 'type', 'tagline', 'description',
+        'logo_path', 'cover_path', 'currency', 'whatsapp', 'phone', 'address',
+        'pay_page_id', 'accent_color', 'theme', 'show_prices', 'ordering_enabled',
+        'is_active', 'views',
+    ];
+
+    protected $casts = [
+        'show_prices'      => 'boolean',
+        'ordering_enabled' => 'boolean',
+        'is_active'        => 'boolean',
+        'views'            => 'integer',
+    ];
+
+    public static function generateAlias(string $base): string
+    {
+        $slug = Str::slug($base) ?: 'menu';
+        $alias = $slug; $i = 1;
+        while (static::query()->where('alias', $alias)->exists()) {
+            $alias = $slug.'-'.(++$i);
+        }
+        return $alias;
+    }
+
+    public function vcard(): BelongsTo
+    {
+        return $this->belongsTo(Vcard::class, 'vcard_id');
+    }
+
+    public function payPage(): BelongsTo
+    {
+        return $this->belongsTo(PaymentPage::class, 'pay_page_id');
+    }
+
+    public function categories(): HasMany
+    {
+        return $this->hasMany(Category::class, 'menu_id')->orderBy('sort');
+    }
+
+    public function activeCategories(): HasMany
+    {
+        return $this->categories()->where('is_active', true);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(Item::class, 'menu_id');
+    }
+
+    public function getTypeMetaAttribute(): array
+    {
+        return self::TYPES[$this->type] ?? self::TYPES['other'];
+    }
+
+    public function getLogoUrlAttribute(): ?string
+    {
+        return $this->logo_path ? Storage::url($this->logo_path) : null;
+    }
+
+    public function getCoverUrlAttribute(): ?string
+    {
+        return $this->cover_path ? Storage::url($this->cover_path) : null;
+    }
+
+    public function getPublicUrlAttribute(): string
+    {
+        return url('/menu/'.$this->alias);
+    }
+
+    /** Numéro WhatsApp normalisé (chiffres uniquement) pour wa.me. */
+    public function getWhatsappDigitsAttribute(): ?string
+    {
+        return $this->whatsapp ? preg_replace('/\D+/', '', $this->whatsapp) : null;
+    }
+}

--- a/Modules/Tagtoa/deploy/remote-deploy.sh
+++ b/Modules/Tagtoa/deploy/remote-deploy.sh
@@ -58,6 +58,14 @@ if ! php artisan package:discover >/dev/null 2>&1; then
   rollback
 fi
 
+# 4.5) Données de démo (idempotent — firstOrCreate sur les alias).
+#      Ne bloque JAMAIS le déploiement. Désactivable : TAGTOA_SEED_DEMO=0
+if [ "${TAGTOA_SEED_DEMO:-1}" != "0" ]; then
+  echo "==> Seed démo TAGTOA (idempotent)"
+  php artisan db:seed --class="Modules\\Tagtoa\\Database\\Seeders\\TagtoaDemoSeeder" --force \
+    || echo "WARN: seed démo ignoré (non bloquant)"
+fi
+
 # 5) Caches + réouverture
 php artisan optimize:clear >/dev/null 2>&1 || true
 php artisan up

--- a/Modules/Tagtoa/resources/views/hub/index.blade.php
+++ b/Modules/Tagtoa/resources/views/hub/index.blade.php
@@ -13,6 +13,7 @@
 <div class="h-row" style="margin-top:26px"><h2>{{ __('Vos outils TAGTOA') }}</h2></div>
 <div class="grid g3">
     @foreach([
+        ['menu','Menu','fa-utensils','Menu digital NFC/QR : restaurant, club, lounge, hôtel… vendez produits & services.'],
         ['pay','Paiements','fa-money-bill-transfer','Page de paiement (MonCash, NatCash, Zelle, PayPal…) + preuves.'],
         ['loyalty','Fidélité','fa-id-card','Cartes NFC de fidélité : solde, points, récompenses.'],
         ['links','Liens','fa-link','Page de liens style Linktree + don.'],

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -92,6 +92,7 @@
         <nav class="nav">
             <a href="{{ url('/tagtoa/home') }}" class="{{ request()->is('tagtoa/home') ? 'on' : '' }}"><i class="fa-solid fa-grip"></i> {{ __('Accueil') }}</a>
             <span class="sep">{{ __('Modules') }}</span>
+            <a href="{{ url('/tagtoa/menu') }}" class="{{ request()->is('tagtoa/menu*') ? 'on' : '' }}"><i class="fa-solid fa-utensils"></i> {{ __('Menu') }}</a>
             <a href="{{ url('/tagtoa/pay') }}" class="{{ request()->is('tagtoa/pay*') ? 'on' : '' }}"><i class="fa-solid fa-money-bill-transfer"></i> {{ __('Paiements') }}</a>
             <a href="{{ url('/tagtoa/loyalty') }}" class="{{ request()->is('tagtoa/loyalty*') ? 'on' : '' }}"><i class="fa-solid fa-id-card"></i> {{ __('Fidélité') }}</a>
             <a href="{{ url('/tagtoa/links') }}" class="{{ request()->is('tagtoa/links*') ? 'on' : '' }}"><i class="fa-solid fa-link"></i> {{ __('Liens') }}</a>

--- a/Modules/Tagtoa/resources/views/menu/form.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/form.blade.php
@@ -1,0 +1,143 @@
+@extends('tagtoa::layouts.dashboard')
+@php $editing = $menu->exists; @endphp
+@section('title', $editing ? __('Modifier le menu') : __('Nouveau menu'))
+@section('page', $editing ? __('Modifier le menu') : __('Nouveau menu'))
+
+@section('content')
+<form method="POST" enctype="multipart/form-data" action="{{ $editing ? route('tagtoa.menu.dashboard.update',$menu->id) : route('tagtoa.menu.dashboard.store') }}">
+    @csrf @if($editing) @method('PUT') @endif
+
+    {{-- ----- Réglages de l'établissement ----- --}}
+    <div class="card">
+        <div class="h-row"><h2>{{ __('Établissement') }}</h2></div>
+        <div class="row">
+            <div><label class="lbl">{{ __('Nom') }}</label><input class="inp" name="name" value="{{ old('name',$menu->name) }}" placeholder="{{ __('Ex. Lounge 509') }}" required></div>
+            <div><label class="lbl">{{ __('Type') }}</label><select class="sel" name="type">@foreach(\Modules\Tagtoa\App\Models\Menu\Menu::TYPES as $k=>$v)<option value="{{ $k }}" @selected(old('type',$menu->type ?: 'restaurant')===$k)>{{ __($v['label']) }}</option>@endforeach</select></div>
+        </div>
+        <label class="lbl">{{ __('Alias (URL)') }}</label>
+        <div style="display:flex;align-items:center;gap:8px"><span style="color:var(--muted);font-size:14px">tagtoa.com/menu/</span><input class="inp" name="alias" value="{{ old('alias',$menu->alias) }}" placeholder="{{ __('auto si vide') }}"></div>
+        <label class="lbl">{{ __('Slogan') }}</label><input class="inp" name="tagline" value="{{ old('tagline',$menu->tagline) }}" placeholder="{{ __('Cuisine créole • Ambiance lounge') }}">
+        <label class="lbl">{{ __('Description') }}</label><textarea class="inp" name="description" rows="2" maxlength="600">{{ old('description',$menu->description) }}</textarea>
+        <div class="row">
+            <div><label class="lbl">{{ __('Logo') }}</label><input class="inp" type="file" name="logo" accept="image/*">@if($editing && $menu->logo_url)<img src="{{ $menu->logo_url }}" style="height:42px;border-radius:10px;margin-top:8px">@endif</div>
+            <div><label class="lbl">{{ __('Couverture') }}</label><input class="inp" type="file" name="cover" accept="image/*">@if($editing && $menu->cover_url)<img src="{{ $menu->cover_url }}" style="height:42px;border-radius:10px;margin-top:8px">@endif</div>
+        </div>
+    </div>
+
+    {{-- ----- Contact & commande ----- --}}
+    <div class="card">
+        <div class="h-row"><h2>{{ __('Contact & commande') }}</h2></div>
+        <div class="row">
+            <div><label class="lbl">{{ __('WhatsApp (commande)') }}</label><input class="inp" name="whatsapp" value="{{ old('whatsapp',$menu->whatsapp) }}" placeholder="+509 0000 0000"></div>
+            <div><label class="lbl">{{ __('Téléphone') }}</label><input class="inp" name="phone" value="{{ old('phone',$menu->phone) }}" placeholder="+509 0000 0000"></div>
+        </div>
+        <label class="lbl">{{ __('Adresse') }}</label><input class="inp" name="address" value="{{ old('address',$menu->address) }}" placeholder="{{ __('Rue, ville') }}">
+        <div class="row">
+            <div><label class="lbl">{{ __('Devise') }}</label><input class="inp" name="currency" value="{{ old('currency',$menu->currency ?: 'HTG') }}" maxlength="8"></div>
+            <div><label class="lbl">{{ __('Page de paiement (TAGTOA Pay)') }}</label><select class="sel" name="pay_page_id"><option value="">{{ __('— Aucune —') }}</option>@foreach($payPages as $pp)<option value="{{ $pp->id }}" @selected(old('pay_page_id',$menu->pay_page_id)==$pp->id)>{{ $pp->title ?: $pp->alias }}</option>@endforeach</select></div>
+        </div>
+        <label class="switch"><input type="hidden" name="ordering_enabled" value="0"><input type="checkbox" name="ordering_enabled" value="1" @checked(old('ordering_enabled',$menu->ordering_enabled ?? true))> {{ __('Activer la commande WhatsApp') }}</label>
+    </div>
+
+    {{-- ----- Apparence ----- --}}
+    <div class="card">
+        <div class="h-row"><h2>{{ __('Apparence') }}</h2></div>
+        <div class="row">
+            <div><label class="lbl">{{ __('Thème') }}</label><select class="sel" name="theme">@foreach(['light'=>'Clair','dark'=>'Sombre'] as $k=>$v)<option value="{{ $k }}" @selected(old('theme',$menu->theme ?: 'light')===$k)>{{ __($v) }}</option>@endforeach</select></div>
+            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$menu->accent_color ?: '#0055FF') }}" style="height:48px;padding:6px"></div>
+        </div>
+        <label class="switch"><input type="hidden" name="show_prices" value="0"><input type="checkbox" name="show_prices" value="1" @checked(old('show_prices',$menu->show_prices ?? true))> {{ __('Afficher les prix') }}</label>
+        <label class="switch"><input type="hidden" name="is_active" value="0"><input type="checkbox" name="is_active" value="1" @checked(old('is_active',$menu->is_active ?? true))> {{ __('Menu actif (visible au public)') }}</label>
+    </div>
+
+    {{-- ----- Catégories & produits ----- --}}
+    <div class="card">
+        <div class="h-row"><h2>{{ __('Catégories & produits') }}</h2><button type="button" class="btn btn-d btn-sm" onclick="addCat()"><i class="fa-solid fa-plus"></i> {{ __('Catégorie') }}</button></div>
+        <p style="color:var(--muted);font-size:13px;margin-top:-8px">{{ __('Organisez vos produits & services par catégorie (Entrées, Plats, Boissons, Services…).') }}</p>
+        <div id="cats"></div>
+    </div>
+
+    <button class="btn btn-p"><i class="fa-solid fa-floppy-disk"></i> {{ __('Enregistrer le menu') }}</button>
+</form>
+
+{{-- Template catégorie --}}
+<template id="cattpl">
+    <div class="catblock" data-ci="CIDX" style="border:1.5px solid var(--bd);border-radius:14px;padding:14px;margin-top:12px;background:#fafafa">
+        <div style="display:flex;gap:8px;align-items:center">
+            <input name="cats[CIDX][icon]" class="inp" placeholder="🍔" style="max-width:64px;text-align:center">
+            <input name="cats[CIDX][name]" class="inp" placeholder="{{ __('Nom de la catégorie') }}" style="font-weight:600">
+            <button type="button" class="btn btn-o btn-sm" style="flex:0;color:var(--red)" onclick="this.closest('.catblock').remove()"><i class="fa-solid fa-trash"></i></button>
+        </div>
+        <div class="items" style="margin-top:10px"></div>
+        <button type="button" class="btn btn-o btn-sm" onclick="addItem(this.closest('.catblock'))" style="margin-top:6px"><i class="fa-solid fa-plus"></i> {{ __('Ajouter un produit') }}</button>
+    </div>
+</template>
+
+{{-- Template produit/service --}}
+<template id="itemtpl">
+    <div class="itemrow" style="background:#fff;border:1px solid var(--bd);border-radius:11px;padding:10px;margin-bottom:8px">
+        <div style="display:flex;gap:8px;align-items:center">
+            <input name="cats[CIDX][items][IIDX][emoji]" class="inp" placeholder="🍔" style="max-width:56px;text-align:center">
+            <input name="cats[CIDX][items][IIDX][name]" class="inp" placeholder="{{ __('Nom du produit / service') }}">
+            <input name="cats[CIDX][items][IIDX][price]" class="inp" type="number" step="0.01" min="0" placeholder="{{ __('Prix') }}" style="max-width:110px">
+            <button type="button" class="btn btn-o btn-sm" style="flex:0;color:var(--red)" onclick="this.closest('.itemrow').remove()"><i class="fa-solid fa-trash"></i></button>
+        </div>
+        <input name="cats[CIDX][items][IIDX][description]" class="inp" placeholder="{{ __('Description (optionnel)') }}" style="margin-top:8px">
+        <div style="display:flex;gap:16px;align-items:center;margin-top:8px;flex-wrap:wrap">
+            <input name="cats[CIDX][items][IIDX][badge]" class="inp" placeholder="{{ __('Badge: Nouveau, Promo…') }}" style="max-width:200px">
+            <label class="switch" style="flex:0"><input type="hidden" name="cats[CIDX][items][IIDX][is_available]" value="0"><input type="checkbox" name="cats[CIDX][items][IIDX][is_available]" value="1" checked> {{ __('Disponible') }}</label>
+            <label class="switch" style="flex:0"><input type="checkbox" name="cats[CIDX][items][IIDX][is_featured]" value="1"> {{ __('Mis en avant') }}</label>
+        </div>
+    </div>
+</template>
+
+@push('scripts')
+<script>
+var cIdx = 0;
+
+function addItem(catEl, d){
+    var ci = catEl.getAttribute('data-ci');
+    var ii = parseInt(catEl.getAttribute('data-ii') || '0', 10);
+    catEl.setAttribute('data-ii', ii + 1);
+    var html = document.getElementById('itemtpl').innerHTML.replace(/CIDX/g, ci).replace(/IIDX/g, ii);
+    var box = document.createElement('div'); box.innerHTML = html;
+    var row = box.firstElementChild;
+    catEl.querySelector('.items').appendChild(row);
+    if (d){
+        row.querySelector('[name$="[emoji]"]').value = d.emoji || '';
+        row.querySelector('[name$="[name]"]').value = d.name || '';
+        row.querySelector('[name$="[price]"]').value = (d.price != null ? d.price : '');
+        row.querySelector('[name$="[description]"]').value = d.description || '';
+        row.querySelector('[name$="[badge]"]').value = d.badge || '';
+        row.querySelector('input[type=checkbox][name$="[is_available]"]').checked = d.is_available !== false;
+        row.querySelector('[name$="[is_featured]"]').checked = !!d.is_featured;
+        var h = document.createElement('input'); h.type='hidden'; h.name='cats['+ci+'][items]['+ii+'][id]'; h.value=d.id; row.appendChild(h);
+    }
+    return row;
+}
+
+function addCat(d){
+    var ci = cIdx++;
+    var html = document.getElementById('cattpl').innerHTML.replace(/CIDX/g, ci);
+    var box = document.createElement('div'); box.innerHTML = html;
+    var block = box.firstElementChild;
+    document.getElementById('cats').appendChild(block);
+    if (d){
+        block.querySelector('[name$="[icon]"]').value = d.icon || '';
+        block.querySelector('[name$="[name]"]').value = d.name || '';
+        var h = document.createElement('input'); h.type='hidden'; h.name='cats['+ci+'][id]'; h.value=d.id; block.appendChild(h);
+        (d.items || []).forEach(function(it){ addItem(block, it); });
+    }
+    return block;
+}
+
+var existing = @json($menu->relationLoaded('categories') ? $menu->categories->map(fn($c)=>[
+    'id'=>$c->id,'name'=>$c->name,'icon'=>$c->icon,
+    'items'=>$c->items->map(fn($i)=>['id'=>$i->id,'name'=>$i->name,'emoji'=>$i->emoji,'price'=>$i->price,'description'=>$i->description,'badge'=>$i->badge,'is_available'=>$i->is_available,'is_featured'=>$i->is_featured]),
+]) : []);
+
+if (existing.length){ existing.forEach(addCat); }
+else { var c = addCat(); addItem(c); }
+</script>
+@endpush
+@endsection

--- a/Modules/Tagtoa/resources/views/menu/index.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/index.blade.php
@@ -1,0 +1,48 @@
+@extends('tagtoa::layouts.dashboard')
+@section('title', __('Menu'))
+@section('page', __('Menu'))
+
+@section('content')
+<div class="h-row">
+    <h2>{{ __('Vos menus digitaux') }}</h2>
+    <a href="{{ route('tagtoa.menu.dashboard.create') }}" class="btn btn-p"><i class="fa-solid fa-plus"></i> {{ __('Nouveau menu') }}</a>
+</div>
+
+@if($menus->isEmpty())
+    <div class="card"><div class="empty">
+        <i class="fa-solid fa-utensils"></i>
+        {{ __('Aucun menu. Créez le menu digital de votre restaurant, club, lounge ou hôtel — vendez vos produits & services par NFC/QR.') }}
+        <div style="margin-top:16px"><a href="{{ route('tagtoa.menu.dashboard.create') }}" class="btn btn-p"><i class="fa-solid fa-plus"></i> {{ __('Créer mon menu') }}</a></div>
+    </div></div>
+@else
+    <div class="grid g2">
+        @foreach($menus as $m)
+            @php $tm = $m->type_meta; @endphp
+            <div class="card">
+                <div style="display:flex;justify-content:space-between;align-items:flex-start">
+                    <div style="display:flex;gap:12px;align-items:center">
+                        <div class="ic" style="width:44px;height:44px;border-radius:12px;background:var(--blue-pale);color:var(--blue-deep);display:flex;align-items:center;justify-content:center;font-size:18px"><i class="{{ $tm['icon'] }}"></i></div>
+                        <div>
+                            <b style="font-family:var(--fh);font-size:16px;display:block">{{ $m->name }}</b>
+                            <span style="font-size:12.5px;color:var(--muted)">{{ __($tm['label']) }}</span>
+                        </div>
+                    </div>
+                    <span class="pill {{ $m->is_active ? 'g' : 'n' }}">{{ $m->is_active ? __('Actif') : __('Inactif') }}</span>
+                </div>
+                <a href="{{ url('/menu/'.$m->alias) }}" target="_blank" style="color:var(--blue);font-size:13px;display:inline-block;margin-top:12px">tagtoa.com/menu/{{ $m->alias }} <i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+                <div style="display:flex;gap:16px;margin-top:10px;color:var(--muted);font-size:13px">
+                    <span><i class="fa-solid fa-layer-group"></i> {{ $m->categories_count }} {{ __('cat.') }}</span>
+                    <span><i class="fa-solid fa-bowl-food"></i> {{ $m->items_count }} {{ __('produits') }}</span>
+                    <span><i class="fa-solid fa-eye"></i> {{ $m->views }}</span>
+                </div>
+                <div class="row" style="margin-top:14px;gap:8px">
+                    <a href="{{ route('tagtoa.menu.dashboard.edit',$m->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-pen"></i> {{ __('Modifier') }}</a>
+                    <a href="{{ url('/menu/'.$m->alias) }}" target="_blank" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-eye"></i> {{ __('Voir') }}</a>
+                    <form method="POST" action="{{ route('tagtoa.menu.dashboard.destroy',$m->id) }}" onsubmit="return confirm('{{ __('Supprimer ce menu ?') }}')" style="flex:0">@csrf @method('DELETE')<button class="btn btn-o btn-sm" style="color:var(--red)"><i class="fa-solid fa-trash"></i></button></form>
+                </div>
+            </div>
+        @endforeach
+    </div>
+    <div style="margin-top:16px">{{ $menus->links() }}</div>
+@endif
+@endsection

--- a/Modules/Tagtoa/resources/views/menu/show.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/show.blade.php
@@ -1,0 +1,217 @@
+{{-- TAGTOA MENU — page publique (NFC/QR). Variables : $menu, $categories --}}
+@php
+    $dark = $menu->theme === 'dark';
+    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $menu->accent_color) ? $menu->accent_color : '#0055FF';
+    $bg   = $dark ? '#0A0A0A' : '#F5F5F3';
+    $fg   = $dark ? '#FFFFFF' : '#0A0A0A';
+    $surf = $dark ? '#161616' : '#FFFFFF';
+    $mut  = $dark ? 'rgba(255,255,255,.6)' : '#888888';
+    $bd   = $dark ? 'rgba(255,255,255,.10)' : 'rgba(0,0,0,.08)';
+    $tm   = $menu->type_meta;
+    $canOrder = $menu->ordering_enabled && $menu->whatsapp_digits;
+    $cur = $menu->currency ?: 'HTG';
+@endphp
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <title>{{ $menu->name }} — TAGTOA Menu</title>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        :root{
+            --acc:{{ $accent }};--bg:{{ $bg }};--fg:{{ $fg }};--surf:{{ $surf }};--mut:{{ $mut }};--bd:{{ $bd }};
+            --fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;
+        }
+        *{box-sizing:border-box;margin:0;padding:0}
+        body{font-family:var(--fb);background:var(--bg);color:var(--fg);min-height:100vh;-webkit-font-smoothing:antialiased}
+        a{text-decoration:none;color:inherit}
+        .wrap{max-width:560px;margin:0 auto;padding-bottom:120px}
+        /* Header */
+        .cover{height:180px;background:linear-gradient(150deg,var(--acc),#0A0A0A);position:relative;background-size:cover;background-position:center}
+        .cover::after{content:"";position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,.45),transparent 60%)}
+        .head{padding:0 20px;margin-top:-44px;position:relative;z-index:2}
+        .logo{width:84px;height:84px;border-radius:20px;border:3px solid var(--surf);background:var(--surf);object-fit:cover;display:flex;align-items:center;justify-content:center;font:700 30px var(--fh);color:var(--acc);box-shadow:0 8px 26px rgba(0,0,0,.18)}
+        .title{font:700 24px var(--fh);margin-top:12px;display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+        .badge-type{display:inline-flex;align-items:center;gap:6px;font:600 12px var(--fh);background:color-mix(in srgb,var(--acc) 16%,transparent);color:var(--acc);padding:4px 10px;border-radius:999px}
+        .tag{color:var(--mut);font-size:14.5px;margin-top:4px}
+        .meta{display:flex;flex-wrap:wrap;gap:14px;margin-top:12px;color:var(--mut);font-size:13.5px}
+        .meta a{display:inline-flex;align-items:center;gap:6px}.meta i{color:var(--acc)}
+        /* Category nav */
+        .catnav{position:sticky;top:0;z-index:30;background:color-mix(in srgb,var(--bg) 85%,transparent);backdrop-filter:blur(10px);border-bottom:1px solid var(--bd);padding:12px 16px;display:flex;gap:8px;overflow-x:auto;margin-top:18px;-ms-overflow-style:none;scrollbar-width:none}
+        .catnav::-webkit-scrollbar{display:none}
+        .chip{white-space:nowrap;font:600 13.5px var(--fh);color:var(--fg);background:var(--surf);border:1px solid var(--bd);padding:8px 14px;border-radius:999px;cursor:pointer}
+        .chip.on{background:var(--acc);color:#fff;border-color:transparent}
+        /* Sections */
+        .sec{padding:22px 16px 4px}
+        .sec h2{font:700 18px var(--fh);display:flex;align-items:center;gap:9px;margin-bottom:14px}
+        .item{display:flex;gap:14px;background:var(--surf);border:1px solid var(--bd);border-radius:16px;padding:14px;margin-bottom:12px}
+        .item .ph{width:64px;height:64px;border-radius:13px;flex:0 0 64px;background:color-mix(in srgb,var(--acc) 10%,var(--surf));display:flex;align-items:center;justify-content:center;font-size:30px;object-fit:cover}
+        .item .body{flex:1;min-width:0}
+        .item .nm{font:700 15.5px var(--fh);display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+        .pillb{font:700 10.5px var(--fh);background:var(--acc);color:#fff;padding:2px 8px;border-radius:999px;text-transform:uppercase;letter-spacing:.04em}
+        .item .ds{color:var(--mut);font-size:13.5px;margin-top:3px}
+        .item .ft{display:flex;align-items:center;justify-content:space-between;margin-top:10px;gap:10px}
+        .price{font:700 15px var(--fh);color:var(--acc)}
+        .add{border:0;background:var(--acc);color:#fff;width:36px;height:36px;border-radius:11px;font-size:16px;cursor:pointer;flex:0 0 auto;transition:transform .12s}
+        .add:active{transform:scale(.9)}
+        .foot{text-align:center;margin:34px 0 10px;color:var(--mut);font-size:12px}.foot b{font-family:var(--fh);color:var(--fg)}
+        /* Cart bar + drawer */
+        .cartbar{position:fixed;left:0;right:0;bottom:0;z-index:40;display:none;justify-content:center;padding:14px 16px calc(14px + env(safe-area-inset-bottom))}
+        .cartbar.show{display:flex}
+        .cartbar button{width:100%;max-width:528px;border:0;background:var(--acc);color:#fff;border-radius:15px;padding:15px 20px;font:700 15.5px var(--fh);display:flex;align-items:center;justify-content:space-between;cursor:pointer;box-shadow:0 10px 30px rgba(0,0,0,.25)}
+        .cartbar .cnt{background:rgba(255,255,255,.22);border-radius:999px;padding:2px 10px;font-size:13px}
+        .sheet{position:fixed;inset:0;z-index:60;display:none}
+        .sheet.show{display:block}
+        .sheet .ov{position:absolute;inset:0;background:rgba(0,0,0,.5)}
+        .sheet .pan{position:absolute;left:0;right:0;bottom:0;max-width:560px;margin:0 auto;background:var(--bg);border-radius:22px 22px 0 0;padding:18px 18px calc(18px + env(safe-area-inset-bottom));max-height:84vh;overflow:auto}
+        .sheet h3{font:700 18px var(--fh);margin-bottom:6px;display:flex;justify-content:space-between;align-items:center}
+        .sheet .x{background:none;border:0;color:var(--mut);font-size:22px;cursor:pointer}
+        .crow{display:flex;align-items:center;gap:12px;padding:12px 0;border-bottom:1px solid var(--bd)}
+        .crow .cn{flex:1;font:600 14.5px var(--fh)}
+        .crow .cp{color:var(--mut);font-size:13px}
+        .qty{display:flex;align-items:center;gap:10px}
+        .qty button{width:30px;height:30px;border-radius:9px;border:1px solid var(--bd);background:var(--surf);color:var(--fg);font-size:15px;cursor:pointer}
+        .qty span{min-width:18px;text-align:center;font:700 14px var(--fh)}
+        .tot{display:flex;justify-content:space-between;font:700 17px var(--fh);margin:16px 0}
+        .cta{display:flex;flex-direction:column;gap:10px}
+        .cta a,.cta button{width:100%;border:0;border-radius:14px;padding:15px;font:700 15px var(--fh);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:9px}
+        .cta .wa{background:#25D366;color:#fff}
+        .cta .pay{background:var(--acc);color:#fff}
+        .cta .clr{background:transparent;color:var(--mut)}
+        .empty{color:var(--mut);text-align:center;padding:30px 0}
+        @media (prefers-reduced-motion:reduce){*{transition:none!important}}
+    </style>
+</head>
+<body>
+<div class="wrap">
+    <div class="cover" @if($menu->cover_url) style="background-image:url('{{ $menu->cover_url }}')" @endif></div>
+    <div class="head">
+        @if($menu->logo_url)<img class="logo" src="{{ $menu->logo_url }}" alt="">
+        @else<div class="logo">{{ \Illuminate\Support\Str::upper(\Illuminate\Support\Str::substr($menu->name,0,1)) }}</div>@endif
+        <div class="title">{{ $menu->name }} <span class="badge-type"><i class="{{ $tm['icon'] }}"></i> {{ __($tm['label']) }}</span></div>
+        @if($menu->tagline)<div class="tag">{{ $menu->tagline }}</div>@endif
+        <div class="meta">
+            @if($menu->address)<span><i class="fa-solid fa-location-dot"></i> {{ $menu->address }}</span>@endif
+            @if($menu->phone)<a href="tel:{{ $menu->phone }}"><i class="fa-solid fa-phone"></i> {{ $menu->phone }}</a>@endif
+            @if($menu->whatsapp_digits)<a href="https://wa.me/{{ $menu->whatsapp_digits }}" target="_blank" rel="noopener"><i class="fa-brands fa-whatsapp"></i> WhatsApp</a>@endif
+        </div>
+        @if($menu->description)<p class="tag" style="margin-top:12px">{{ $menu->description }}</p>@endif
+    </div>
+
+    @if($categories->isEmpty())
+        <div class="sec"><div class="empty"><i class="fa-solid fa-utensils" style="font-size:30px;display:block;margin-bottom:10px;opacity:.4"></i>{{ __('Le menu arrive bientôt.') }}</div></div>
+    @else
+        <nav class="catnav" id="catnav">
+            @foreach($categories as $c)
+                <div class="chip" data-target="cat{{ $c->id }}">{{ $c->icon ? $c->icon.' ' : '' }}{{ $c->name }}</div>
+            @endforeach
+        </nav>
+
+        @foreach($categories as $c)
+            <section class="sec" id="cat{{ $c->id }}">
+                <h2>{{ $c->icon ? $c->icon.' ' : '' }}{{ $c->name }}</h2>
+                @foreach($c->availableItems as $it)
+                    <div class="item">
+                        @if($it->image_url)<img class="ph" src="{{ $it->image_url }}" alt="">
+                        @else<div class="ph">{{ $it->emoji ?: '🍽️' }}</div>@endif
+                        <div class="body">
+                            <div class="nm">{{ $it->name }} @if($it->badge)<span class="pillb">{{ $it->badge }}</span>@endif</div>
+                            @if($it->description)<div class="ds">{{ $it->description }}</div>@endif
+                            <div class="ft">
+                                @if($menu->show_prices)<span class="price">{{ number_format((float) $it->price, 2) }} {{ $cur }}</span>@else<span></span>@endif
+                                @if($canOrder)
+                                    <button class="add" aria-label="{{ __('Ajouter') }}" data-id="{{ $it->id }}" data-name="{{ $it->name }}" data-price="{{ (float) $it->price }}" onclick="add(this)"><i class="fa-solid fa-plus"></i></button>
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+                @endforeach
+            </section>
+        @endforeach
+    @endif
+
+    <div class="foot">{{ __('Propulsé par') }} <b>TAGTOA</b> · tagtoa.com</div>
+</div>
+
+@if($canOrder)
+    <div class="cartbar" id="cartbar">
+        <button onclick="openCart()"><span><i class="fa-solid fa-bag-shopping"></i> {{ __('Voir la commande') }} <span class="cnt" id="cnt">0</span></span><span id="bartot">0 {{ $cur }}</span></button>
+    </div>
+
+    <div class="sheet" id="sheet">
+        <div class="ov" onclick="closeCart()"></div>
+        <div class="pan">
+            <h3>{{ __('Votre commande') }} <button class="x" onclick="closeCart()">&times;</button></h3>
+            <div id="clist"></div>
+            <div class="tot"><span>{{ __('Total') }}</span><span id="total">0 {{ $cur }}</span></div>
+            <div class="cta">
+                <a class="wa" id="waBtn" href="#" target="_blank" rel="noopener"><i class="fa-brands fa-whatsapp"></i> {{ __('Commander sur WhatsApp') }}</a>
+                @if($menu->payPage)<a class="pay" href="{{ url('/pay/'.$menu->payPage->alias) }}"><i class="fa-solid fa-credit-card"></i> {{ __('Payer maintenant') }}</a>@endif
+                <button class="clr" onclick="clearCart()">{{ __('Vider la commande') }}</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        var CUR = @json($cur);
+        var WA  = @json($menu->whatsapp_digits);
+        var NAME = @json($menu->name);
+        var cart = {};
+        function fmt(n){ return n.toLocaleString('fr-FR',{minimumFractionDigits:2,maximumFractionDigits:2}) + ' ' + CUR; }
+        function add(el){
+            var id = el.getAttribute('data-id');
+            if(!cart[id]) cart[id] = {name:el.getAttribute('data-name'), price:parseFloat(el.getAttribute('data-price'))||0, qty:0};
+            cart[id].qty++; render();
+        }
+        function chg(id,d){ if(!cart[id])return; cart[id].qty+=d; if(cart[id].qty<=0) delete cart[id]; render(); }
+        function clearCart(){ cart={}; render(); closeCart(); }
+        function totals(){ var n=0,t=0; for(var k in cart){ n+=cart[k].qty; t+=cart[k].qty*cart[k].price; } return {n:n,t:t}; }
+        function render(){
+            var s = totals();
+            document.getElementById('cnt').textContent = s.n;
+            document.getElementById('bartot').textContent = fmt(s.t);
+            document.getElementById('total').textContent = fmt(s.t);
+            document.getElementById('cartbar').classList.toggle('show', s.n>0);
+            var list = document.getElementById('clist'), html='';
+            if(s.n===0){ html = '<div class="empty">'+@json(__('Votre commande est vide.'))+'</div>'; }
+            else { for(var k in cart){ var c=cart[k];
+                html += '<div class="crow"><div class="cn">'+esc(c.name)+'<div class="cp">'+fmt(c.price)+'</div></div>'+
+                        '<div class="qty"><button onclick="chg(\''+k+'\',-1)">−</button><span>'+c.qty+'</span><button onclick="chg(\''+k+'\',1)">+</button></div></div>';
+            }}
+            list.innerHTML = html;
+            updateWa(s);
+        }
+        function updateWa(s){
+            var lines = [@json(__('Bonjour')) + ' ' + NAME + ', ' + @json(__('je voudrais commander :'))];
+            for(var k in cart){ var c=cart[k]; lines.push('• '+c.qty+'x '+c.name+' — '+fmt(c.qty*c.price)); }
+            lines.push(''); lines.push(@json(__('Total')) + ': ' + fmt(s.t));
+            document.getElementById('waBtn').href = 'https://wa.me/'+WA+'?text='+encodeURIComponent(lines.join('\n'));
+        }
+        function esc(x){ return String(x).replace(/[&<>"]/g,function(m){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[m];}); }
+        function openCart(){ document.getElementById('sheet').classList.add('show'); }
+        function closeCart(){ document.getElementById('sheet').classList.remove('show'); }
+        render();
+    </script>
+@endif
+
+<script>
+    // Surlignage de la catégorie active dans la barre de navigation.
+    (function(){
+        var chips = [].slice.call(document.querySelectorAll('.catnav .chip'));
+        chips.forEach(function(ch){ ch.addEventListener('click', function(){
+            var el = document.getElementById(ch.getAttribute('data-target'));
+            if(el){ var y = el.getBoundingClientRect().top + window.pageYOffset - 64; window.scrollTo({top:y,behavior:'smooth'}); }
+        }); });
+        var secs = chips.map(function(ch){ return document.getElementById(ch.getAttribute('data-target')); });
+        function onScroll(){
+            var i = secs.length-1;
+            for(var j=0;j<secs.length;j++){ if(secs[j] && secs[j].getBoundingClientRect().top<=90){ i=j; } }
+            chips.forEach(function(c,k){ c.classList.toggle('on', k===i); });
+        }
+        window.addEventListener('scroll', onScroll, {passive:true}); onScroll();
+    })();
+</script>
+</body>
+</html>

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -10,6 +10,8 @@ use Modules\Tagtoa\App\Http\Controllers\Links\DashboardController as LinksDashbo
 use Modules\Tagtoa\App\Http\Controllers\Links\PublicController as LinksPublic;
 use Modules\Tagtoa\App\Http\Controllers\Loyalty\DashboardController as LoyaltyDashboard;
 use Modules\Tagtoa\App\Http\Controllers\Loyalty\PublicController as LoyaltyPublic;
+use Modules\Tagtoa\App\Http\Controllers\Menu\DashboardController as MenuDashboard;
+use Modules\Tagtoa\App\Http\Controllers\Menu\PublicController as MenuPublic;
 use Modules\Tagtoa\App\Http\Controllers\Pay\DashboardController as PayDashboard;
 use Modules\Tagtoa\App\Http\Controllers\Pay\PublicController as PayPublic;
 use Modules\Tagtoa\App\Http\Controllers\Pos\PosController;
@@ -27,6 +29,7 @@ Route::post('/pay/{alias}/submit-proof', [PayPublic::class, 'submitProof'])->nam
 Route::get('/loyalty/card/{token}', [LoyaltyPublic::class, 'show'])->name('tagtoa.loyalty.card');
 Route::get('/links/{alias}', [LinksPublic::class, 'show'])->name('tagtoa.links.show');
 Route::get('/links/go/{link}', [LinksPublic::class, 'go'])->name('tagtoa.links.go');
+Route::get('/menu/{alias}', [MenuPublic::class, 'show'])->name('tagtoa.menu.show');
 Route::get('/event/{alias}', [EventPublic::class, 'show'])->name('tagtoa.event.show');
 Route::post('/event/{alias}/buy', [EventPublic::class, 'buy'])->name('tagtoa.event.buy');
 Route::get('/event/order/{reference}', [EventPublic::class, 'order'])->name('tagtoa.event.order');
@@ -54,6 +57,16 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
         Route::get('/{id}/proofs', [PayDashboard::class, 'proofs'])->name('proofs');
         Route::post('/proofs/{id}/approve', [PayDashboard::class, 'approveProof'])->name('proofs.approve');
         Route::post('/proofs/{id}/reject', [PayDashboard::class, 'rejectProof'])->name('proofs.reject');
+    });
+
+    // MENU (restaurant, club, lounge, hôtel, bar, café…)
+    Route::prefix('menu')->name('tagtoa.menu.dashboard.')->group(function () {
+        Route::get('/', [MenuDashboard::class, 'index'])->name('index');
+        Route::get('/create', [MenuDashboard::class, 'create'])->name('create');
+        Route::post('/', [MenuDashboard::class, 'store'])->name('store');
+        Route::get('/{id}/edit', [MenuDashboard::class, 'edit'])->name('edit');
+        Route::put('/{id}', [MenuDashboard::class, 'update'])->name('update');
+        Route::delete('/{id}', [MenuDashboard::class, 'destroy'])->name('destroy');
     });
 
     // LOYALTY


### PR DESCRIPTION
## TAGTOA MENU — module à part entière

MENU est un **module de premier plan**, distinct du concept WhatsApp Store. Il
permet aux **restaurants, clubs, lounges, hôtels, bars et cafés** de vendre leurs
**produits & services** via NFC/QR.

### Base de données (règle respectée : nouvelles tables `tagtoa_*` uniquement)
- `tagtoa_menus` — l'établissement (type, thème, couleur, WhatsApp, lien TAGTOA Pay…)
- `tagtoa_menu_categories` — catégories (Entrées, Plats, Boissons, Services…)
- `tagtoa_menu_items` — produits & services (prix, image/emoji, badge, dispo)

### Code
- **Modèles** : `Menu` (types restaurant/bar/cafe/club/lounge/hotel), `Category`, `Item`
- **Dashboard** (`/tagtoa/menu`) : CRUD complet, éditeur imbriqué catégories + produits,
  upload logo/couverture, thème clair/sombre, couleur d'accent, commande WhatsApp,
  lien de paiement TAGTOA Pay optionnel — le tout **scopé par tenant**
- **Page publique** (`/menu/{alias}`) : couverture/logo, navigation par catégories,
  fiches produits, panier coulissant, génération de commande WhatsApp, bouton de
  paiement, thème clair/sombre
- **Routes** : public `/menu/{alias}` + dashboard `/tagtoa/menu/*`
- **Navigation** : lien sidebar + tuile sur le hub (placé en premier parmi les modules)
- **Démo** : `TAGTOA Lounge Demo` (alias `demo-menu`) avec catégories & produits

### À tester après déploiement
- Public : `/menu/demo-menu`
- Dashboard : `/tagtoa/menu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_