### PR TITLE
TAGTOA: Phase 5 — POS en PWA (installable + hors ligne)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,11 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
     pi teste). Branche sou aksyon sansib: moderasyon avi (approve/reject/reply/delete),
     estati randevou (completed/cancelled/confirmed), kòmand menu ankese, billing settle/update,
     chanjman fòfè. Viewer lekti sèl `/tagtoa/audit` (filtre pa aksyon, pajine).
-  - ⏳ RES: notifikasyon WhatsApp (API), PWA POS.
+  - ✅ PWA POS: kès la enstalab + offline. Manifeste pa terminal (`/tagtoa/pos/{id}/app.webmanifest`),
+    service worker (`/tagtoa/pos/sw.js`, network-first navigation + cache-first asset, scope
+    `/tagtoa/pos/`), ikòn SVG (`/tagtoa/pos/icon.svg`), bouton « Installer » (beforeinstallprompt).
+    Lavant offline (localStorage queue + sync) te deja egziste — PWA ajoute app shell hors-ligne.
+  - ⏳ RES: notifikasyon WhatsApp (API — bloke, bezwen kredansyèl).
 
 ## 6. Deplwaman & URL
 - App sèvi nan `public/`: base = **https://tagtoa.com/tapbiz/public**

--- a/Modules/Tagtoa/app/Http/Controllers/Pos/PosController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pos/PosController.php
@@ -138,6 +138,80 @@ class PosController extends Controller
         return back()->with('success', __('Produits enregistrés.'));
     }
 
