### PR TITLE
TAGTOA EVENT: données démo wallet testables avec un tag NFC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,8 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
 ## 7. Done demo (pou teste)
 - MENU: `demo-menu` · PAY: `demo` · LINKS: `demo-links` · EVENT: `demo-concert` · BOOKING: `demo-booking`
 - LOYALTY token: `uvcudqvm9xsie6knrkhbdcok` · POS terminal id: `1`
+- EVENT WALLET: tag NFC demo UID `TAGTOA-DEMO-TAG` (solde 1000 G, stand « Bar Demo ») sou
+  `demo-concert` → teste sou `/tagtoa/event/{id}/wallet/terminal` (tape UID a oswa tap NFC).
 - Teste lang: ajoute `?lang=ht|en|es|fr` sou nenpòt paj.
 
 ## 8. Pyèj konnen (gotchas)

--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -95,6 +95,18 @@ class TagtoaDemoSeeder extends Seeder
         );
         $event->ticketTypes()->firstOrCreate(['name' => 'Standard'], ['price' => 0, 'quantity' => 200, 'is_active' => true]);
 
+        // 4b) EVENT WALLET — démo testable avec un tag NFC (UID: TAGTOA-DEMO-TAG)
+        app(\Modules\Tagtoa\App\Actions\Event\Wallet\OpenEventWalletAccounts::class)->handle($event);
+        \Modules\Tagtoa\App\Actions\Event\Wallet\OpenEventWalletAccounts::vendor($event, 'Bar Demo');
+        $demoTag = app(\Modules\Tagtoa\App\Actions\Event\Wallet\IssueNfcTag::class)->handle(
+            $event, 'TAGTOA-DEMO-TAG', ['label' => 'Client Demo', 'phone' => '+509 3000 0000', 'kind' => 'wristband']
+        );
+        if ($demoTag->walletAccount && (int) $demoTag->walletAccount->balance_minor === 0) {
+            app(\Modules\Tagtoa\App\Actions\Event\Wallet\TopUpWallet::class)->handle(
+                $demoTag->walletAccount, 1000, ['idempotency_key' => 'demo-topup-concert', 'payment_ref' => 'DEMO']
+            );
+        }
+
         // 5) MENU — menu digital démo (lounge/restaurant) + catégories + produits
         $menu = Menu::firstOrCreate(
             ['alias' => 'demo-menu'],


### PR DESCRIPTION
## Résumé

Rend le **wallet event testable immédiatement** après déploiement, avec un tag NFC de démonstration.

## Changements

- **Seeder** (`demo-concert`) : crée les comptes système, un stand « Bar Demo », un **tag NFC démo** (`UID: TAGTOA-DEMO-TAG`, porteur + téléphone) et une **recharge de 1000 G** — le tout **idempotent** (via `firstOrCreate` + `idempotency_key` fixe, garde sur solde).
- **CLAUDE.md** : UID démo documenté (section 7).

## Comment tester
1. `/tagtoa/event/{id}/wallet/terminal`
2. Choisir « Bar Demo », saisir `TAGTOA-DEMO-TAG` (ou tap NFC sur Chrome Android)
3. Vérifier le solde (1000 G) → encaisser → le solde diminue, le stand est crédité
4. Réconciliation + payout depuis `/tagtoa/event/{id}/wallet`

## Tests
- `php -l` OK (seeder). Actions déjà couvertes par `WalletFlowTest` (Biztap) + `LedgerTest` (CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_