### PR TITLE
TAGTOA EVENT: notifications e-mail achat/recharge + reçu public

### DIFF
--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000081_add_owner_email_to_tagtoa_ev_wallet_accounts.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000081_add_owner_email_to_tagtoa_ev_wallet_accounts.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — e-mail du porteur (notifications achat/recharge par e-mail).
+ * Colonne nullable, conforme à la règle "nouvelles colonnes nullable/default".
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('tagtoa_ev_wallet_accounts', 'owner_email')) {
+            Schema::table('tagtoa_ev_wallet_accounts', function (Blueprint $table) {
+                $table->string('owner_email', 160)->nullable()->after('owner_phone');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('tagtoa_ev_wallet_accounts', 'owner_email')) {
+            Schema::table('tagtoa_ev_wallet_accounts', function (Blueprint $table) {
+                $table->dropColumn('owner_email');
+            });
+        }
+    }
+};

--- a/Modules/Tagtoa/app/Actions/Event/Wallet/EncodeParticipantCard.php
+++ b/Modules/Tagtoa/app/Actions/Event/Wallet/EncodeParticipantCard.php
@@ -39,6 +39,7 @@ class EncodeParticipantCard
             $tag = $this->issue->handle($event, $data['uid'], [
                 'label'     => $data['name'] ?? null,
                 'phone'     => $data['phone'] ?? null,
+                'email'     => $data['email'] ?? null,
                 'ticket_id' => $ticket->id,
                 'kind'      => $data['kind'] ?? 'card',
             ]);

--- a/Modules/Tagtoa/app/Actions/Event/Wallet/IssueNfcTag.php
+++ b/Modules/Tagtoa/app/Actions/Event/Wallet/IssueNfcTag.php
@@ -39,6 +39,7 @@ class IssueNfcTag
                 'type'          => WalletAccount::TYPE_PARTICIPANT,
                 'owner_label'   => $opts['label'] ?? null,
                 'owner_phone'   => $opts['phone'] ?? null,
+                'owner_email'   => $opts['email'] ?? null,
                 'currency'      => $event->currency ?: 'HTG',
                 'balance_minor' => 0,
                 'status'        => 'active',

--- a/Modules/Tagtoa/app/Http/Controllers/Event/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/PublicController.php
@@ -9,6 +9,7 @@ use Illuminate\View\View;
 use Modules\Tagtoa\App\Models\Event\Event;
 use Modules\Tagtoa\App\Models\Event\Order;
 use Modules\Tagtoa\App\Models\Event\Ticket;
+use Modules\Tagtoa\App\Models\Event\WalletTxn;
 use Modules\Tagtoa\App\Services\Billing\RevenueService;
 use Modules\Tagtoa\App\Services\Event\TicketService;
 
@@ -28,6 +29,16 @@ class PublicController extends Controller
         $event->incrementQuietly('views');
 
         return view('tagtoa::event.show', ['event' => $event]);
+    }
+
+    /** Reçu public d'une transaction wallet (achat/recharge), par référence. */
+    public function walletReceipt(string $reference): View
+    {
+        $txn = WalletTxn::where('reference', $reference)->firstOrFail();
+        $event = $txn->event_id ? Event::find($txn->event_id) : null;
+        $vendor = $txn->destAccount; // pour un achat : le stand
+
+        return view('tagtoa::event.wallet-receipt', compact('txn', 'event', 'vendor'));
     }
 
     public function buy(Request $request, string $alias): RedirectResponse

--- a/Modules/Tagtoa/app/Http/Controllers/Event/WalletController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/WalletController.php
@@ -62,6 +62,7 @@ class WalletController extends Controller
             'uid'            => ['required', 'string', 'max:120'],
             'name'           => ['required', 'string', 'max:120'],
             'phone'          => ['nullable', 'string', 'max:40'],
+            'email'          => ['nullable', 'email', 'max:160'],
             'ticket_type_id' => ['nullable', 'integer'],
             'amount'         => ['nullable', 'numeric', 'min:0'],
             'kind'           => ['nullable', Rule::in(\Modules\Tagtoa\App\Models\Event\NfcTag::KINDS)],
@@ -155,8 +156,9 @@ class WalletController extends Controller
 
         $fresh = $participant->fresh();
         app(\Modules\Tagtoa\App\Services\Notifications\NotificationService::class)->push([
-            'channels' => ['whatsapp'],
+            'channels' => ['whatsapp', 'email'],
             'phone'    => $fresh->owner_phone,
+            'email'    => $fresh->owner_email,
             'subject'  => __('Recharge TAGTOA'),
             'body'     => __('Recharge effectuée.').' '.__('Nouveau solde').' : '.Money::formatMinor((int) $fresh->balance_minor, $fresh->currency),
         ]);
@@ -239,20 +241,24 @@ class WalletController extends Controller
         }
 
         $fresh = $participant->fresh();