+    /* ---------- PWA (installable + offline) ---------- */
+
+    /** Manifeste Web App de la caisse (par terminal). */
+    public function manifest(int $id): JsonResponse
+    {
+        $terminal = $this->own($id);
+        $scope = rtrim(url('/tagtoa/pos'), '/').'/';
+
+        return response()->json([
+            'name'             => $terminal->name.' — TAGTOA POS',
+            'short_name'       => 'TAGTOA POS',
+            'start_url'        => route('tagtoa.pos.register', $terminal->id),
+            'scope'            => $scope,
+            'display'          => 'standalone',
+            'orientation'      => 'portrait-primary',
+            'background_color' => '#0A0A0A',
+            'theme_color'      => '#16A34A',
+            'lang'             => app()->getLocale(),
+            'icons'            => [
+                ['src' => route('tagtoa.pos.icon'), 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable'],
+            ],
+        ]);
+    }
+
+    /** Icône SVG (vectorielle, sans fichier binaire à publier). */
+    public function icon()
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">'
+            .'<rect width="512" height="512" rx="96" fill="#16A34A"/>'
+            .'<path d="M300 96 154 288h86l-28 128 160-208h-92z" fill="#fff"/>'
+            .'</svg>';
+
+        return response($svg, 200)
+            ->header('Content-Type', 'image/svg+xml')
+            ->header('Cache-Control', 'public, max-age=86400');
+    }
+
+    /** Service worker : cache l'enveloppe (app shell) pour un usage hors ligne. */
+    public function serviceWorker()
+    {
+        $scope = rtrim(url('/tagtoa/pos'), '/').'/';
+        $js = <<<JS
+const CACHE = 'tagtoa-pos-v1';
+self.addEventListener('install', (e) => self.skipWaiting());
+self.addEventListener('activate', (e) => {
+    e.waitUntil(caches.keys().then(ks => Promise.all(ks.filter(k => k !== CACHE).map(k => caches.delete(k)))).then(() => self.clients.claim()));
+});
+// Network-first pour la navigation (HTML), cache-first pour le reste. GET seulement.
+self.addEventListener('fetch', (e) => {
+    const req = e.request;
+    if (req.method !== 'GET') return;
+    if (req.mode === 'navigate') {
+        e.respondWith(
+            fetch(req).then(res => { const c = res.clone(); caches.open(CACHE).then(ca => ca.put(req, c)); return res; })
+                      .catch(() => caches.match(req))
+        );
+        return;
+    }
+    e.respondWith(
+        caches.match(req).then(hit => hit || fetch(req).then(res => {
+            if (res && res.status === 200 && (res.type === 'basic' || res.type === 'cors')) {
+                const c = res.clone(); caches.open(CACHE).then(ca => ca.put(req, c));
+            }
+            return res;
+        }).catch(() => hit))
+    );
+});
+JS;
+
+        return response($js, 200)
+            ->header('Content-Type', 'application/javascript')
+            ->header('Service-Worker-Allowed', $scope);
+    }
+
     protected function own(int $id, array $with = []): Terminal
     {
         return Terminal::with($with)->where('tenant_id', Tenant::id())->findOrFail($id);

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -237,6 +237,8 @@
     "Inactif": "Inactive",
     "Inactive": "Inactive",
     "Inscrivez-vous et choisissez vos outils : site, menu, paiements, fidélité…": "Sign up and pick your tools: website, menu, payments, loyalty…",
+    "Installer": "Install",
+    "Installer l'application": "Install the app",
     "Institution": "Institution",
     "Institution (banque / wallet)": "Institution (bank / wallet)",
     "Instructions (optionnel)": "Instructions (optional)",

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -237,6 +237,8 @@
     "Inactif": "Inactivo",
     "Inactive": "Inactiva",
     "Inscrivez-vous et choisissez vos outils : site, menu, paiements, fidélité…": "Regístrate y elige tus herramientas: sitio, menú, pagos, fidelidad…",
+    "Installer": "Instalar",
+    "Installer l'application": "Instalar la aplicación",
     "Institution": "Institución",
     "Institution (banque / wallet)": "Institución (banco / wallet)",
     "Instructions (optionnel)": "Instrucciones (opcional)",

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -237,6 +237,8 @@
     "Inactif": "Inaktif",
     "Inactive": "Inaktif",
     "Inscrivez-vous et choisissez vos outils : site, menu, paiements, fidélité…": "Enskri epi chwazi zouti w: sitwèb, meni, peman, fidelite…",
+    "Installer": "Enstale",
+    "Installer l'application": "Enstale aplikasyon an",
     "Institution": "Enstitisyon",
     "Institution (banque / wallet)": "Enstitisyon (bank / wallet)",
     "Instructions (optionnel)": "Enstriksyon (opsyonèl)",

--- a/Modules/Tagtoa/resources/views/pos/register.blade.php
+++ b/Modules/Tagtoa/resources/views/pos/register.blade.php
@@ -5,6 +5,13 @@
 <head>
     <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"><meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ $terminal->name }} — TAGTOA POS</title>
+    {{-- PWA : installable + hors ligne --}}
+    <link rel="manifest" href="{{ route('tagtoa.pos.manifest',$terminal->id) }}">
+    <meta name="theme-color" content="#16A34A">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+    <link rel="apple-touch-icon" href="{{ route('tagtoa.pos.icon') }}">
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
@@ -31,7 +38,7 @@
 </head>
 <body data-terminal="{{ $terminal->id }}" data-currency="{{ $terminal->currency }}">
     <div class="app">
-        <div class="top"><i class="fa-solid fa-cash-register" style="color:var(--blue)"></i><h1>{{ $terminal->name }}</h1><span class="net" id="net">●</span><a href="{{ route('tagtoa.pos.report',$terminal->id) }}"><i class="fa-solid fa-chart-simple"></i></a></div>
+        <div class="top"><i class="fa-solid fa-cash-register" style="color:var(--blue)"></i><h1>{{ $terminal->name }}</h1><button id="installBtn" class="net" style="display:none;border:0;cursor:pointer;background:var(--blue)" title="{{ __('Installer l\'application') }}"><i class="fa-solid fa-download"></i> {{ __('Installer') }}</button><span class="net" id="net">●</span><a href="{{ route('tagtoa.pos.report',$terminal->id) }}"><i class="fa-solid fa-chart-simple"></i></a></div>
         <div class="grid" id="grid">
             @foreach($products as $p)
                 <button class="p" style="background:{{ $p->color }}" onclick="add({{ $p->id }},'{{ addslashes($p->name) }}',{{ $p->price }})"><span class="em">{{ $p->emoji ?: '🛒' }}</span><span>{{ $p->name }}</span><span class="pr">{{ number_format($p->price,2) }}</span></button>
@@ -91,6 +98,15 @@ function ok(ref,p){beep('success');closePay();document.getElementById('dref').te
     document.getElementById('wa').href='https://wa.me/'+(p.customer_phone||'').replace(/[^0-9]/g,'')+'?text='+msg;document.getElementById('done').classList.add('show');}
 function newSale(){cart={};document.getElementById('disc').value=0;document.getElementById('phone').value='';document.getElementById('done').classList.remove('show');render();}
 window.addEventListener('load',function(){setNet();render();});
+
+// --- PWA : service worker + invite d'installation ---
+if('serviceWorker' in navigator){
+    navigator.serviceWorker.register("{{ route('tagtoa.pos.sw') }}", {scope:"{{ rtrim(url('/tagtoa/pos'),'/') }}/"}).catch(function(){});
+}
+var deferredPrompt=null;
+window.addEventListener('beforeinstallprompt',function(e){e.preventDefault();deferredPrompt=e;var b=document.getElementById('installBtn');if(b)b.style.display='inline-block';});
+(function(){var b=document.getElementById('installBtn');if(b)b.addEventListener('click',function(){if(!deferredPrompt)return;deferredPrompt.prompt();deferredPrompt.userChoice.finally(function(){deferredPrompt=null;b.style.display='none';});});})();
+window.addEventListener('appinstalled',function(){var b=document.getElementById('installBtn');if(b)b.style.display='none';});
 </script>
 </body>
 </html>

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -143,6 +143,10 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
         Route::get('/{id}/report', [PosController::class, 'report'])->name('report');
         Route::get('/{id}/products', [PosController::class, 'products'])->name('products');
         Route::post('/{id}/products', [PosController::class, 'saveProducts'])->name('products.save');
+        // PWA (installable + offline)
+        Route::get('/sw.js', [PosController::class, 'serviceWorker'])->name('sw');
+        Route::get('/icon.svg', [PosController::class, 'icon'])->name('icon');
+        Route::get('/{id}/app.webmanifest', [PosController::class, 'manifest'])->name('manifest');
     });
 
     // BOOKING (rendez-vous)


