### PR TITLE
TAGTOA: rebrand primary color to green #16A34A

### DIFF
--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -99,7 +99,7 @@ class TagtoaDemoSeeder extends Seeder
                 'tagline' => 'Cuisine créole • Cocktails • Ambiance lounge',
                 'description' => 'Scannez, commandez, payez. Le menu digital TAGTOA.',
                 'currency' => 'HTG', 'whatsapp' => '+509 3000 0000',
-                'pay_page_id' => $pay->id, 'accent_color' => '#0055FF', 'theme' => 'dark',
+                'pay_page_id' => $pay->id, 'accent_color' => '#16A34A', 'theme' => 'dark',
                 'show_prices' => true, 'ordering_enabled' => true, 'is_active' => true,
             ]
         );
@@ -150,7 +150,7 @@ class TagtoaDemoSeeder extends Seeder
         // 6) POS — caisse démo + produits
         $terminal = Terminal::firstOrCreate(['name' => 'Caisse Demo'], ['currency' => 'HTG', 'is_active' => true]);
         foreach ([
-            ['Café', 100, '☕', '#0055FF'],
+            ['Café', 100, '☕', '#16A34A'],
             ['Sandwich', 250, '🥪', '#1D9E75'],
             ['Jus', 150, '🧃', '#E08A1E'],
         ] as $i => [$name, $price, $emoji, $color]) {

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000051_create_tagtoa_pos_products_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000051_create_tagtoa_pos_products_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->string('name');
             $table->decimal('price', 10, 2)->default(0);
             $table->string('emoji', 8)->nullable();
-            $table->string('color', 12)->default('#0055FF');
+            $table->string('color', 12)->default('#16A34A');
             $table->integer('stock')->nullable();
             $table->boolean('is_active')->default(true);
             $table->unsignedSmallInteger('sort')->default(0);

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000060_create_tagtoa_menus_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000060_create_tagtoa_menus_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
             $table->string('phone', 40)->nullable();
             $table->string('address')->nullable();
             $table->unsignedBigInteger('pay_page_id')->nullable(); // lien TAGTOA Pay
-            $table->string('accent_color', 16)->default('#0055FF');
+            $table->string('accent_color', 16)->default('#16A34A');
             $table->string('theme', 20)->default('light');    // light|dark
             $table->boolean('show_prices')->default(true);
             $table->boolean('ordering_enabled')->default(true); // commande WhatsApp

--- a/Modules/Tagtoa/app/Http/Controllers/Menu/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Menu/DashboardController.php
@@ -33,7 +33,7 @@ class DashboardController extends Controller
     public function create(): View
     {
         return view('tagtoa::menu.form', [
-            'menu'     => new Menu(['theme' => 'light', 'accent_color' => '#0055FF', 'currency' => Locale::currencyFor()]),
+            'menu'     => new Menu(['theme' => 'light', 'accent_color' => '#16A34A', 'currency' => Locale::currencyFor()]),
             'vcards'   => $this->vcards(),
             'payPages' => $this->payPages(),
         ]);

--- a/Modules/Tagtoa/app/Http/Controllers/Pos/PosController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pos/PosController.php
@@ -118,7 +118,7 @@ class PosController extends Controller
                 'name'      => $row['name'],
                 'price'     => (float) ($row['price'] ?? 0),
                 'emoji'     => $row['emoji'] ?? null,
-                'color'     => $row['color'] ?? '#0055FF',
+                'color'     => $row['color'] ?? '#16A34A',
                 'stock'     => ($row['stock'] ?? '') === '' ? null : (int) $row['stock'],
                 'is_active' => ! empty($row['is_active']),
                 'sort'      => (int) ($row['sort'] ?? $i),

--- a/Modules/Tagtoa/app/Models/Pay/PaymentMethod.php
+++ b/Modules/Tagtoa/app/Models/Pay/PaymentMethod.php
@@ -50,7 +50,7 @@ class PaymentMethod extends Model
 
     public function getBrandColorAttribute(): string
     {
-        return $this->meta['color'] ?? '#0055FF';
+        return $this->meta['color'] ?? '#16A34A';
     }
 
     /** Cette méthode est-elle une passerelle automatique (API) ? */

--- a/Modules/Tagtoa/app/Support/PaymentGateway.php
+++ b/Modules/Tagtoa/app/Support/PaymentGateway.php
@@ -57,10 +57,10 @@ class PaymentGateway
         'binance'     => ['mode' => self::MODE_MANUAL, 'kind' => 'crypto', 'color' => '#F0B90B', 'driver' => null],
         'crypto'      => ['mode' => self::MODE_MANUAL, 'kind' => 'crypto', 'color' => '#8a8a8a', 'driver' => null],
         // TAGTOA
-        'tagtoa_card' => ['mode' => self::MODE_MANUAL, 'kind' => 'card', 'color' => '#0055FF', 'driver' => null],
+        'tagtoa_card' => ['mode' => self::MODE_MANUAL, 'kind' => 'card', 'color' => '#16A34A', 'driver' => null],
     ];
 
-    private const DEFAULT = ['mode' => self::MODE_MANUAL, 'kind' => 'other', 'color' => '#0055FF', 'driver' => null];
+    private const DEFAULT = ['mode' => self::MODE_MANUAL, 'kind' => 'other', 'color' => '#16A34A', 'driver' => null];
 
     /** Métadonnées complètes d'un type : label + icon (METHODS) + mode/kind/color/driver. */
     public static function meta(string $type): array

--- a/Modules/Tagtoa/resources/views/billing/index.blade.php
+++ b/Modules/Tagtoa/resources/views/billing/index.blade.php
@@ -17,7 +17,7 @@
                 'commission'=>['Commission','fa-percent','Pas de forfait. TAGTOA prélève un % sur chaque vente.'],
                 'both'=>['Les deux','fa-layer-group','Forfait réduit + petite commission.'],
             ] as $k=>$v)