+        $receiptUrl = route('tagtoa.event.wallet.receipt', $txn->reference);
 
         app(\Modules\Tagtoa\App\Services\Notifications\NotificationService::class)->push([
-            'channels' => ['whatsapp'],
+            'channels' => ['whatsapp', 'email'],
             'phone'    => $fresh->owner_phone,
+            'email'    => $fresh->owner_email,
             'subject'  => __('Achat TAGTOA'),
             'body'     => __('Achat').' : '.Money::formatMinor((int) $txn->amount_minor, $txn->currency)
-                .' — '.$vendor->owner_label.'. '.__('Nouveau solde').' : '.Money::formatMinor((int) $fresh->balance_minor, $fresh->currency),
+                .' — '.$vendor->owner_label.'. '.__('Nouveau solde').' : '.Money::formatMinor((int) $fresh->balance_minor, $fresh->currency)
+                .' '.__('Reçu').' : '.$receiptUrl,
         ]);
 
         return response()->json([
-            'ok'        => true,
-            'reference' => $txn->reference,
-            'charged'   => Money::formatMinor((int) $txn->amount_minor, $txn->currency),
-            'balance'   => Money::formatMinor((int) $fresh->balance_minor, $fresh->currency),
+            'ok'          => true,
+            'reference'   => $txn->reference,
+            'charged'     => Money::formatMinor((int) $txn->amount_minor, $txn->currency),
+            'balance'     => Money::formatMinor((int) $fresh->balance_minor, $fresh->currency),
+            'receipt_url' => $receiptUrl,
         ]);
     }
 