### PR DESCRIPTION
## Résumé

La caisse **POS** devient une **Progressive Web App** : installable sur l'écran d'accueil et fonctionnelle hors ligne. La file de ventes offline + synchronisation existait déjà ; cette PR ajoute l'**enveloppe applicative hors-ligne** et l'installation.

## Changements

- **Manifeste** par terminal : `GET /tagtoa/pos/{id}/app.webmanifest` (nom, start_url, scope, display standalone, couleurs, icône)
- **Service worker** : `GET /tagtoa/pos/sw.js` — *network-first* pour la navigation (HTML), *cache-first* pour les assets, scope `/tagtoa/pos/`, en-tête `Service-Worker-Allowed`
- **Icône SVG** vectorielle : `GET /tagtoa/pos/icon.svg` (aucun binaire à publier)
- **Bouton « Installer »** dans la barre (via `beforeinstallprompt`) + métas PWA / Apple
- Enregistrement du SW dans la page caisse

## Tests
- `php -l` OK · équilibrage Blade vérifié · JSON i18n valides (589 clés / langue)
- Le contenu JS du SW est généré côté serveur (heredoc) avec `Content-Type: application/javascript`

## Note
Clôt la **Phase 5**. Reste uniquement les **notifications WhatsApp**, bloquées tant qu'une API / des identifiants ne sont pas fournis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_