-                <label class="card" style="cursor:pointer;border-color:{{ $rm===$k ? 'var(--blue)' : 'var(--bd)' }};{{ $rm===$k ? 'box-shadow:0 6px 22px rgba(0,85,255,.12)' : '' }}">
+                <label class="card" style="cursor:pointer;border-color:{{ $rm===$k ? 'var(--blue)' : 'var(--bd)' }};{{ $rm===$k ? 'box-shadow:0 6px 22px rgba(22,163,74,.12)' : '' }}">
                     <div style="display:flex;align-items:center;gap:10px">
                         <input type="radio" name="revenue_model" value="{{ $k }}" @checked($rm===$k)>
                         <i class="fa-solid {{ $v[1] }}" style="color:var(--blue);font-size:18px"></i>

--- a/Modules/Tagtoa/resources/views/event/order.blade.php
+++ b/Modules/Tagtoa/resources/views/event/order.blade.php
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#0055FF;--green:#1D9E75;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#16A34A;--green:#1D9E75;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--bg);color:var(--blk)}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;padding:24px 18px}
         .ok{text-align:center;padding:18px}.ok i{font-size:46px;color:var(--green)}.ok h1{font:700 22px var(--fh);margin-top:10px}.ok p{color:#666;font-size:14px;margin-top:4px}

--- a/Modules/Tagtoa/resources/views/event/scanner.blade.php
+++ b/Modules/Tagtoa/resources/views/event/scanner.blade.php
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
     <style>
-        :root{--blk:#0A0A0A;--blue:#0055FF;--green:#1D9E75;--red:#E0473E;--orange:#E08A1E;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#16A34A;--green:#1D9E75;--red:#E0473E;--orange:#E08A1E;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--blk);color:#fff;min-height:100vh}
         .top{padding:16px 18px;display:flex;align-items:center;gap:12px;border-bottom:1px solid rgba(255,255,255,.1)}.top h1{font:600 16px var(--fh);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.top .net{font-size:12px;padding:4px 9px;border-radius:999px;background:rgba(255,255,255,.12)}.top .net.off{background:var(--orange)}
         .stats{display:flex;gap:10px;padding:14px 18px}.stat{flex:1;background:rgba(255,255,255,.07);border-radius:12px;padding:12px;text-align:center}.stat b{font:700 22px var(--fh);display:block}.stat span{font-size:11px;opacity:.6}

--- a/Modules/Tagtoa/resources/views/event/show.blade.php
+++ b/Modules/Tagtoa/resources/views/event/show.blade.php
@@ -7,10 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#0055FF;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#16A34A;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.5}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;background:var(--bg);padding-bottom:90px}
-        .cover{height:200px;background:linear-gradient(135deg,#0A0A0A,#0040CC);position:relative;overflow:hidden}.cover img{width:100%;height:100%;object-fit:cover}
+        .cover{height:200px;background:linear-gradient(135deg,#0A0A0A,#15803D);position:relative;overflow:hidden}.cover img{width:100%;height:100%;object-fit:cover}
         .tb{position:absolute;top:14px;left:14px;background:var(--blue);color:#fff;font:600 11px var(--fh);letter-spacing:.1em;text-transform:uppercase;padding:5px 11px;border-radius:999px}
         .body{padding:20px 18px}h1{font:700 23px var(--fh)}
         .meta{display:flex;flex-direction:column;gap:8px;margin:14px 0;color:#555;font-size:14px}.meta i{color:var(--blue);width:18px}

--- a/Modules/Tagtoa/resources/views/event/ticket.blade.php
+++ b/Modules/Tagtoa/resources/views/event/ticket.blade.php
@@ -7,10 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#0055FF;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#16A34A;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:#0A0A0A;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
         .tk{max-width:380px;width:100%;background:#fff;color:var(--blk);border-radius:22px;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.5)}
-        .top{background:linear-gradient(135deg,#0A0A0A,#0040CC);color:#fff;padding:22px;text-align:center}.top .b{font:600 11px var(--fh);letter-spacing:.14em;text-transform:uppercase;opacity:.8}.top h1{font:700 19px var(--fh);margin-top:6px}
+        .top{background:linear-gradient(135deg,#0A0A0A,#15803D);color:#fff;padding:22px;text-align:center}.top .b{font:600 11px var(--fh);letter-spacing:.14em;text-transform:uppercase;opacity:.8}.top h1{font:700 19px var(--fh);margin-top:6px}
         .qr{padding:26px;text-align:center}.qr svg,.qr img{width:220px;height:220px}
         .dash{border:0;border-top:2px dashed rgba(0,0,0,.12);margin:0 20px}
         .info{padding:18px 22px}.kv{display:flex;justify-content:space-between;padding:8px 0;font-size:14px;border-bottom:1px solid rgba(0,0,0,.06)}.kv:last-child{border:0}.kv span{color:#888}.kv b{font-family:var(--fh)}

--- a/Modules/Tagtoa/resources/views/landing.blade.php
+++ b/Modules/Tagtoa/resources/views/landing.blade.php
@@ -20,7 +20,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#0055FF;--blue-deep:#0040CC;--blue-pale:rgba(0,85,255,.08);--mut:#8a8a8a;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#16A34A;--blue-deep:#15803D;--blue-pale:rgba(22,163,74,.08);--mut:#8a8a8a;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.6;-webkit-font-smoothing:antialiased}
         a{text-decoration:none;color:inherit}
@@ -37,7 +37,7 @@
         .btn-o{background:#fff;border:1.5px solid var(--bd);color:var(--blk)}
         .btn-g{background:rgba(255,255,255,.14);color:#fff;border:1px solid rgba(255,255,255,.25)}
         /* Hero */
-        .hero{background:linear-gradient(160deg,#0040CC,#0A0A0A);color:#fff;border-radius:0 0 32px 32px;overflow:hidden;position:relative}
+        .hero{background:linear-gradient(160deg,#15803D,#0A0A0A);color:#fff;border-radius:0 0 32px 32px;overflow:hidden;position:relative}
         .hero::after{content:"";position:absolute;right:-80px;top:-80px;width:340px;height:340px;background:radial-gradient(circle,var(--blue) 0%,transparent 70%);opacity:.4}
         .hero .in{padding:64px 0 72px;position:relative;z-index:2;text-align:center}
         .tagpill{display:inline-flex;align-items:center;gap:7px;background:rgba(255,255,255,.12);border:1px solid rgba(255,255,255,.22);padding:6px 14px;border-radius:999px;font:600 12px var(--fh);letter-spacing:.06em;text-transform:uppercase}

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -13,8 +13,8 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         :root{
-            --blk:#0A0A0A;--white:#fff;--bg:#F5F5F3;--surface:#fff;--blue:#0055FF;--blue-deep:#0040CC;
-            --blue-pale:rgba(0,85,255,.08);--green:#1D9E75;--red:#E0473E;--amber:#E08A1E;
+            --blk:#0A0A0A;--white:#fff;--bg:#F5F5F3;--surface:#fff;--blue:#16A34A;--blue-deep:#15803D;
+            --blue-pale:rgba(22,163,74,.08);--green:#1D9E75;--red:#E0473E;--amber:#E08A1E;
             --bd:rgba(0,0,0,.08);--muted:#8a8a8a;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;
             --sb:248px;
         }

--- a/Modules/Tagtoa/resources/views/links/show.blade.php
+++ b/Modules/Tagtoa/resources/views/links/show.blade.php
@@ -3,7 +3,7 @@
     $themes = [
         'dark'=>['bg'=>'#0A0A0A','fg'=>'#fff','card'=>'rgba(255,255,255,.08)','cfg'=>'#fff','mut'=>'rgba(255,255,255,.6)'],
         'light'=>['bg'=>'#F5F5F3','fg'=>'#0A0A0A','card'=>'#fff','cfg'=>'#0A0A0A','mut'=>'#888'],
-        'blue'=>['bg'=>'linear-gradient(160deg,#0040CC,#0A0A0A)','fg'=>'#fff','card'=>'rgba(255,255,255,.12)','cfg'=>'#fff','mut'=>'rgba(255,255,255,.7)'],
+        'blue'=>['bg'=>'linear-gradient(160deg,#15803D,#0A0A0A)','fg'=>'#fff','card'=>'rgba(255,255,255,.12)','cfg'=>'#fff','mut'=>'rgba(255,255,255,.7)'],
     ];
     $t = $themes[$page->theme] ?? $themes['dark'];
     $social = ['facebook','instagram','tiktok','youtube','twitter','linkedin','telegram','whatsapp','snapchat','twitch','pinterest','discord','spotify'];
@@ -18,7 +18,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blue:#0055FF;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;--bg:{{ $t['bg'] }};--fg:{{ $t['fg'] }};--card:{{ $t['card'] }};--cfg:{{ $t['cfg'] }};--mut:{{ $t['mut'] }}}
+        :root{--blue:#16A34A;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;--bg:{{ $t['bg'] }};--fg:{{ $t['fg'] }};--card:{{ $t['card'] }};--cfg:{{ $t['cfg'] }};--mut:{{ $t['mut'] }}}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--fg);min-height:100vh}
         .wrap{max-width:480px;margin:0 auto;padding:40px 20px 60px;min-height:100vh}
@@ -28,7 +28,7 @@
         .bio{text-align:center;color:var(--mut);font-size:14.5px;margin:8px auto 0;max-width:340px}
         .links{margin-top:28px;display:flex;flex-direction:column;gap:12px}
         .lnk{display:flex;align-items:center;gap:14px;background:var(--card);color:var(--cfg);border:1px solid rgba(128,128,128,.12);border-radius:15px;padding:15px 18px;font:600 15px var(--fh);transition:transform .2s,box-shadow .2s}
-        .lnk:active{transform:scale(.98)}.lnk:hover{box-shadow:0 6px 22px rgba(0,85,255,.18)}
+        .lnk:active{transform:scale(.98)}.lnk:hover{box-shadow:0 6px 22px rgba(22,163,74,.18)}
         .lnk i{font-size:20px;width:24px;text-align:center;color:var(--blue)}
         .lnk.feat{background:var(--blue);color:#fff;border-color:transparent}.lnk.feat i{color:#fff}
         .lnk .chev{margin-left:auto;opacity:.4;font-size:13px}

--- a/Modules/Tagtoa/resources/views/loyalty/card.blade.php
+++ b/Modules/Tagtoa/resources/views/loyalty/card.blade.php
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#0055FF;--blue-deep:#0040CC;--blue-pale:rgba(0,85,255,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#16A34A;--blue-deep:#15803D;--blue-pale:rgba(22,163,74,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.5}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;padding:22px 16px 40px}
@@ -16,8 +16,8 @@
         .brand img,.brand .ph{width:38px;height:38px;border-radius:9px;object-fit:cover}
         .brand .ph{background:var(--blk);color:#fff;display:flex;align-items:center;justify-content:center;font-size:16px}
         .brand b{font-family:var(--fh);font-weight:700;font-size:16px}.brand span{font-size:12px;color:#888;display:block}
-        .card{position:relative;border-radius:20px;padding:22px;color:#fff;overflow:hidden;background:linear-gradient(135deg,#0A0A0A 0%,#0040CC 100%);box-shadow:0 14px 40px rgba(0,64,204,.28)}
-        .card::after{content:"";position:absolute;right:-50px;top:-50px;width:180px;height:180px;background:radial-gradient(circle,rgba(0,85,255,.6),transparent 70%)}
+        .card{position:relative;border-radius:20px;padding:22px;color:#fff;overflow:hidden;background:linear-gradient(135deg,#0A0A0A 0%,#15803D 100%);box-shadow:0 14px 40px rgba(21,128,61,.28)}
+        .card::after{content:"";position:absolute;right:-50px;top:-50px;width:180px;height:180px;background:radial-gradient(circle,rgba(22,163,74,.6),transparent 70%)}
         .card .nfc{position:absolute;top:20px;right:20px;font-size:20px;opacity:.85;transform:rotate(90deg)}
         .chip{width:38px;height:28px;border-radius:6px;background:linear-gradient(135deg,#e9c46a,#d4a017);position:absolute;top:54px;left:22px;opacity:.9}
         .lbl{font:600 11px var(--fh);letter-spacing:.14em;text-transform:uppercase;opacity:.7}

--- a/Modules/Tagtoa/resources/views/menu/form.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/form.blade.php
@@ -44,7 +44,7 @@
         <div class="h-row"><h2>{{ __('Apparence') }}</h2></div>
         <div class="row">
             <div><label class="lbl">{{ __('Thème') }}</label><select class="sel" name="theme">@foreach(['light'=>'Clair','dark'=>'Sombre'] as $k=>$v)<option value="{{ $k }}" @selected(old('theme',$menu->theme ?: 'light')===$k)>{{ __($v) }}</option>@endforeach</select></div>
-            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$menu->accent_color ?: '#0055FF') }}" style="height:48px;padding:6px"></div>
+            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$menu->accent_color ?: '#16A34A') }}" style="height:48px;padding:6px"></div>
         </div>
         <label class="switch"><input type="hidden" name="show_prices" value="0"><input type="checkbox" name="show_prices" value="1" @checked(old('show_prices',$menu->show_prices ?? true))> {{ __('Afficher les prix') }}</label>
         <label class="switch"><input type="hidden" name="is_active" value="0"><input type="checkbox" name="is_active" value="1" @checked(old('is_active',$menu->is_active ?? true))> {{ __('Menu actif (visible au public)') }}</label>

--- a/Modules/Tagtoa/resources/views/menu/show.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/show.blade.php
@@ -1,7 +1,7 @@
 {{-- TAGTOA MENU — page publique (NFC/QR). Variables : $menu, $categories --}}
 @php
     $dark = $menu->theme === 'dark';
-    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $menu->accent_color) ? $menu->accent_color : '#0055FF';
+    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $menu->accent_color) ? $menu->accent_color : '#16A34A';
     $bg   = $dark ? '#0A0A0A' : '#F5F5F3';
     $fg   = $dark ? '#FFFFFF' : '#0A0A0A';
     $surf = $dark ? '#161616' : '#FFFFFF';

--- a/Modules/Tagtoa/resources/views/partials/lang.blade.php
+++ b/Modules/Tagtoa/resources/views/partials/lang.blade.php
@@ -24,9 +24,9 @@
     .tg-lang[open]>summary .ch{transform:rotate(180deg)}
     .tg-lang-menu{position:absolute;right:0;top:calc(100% + 6px);min-width:170px;background:#fff;color:#0A0A0A;border:1px solid rgba(0,0,0,.1);border-radius:12px;box-shadow:0 12px 34px rgba(0,0,0,.16);padding:6px;z-index:200}
     .tg-lang-menu a{display:flex;align-items:center;gap:9px;padding:9px 11px;border-radius:9px;font:600 14px 'Space Grotesk',sans-serif;color:#0A0A0A;white-space:nowrap}
-    .tg-lang-menu a:hover{background:rgba(0,85,255,.08)}
-    .tg-lang-menu a.on{color:#0055FF}
-    .tg-lang-menu a .ck{margin-left:auto;font-size:11px;color:#0055FF}
+    .tg-lang-menu a:hover{background:rgba(22,163,74,.08)}
+    .tg-lang-menu a.on{color:#16A34A}
+    .tg-lang-menu a .ck{margin-left:auto;font-size:11px;color:#16A34A}
     .tg-lang-menu .fl,.tg-lang>summary .fl{font-size:15px;line-height:1}
     @media(max-width:520px){.tg-lang>summary .lb{display:none}}
 </style>

--- a/Modules/Tagtoa/resources/views/pay/show.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/show.blade.php
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#0055FF;--blue-deep:#0040CC;--blue-pale:rgba(0,85,255,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#16A34A;--blue-deep:#15803D;--blue-pale:rgba(22,163,74,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.5}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;padding-bottom:90px}
@@ -22,7 +22,7 @@
         .sec{font:600 13px var(--fh);letter-spacing:.05em;text-transform:uppercase;color:#777;margin:22px 22px 12px}
         .methods{padding:0 16px;display:flex;flex-direction:column;gap:10px}
         .m{background:var(--sf);border:1px solid var(--bd);border-radius:16px;padding:15px 16px;display:flex;align-items:center;gap:14px;cursor:pointer;width:100%;text-align:left;font:inherit;transition:all .25s cubic-bezier(.4,0,.2,1)}
-        .m:active{transform:scale(.985)}.m.on{border-color:var(--blue);background:var(--blue-pale);box-shadow:0 4px 18px rgba(0,85,255,.12)}
+        .m:active{transform:scale(.985)}.m.on{border-color:var(--blue);background:var(--blue-pale);box-shadow:0 4px 18px rgba(22,163,74,.12)}
         .m-ic{width:46px;height:46px;border-radius:12px;background:var(--blk);color:#fff;display:flex;align-items:center;justify-content:center;font-size:19px;flex-shrink:0}
         .m.on .m-ic{background:var(--blue)}
         .m-tx{flex:1;min-width:0}.m-tx b{display:block;font:600 15px var(--fh)}.m-tx span{font-size:12.5px;color:#888;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block}

--- a/Modules/Tagtoa/resources/views/pos/products.blade.php
+++ b/Modules/Tagtoa/resources/views/pos/products.blade.php
@@ -23,7 +23,7 @@
         <input name="products[IDX][name]" class="inp" placeholder="{{ __('Nom') }}" style="max-width:170px">
         <input name="products[IDX][price]" type="number" step="0.01" class="inp" placeholder="{{ __('Prix') }}" style="max-width:100px">
         <input name="products[IDX][stock]" type="number" class="inp" placeholder="{{ __('Stock') }}" style="max-width:90px">
-        <input name="products[IDX][color]" type="color" value="#0055FF" style="width:42px;height:42px;border:1px solid var(--bd);border-radius:8px">
+        <input name="products[IDX][color]" type="color" value="#16A34A" style="width:42px;height:42px;border:1px solid var(--bd);border-radius:8px">
         <label class="switch" style="flex:0"><input type="checkbox" name="products[IDX][is_active]" value="1" checked></label>
         <button type="button" class="btn btn-o btn-sm" style="flex:0;color:var(--red)" onclick="this.closest('.prow').remove()"><i class="fa-solid fa-trash"></i></button>
     </div>
@@ -32,7 +32,7 @@
 <script>
 var pIdx=0;
 function addP(d){var h=document.getElementById('ptpl').innerHTML.replace(/IDX/g,pIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('plist').appendChild(r);
-    if(d){r.querySelector('[name$="[emoji]"]').value=d.emoji||'';r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[stock]"]').value=d.stock==null?'':d.stock;r.querySelector('[name$="[color]"]').value=d.color||'#0055FF';r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='products['+pIdx+'][id]';i.value=d.id;r.appendChild(i);}
+    if(d){r.querySelector('[name$="[emoji]"]').value=d.emoji||'';r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[stock]"]').value=d.stock==null?'':d.stock;r.querySelector('[name$="[color]"]').value=d.color||'#16A34A';r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='products['+pIdx+'][id]';i.value=d.id;r.appendChild(i);}
     pIdx++;}
 var ex=@json($terminal->products->map(fn($p)=>['id'=>$p->id,'emoji'=>$p->emoji,'name'=>$p->name,'price'=>$p->price,'stock'=>$p->stock,'color'=>$p->color,'is_active'=>$p->is_active]));
 if(ex.length){ex.forEach(addP);}else{addP();}

--- a/Modules/Tagtoa/resources/views/pos/register.blade.php
+++ b/Modules/Tagtoa/resources/views/pos/register.blade.php
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#0055FF;--green:#1D9E75;--red:#E0473E;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#16A34A;--green:#1D9E75;--red:#E0473E;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);height:100vh;overflow:hidden}
         .app{display:grid;grid-template-columns:1fr 320px;height:100vh}
@@ -22,7 +22,7 @@
         .pay{display:block;width:100%;background:var(--green);color:#fff;border:0;border-radius:14px;padding:15px;font:600 16px var(--fh);cursor:pointer;margin-top:8px}.pay:disabled{background:#bcd;cursor:not-allowed}
         .modal{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:flex-end;z-index:50}.modal.show{display:flex}
         .sheet{background:#fff;width:100%;max-width:480px;margin:0 auto;border-radius:22px 22px 0 0;padding:18px;max-height:88vh;overflow-y:auto}.sheet h3{font-family:var(--fh);margin-bottom:6px}
-        .methods{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin:12px 0}.m{border:1.5px solid var(--bd);border-radius:12px;padding:10px 6px;text-align:center;cursor:pointer;font-size:12px;background:#fff}.m.on{border-color:var(--blue);background:rgba(0,85,255,.08);color:var(--blue);font-weight:700}
+        .methods{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin:12px 0}.m{border:1.5px solid var(--bd);border-radius:12px;padding:10px 6px;text-align:center;cursor:pointer;font-size:12px;background:#fff}.m.on{border-color:var(--blue);background:rgba(22,163,74,.08);color:var(--blue);font-weight:700}
         .split{font-size:13px;color:#666;margin:8px 0}.split input{width:90px;padding:6px;border:1px solid var(--bd);border-radius:8px;text-align:right}
         .field{width:100%;padding:11px;border:1.5px solid var(--bd);border-radius:10px;margin:6px 0;font:15px var(--fb)}
         .done{position:fixed;inset:0;background:var(--green);color:#fff;display:none;flex-direction:column;align-items:center;justify-content:center;z-index:60;text-align:center;padding:20px}.done.show{display:flex}.done i{font-size:64px}.done h2{font:700 24px var(--fh);margin:12px 0 4px}.done .acts{display:flex;gap:10px;margin-top:20px}.done .acts a,.done .acts button{background:rgba(255,255,255,.2);color:#fff;border:0;border-radius:12px;padding:12px 18px;font:600 14px var(--fh);text-decoration:none;cursor:pointer}


### PR DESCRIPTION
## Rebranding — koulè prensipal → vèt `#16A34A`

Chanje koulè mak prensipal TAGTOA soti ble pou rive **vèt `#16A34A`** atravè tout entèfas la.

- `#0055FF` → `#16A34A` (prensipal)
- `#0040CC` → `#15803D` (vèt fonse)
- `rgba(0,85,255,*)` → `rgba(22,163,74,*)` (pal/lonbraj)

Aplike sou: dashboard, paj akèy, tout paj piblik (pay, menu, links, event, loyalty, pos), partials, ak valè default PHP (aksan menu, mak pasrèl). 44 referans nan 22 fichye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_