--- a/Modules/Tagtoa/app/Models/Event/WalletAccount.php
+++ b/Modules/Tagtoa/app/Models/Event/WalletAccount.php
@@ -31,7 +31,7 @@ class WalletAccount extends Model
 
     protected $fillable = [
         'tenant_id', 'event_id', 'nfc_tag_id', 'ticket_id', 'type',
-        'owner_label', 'owner_phone', 'currency', 'balance_minor', 'status',
+        'owner_label', 'owner_phone', 'owner_email', 'currency', 'balance_minor', 'status',
     ];
 
     protected $casts = [

--- a/Modules/Tagtoa/resources/views/event/wallet-receipt.blade.php
+++ b/Modules/Tagtoa/resources/views/event/wallet-receipt.blade.php
@@ -1,0 +1,40 @@
+{{-- TAGTOA EVENT — reçu public d'une transaction wallet. Variables: $txn, $event, $vendor --}}
+@php use Modules\Tagtoa\App\Support\Money; use Modules\Tagtoa\App\Services\Audit\AuditService; @endphp
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ __('Reçu') }} — {{ $txn->reference }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        :root{--green:#2cb809;--ink:#111;--muted:#666;--bd:rgba(0,0,0,.12);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        *{box-sizing:border-box;margin:0;padding:0}
+        body{font-family:var(--fb);background:#f4f4f5;color:var(--ink);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:18px}
+        .r{background:#fff;border:1px solid var(--bd);border-radius:18px;max-width:400px;width:100%;padding:26px;box-shadow:0 14px 40px rgba(0,0,0,.08)}
+        .ic{width:64px;height:64px;border-radius:50%;background:var(--green);color:#fff;display:flex;align-items:center;justify-content:center;font-size:30px;margin:0 auto 12px}
+        h1{font:700 20px var(--fh);text-align:center}
+        .amt{font:700 34px var(--fh);color:var(--green);text-align:center;margin:6px 0 2px}
+        .sub{text-align:center;color:var(--muted);font-size:13px;margin-bottom:18px}
+        .row{display:flex;justify-content:space-between;padding:10px 0;border-bottom:1px solid var(--bd);font-size:14px}
+        .row .k{color:var(--muted)}.row .v{font-weight:600;font-family:var(--fh)}
+        .foot{text-align:center;color:var(--muted);font-size:12px;margin-top:16px}.foot b{color:var(--ink);font-family:var(--fh)}
+    </style>
+</head>
+<body>
+    <div class="r">
+        <div class="ic"><i class="fa-solid fa-circle-check"></i></div>
+        <h1>{{ __('Reçu') }}</h1>
+        <div class="amt">{{ Money::formatMinor((int) $txn->amount_minor, $txn->currency) }}</div>
+        <div class="sub">{{ __(AuditService::actionLabel('wallet.'.$txn->type)) }}</div>
+
+        @if($event)<div class="row"><span class="k">{{ __('Événement') }}</span><span class="v">{{ $event->title }}</span></div>@endif
+        @if($txn->type === 'purchase' && $vendor)<div class="row"><span class="k">{{ __('Stand') }}</span><span class="v">{{ $vendor->owner_label }}</span></div>@endif
+        <div class="row"><span class="k">{{ __('Référence') }}</span><span class="v">{{ $txn->reference }}</span></div>
+        <div class="row"><span class="k">{{ __('Date') }}</span><span class="v">{{ optional($txn->created_at)->format('d/m/Y H:i') }}</span></div>
+
+        <div class="foot">{{ __('Propulsé par') }} <b>TAGTOA</b> · tagtoa.com</div>
+    </div>
+</body>
+</html>

--- a/Modules/Tagtoa/resources/views/event/wallet-terminal.blade.php
+++ b/Modules/Tagtoa/resources/views/event/wallet-terminal.blade.php
@@ -72,6 +72,7 @@
         <h2 id="doneAmt"></h2>
         <div class="sub">{{ __('Nouveau solde') }} : <b id="doneBal"></b></div>
         <div class="sub" id="doneRef" style="opacity:.7;margin-top:4px"></div>
+        <a id="doneReceipt" href="#" target="_blank" rel="noopener" style="display:none;margin-top:14px;background:rgba(255,255,255,.2);color:#fff;border-radius:12px;padding:11px 18px;font:700 14px var(--fh);text-decoration:none"><i class="fa-solid fa-receipt"></i> {{ __('Reçu') }}</a>
         <button onclick="reset()">{{ __('Nouvelle vente') }}</button>
     </div>
 
@@ -108,6 +109,7 @@
             btn.disabled=false;
             if(!res.ok||!res.j.ok){showErr(res.j.message||T.err);if(res.j.balance){el('amt').textContent=res.j.balance;}return;}
             el('doneAmt').textContent=res.j.charged;el('doneBal').textContent=res.j.balance;el('doneRef').textContent=res.j.reference;
+            var rc=el('doneReceipt');if(res.j.receipt_url){rc.href=res.j.receipt_url;rc.style.display='inline-block';}else{rc.style.display='none';}
             el('doneScr').classList.add('show');
         }).catch(function(){btn.disabled=false;showErr(T.err);});
     }

--- a/Modules/Tagtoa/resources/views/event/wallet.blade.php
+++ b/Modules/Tagtoa/resources/views/event/wallet.blade.php
@@ -65,6 +65,7 @@
         </div>
         <div class="row">
             <div><label class="lbl">{{ __('Téléphone (WhatsApp)') }}</label><input class="inp" name="phone" placeholder="+509 0000 0000"></div>
+            <div><label class="lbl">{{ __('E-mail (optionnel)') }}</label><input class="inp" type="email" name="email" placeholder="participant@exemple.com"></div>
             <div><label class="lbl">{{ __('Type de billet') }}</label>
                 <select class="sel" name="ticket_type_id"><option value="">{{ __('— Aucun —') }}</option>@foreach($ticketTypes as $tt)<option value="{{ $tt->id }}">{{ $tt->name }}</option>@endforeach</select>
             </div>

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -44,6 +44,7 @@ Route::get('/event/{alias}', [EventPublic::class, 'show'])->name('tagtoa.event.s
 Route::post('/event/{alias}/buy', [EventPublic::class, 'buy'])->name('tagtoa.event.buy');
 Route::get('/event/order/{reference}', [EventPublic::class, 'order'])->name('tagtoa.event.order');
 Route::get('/event/ticket/{code}', [EventPublic::class, 'ticket'])->name('tagtoa.event.ticket');
+Route::get('/event/wallet/receipt/{reference}', [EventPublic::class, 'walletReceipt'])->name('tagtoa.event.wallet.receipt');
 Route::get('/book/{alias}', [BookingPublic::class, 'show'])->name('tagtoa.booking.show');
 Route::post('/book/{alias}/reserve', [BookingPublic::class, 'reserve'])->name('tagtoa.booking.reserve');
 Route::post('/reviews', [\Modules\Tagtoa\App\Http\Controllers\Review\PublicController::class, 'store'])->name('tagtoa.reviews.store');


### PR DESCRIPTION
## Résumé

Complète les notifications wallet (e-mail en plus de WhatsApp) et ajoute un **reçu public**.

## Changements

- **Colonne `owner_email`** (nullable) sur `tagtoa_ev_wallet_accounts` + capture à l'encodage de carte et à l'émission de tag (champ e-mail dans le formulaire d'encodage).
- **Recharge & achat** notifient le porteur par **WhatsApp ET e-mail** (SMTP `MAIL_*`), tolérant/opt-in.
- **Reçu public** par référence : `GET /event/wallet/receipt/{reference}` (montant, type, événement, stand, date). Lien **« Reçu »** sur le terminal vendeur + inclus dans la notification d'achat (le client le reçoit sur son téléphone).

## Notes
- E-mail réel : `TAGTOA_NOTIFY=true` + `MAIL_*` (SMTP) sur le VPS.
- WhatsApp réel : `TAGTOA_WA_NOTIFY=true` + `TAGTOA_TWILIO_*`.

## Tests
- `php -l` OK · équilibrage Blade OK · migration additive nullable · i18n déjà couvert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_