### PR TITLE
TAGTOA: couleur de marque #2cb809 + titres Anton dans tout le module

### DIFF
--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -115,7 +115,7 @@ class TagtoaDemoSeeder extends Seeder
                 'tagline' => 'Cuisine créole • Cocktails • Ambiance lounge',
                 'description' => 'Scannez, commandez, payez. Le menu digital TAGTOA.',
                 'currency' => 'HTG', 'whatsapp' => '+509 3000 0000',
-                'pay_page_id' => $pay->id, 'accent_color' => '#16A34A', 'theme' => 'dark',
+                'pay_page_id' => $pay->id, 'accent_color' => '#2cb809', 'theme' => 'dark',
                 'show_prices' => true, 'ordering_enabled' => true, 'is_active' => true,
             ]
         );
@@ -177,7 +177,7 @@ class TagtoaDemoSeeder extends Seeder
                 'name' => 'TAGTOA Lounge', 'tagline' => 'Restaurant • Lounge • Événements à Gonaïves',
                 'about' => "Bienvenue chez TAGTOA Lounge. Cuisine créole raffinée, cocktails signature et ambiance lounge. "
                     ."Réservez, commandez et payez en ligne — simplement.",
-                'theme' => 'dark', 'accent_color' => '#16A34A',
+                'theme' => 'dark', 'accent_color' => '#2cb809',
                 'phone' => '+509 3000 0000', 'whatsapp' => '+509 3000 0000',
                 'email' => 'bonjou@tagtoa.com', 'address' => 'Rue Egalité, Gonaïves, Haïti',
                 'services' => [
@@ -207,7 +207,7 @@ class TagtoaDemoSeeder extends Seeder
             [
                 'name' => 'TAGTOA Studio Demo', 'tagline' => 'Coiffure • Soins • Sur rendez-vous',
                 'about' => 'Réservez votre rendez-vous en ligne en quelques secondes.',
-                'theme' => 'light', 'accent_color' => '#16A34A',
+                'theme' => 'light', 'accent_color' => '#2cb809',
                 'phone' => '+509 3000 0000', 'whatsapp' => '+509 3000 0000',
                 'email' => 'studio@tagtoa.com', 'address' => 'Rue Egalité, Gonaïves, Haïti',
                 'currency' => 'HTG', 'pay_page_id' => $pay->id ?? null, 'is_active' => true,
@@ -255,7 +255,7 @@ class TagtoaDemoSeeder extends Seeder
         // 6) POS — caisse démo + produits
         $terminal = Terminal::firstOrCreate(['name' => 'Caisse Demo'], ['currency' => 'HTG', 'is_active' => true]);
         foreach ([
-            ['Café', 100, '☕', '#16A34A'],
+            ['Café', 100, '☕', '#2cb809'],
             ['Sandwich', 250, '🥪', '#1D9E75'],
             ['Jus', 150, '🧃', '#E08A1E'],
         ] as $i => [$name, $price, $emoji, $color]) {

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000051_create_tagtoa_pos_products_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000051_create_tagtoa_pos_products_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->string('name');
             $table->decimal('price', 10, 2)->default(0);
             $table->string('emoji', 8)->nullable();
-            $table->string('color', 12)->default('#16A34A');
+            $table->string('color', 12)->default('#2cb809');
             $table->integer('stock')->nullable();
             $table->boolean('is_active')->default(true);
             $table->unsignedSmallInteger('sort')->default(0);

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000060_create_tagtoa_menus_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000060_create_tagtoa_menus_table.php
@@ -28,7 +28,7 @@ return new class extends Migration
             $table->string('phone', 40)->nullable();
             $table->string('address')->nullable();
             $table->unsignedBigInteger('pay_page_id')->nullable(); // lien TAGTOA Pay
-            $table->string('accent_color', 16)->default('#16A34A');
+            $table->string('accent_color', 16)->default('#2cb809');
             $table->string('theme', 20)->default('light');    // light|dark
             $table->boolean('show_prices')->default(true);
             $table->boolean('ordering_enabled')->default(true); // commande WhatsApp

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000067_create_tagtoa_sites_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000067_create_tagtoa_sites_table.php
@@ -24,7 +24,7 @@ return new class extends Migration
             $table->string('logo_path')->nullable();
             $table->string('cover_path')->nullable();
             $table->string('theme', 20)->default('light');     // light|dark
-            $table->string('accent_color', 16)->default('#16A34A');
+            $table->string('accent_color', 16)->default('#2cb809');
             // Contact
             $table->string('phone', 40)->nullable();
             $table->string('whatsapp', 40)->nullable();

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000069_create_tagtoa_booking_pages_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000069_create_tagtoa_booking_pages_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->string('logo_path')->nullable();
             $table->string('cover_path')->nullable();
             $table->string('theme', 20)->default('light');
-            $table->string('accent_color', 16)->default('#16A34A');
+            $table->string('accent_color', 16)->default('#2cb809');
             $table->string('phone', 40)->nullable();
             $table->string('whatsapp', 40)->nullable();
             $table->string('email')->nullable();

--- a/Modules/Tagtoa/app/Http/Controllers/Booking/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Booking/DashboardController.php
@@ -37,7 +37,7 @@ class DashboardController extends Controller
     public function create(): View
     {
         return view('tagtoa::booking.form', [
-            'page'     => new BookingPage(['theme' => 'light', 'accent_color' => '#16A34A', 'currency' => Locale::currencyFor()]),
+            'page'     => new BookingPage(['theme' => 'light', 'accent_color' => '#2cb809', 'currency' => Locale::currencyFor()]),
             'vcards'   => $this->vcards(),
             'payPages' => $this->payPages(),
         ]);

--- a/Modules/Tagtoa/app/Http/Controllers/Menu/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Menu/DashboardController.php
@@ -37,7 +37,7 @@ class DashboardController extends Controller
     public function create(): View
     {
         return view('tagtoa::menu.form', [
-            'menu'     => new Menu(['theme' => 'light', 'accent_color' => '#16A34A', 'currency' => Locale::currencyFor()]),
+            'menu'     => new Menu(['theme' => 'light', 'accent_color' => '#2cb809', 'currency' => Locale::currencyFor()]),
             'vcards'   => $this->vcards(),
             'payPages' => $this->payPages(),
         ]);

--- a/Modules/Tagtoa/app/Http/Controllers/Pos/PosController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pos/PosController.php
@@ -124,7 +124,7 @@ class PosController extends Controller
                 'name'      => $row['name'],
                 'price'     => (float) ($row['price'] ?? 0),
                 'emoji'     => $row['emoji'] ?? null,
-                'color'     => $row['color'] ?? '#16A34A',
+                'color'     => $row['color'] ?? '#2cb809',
                 'stock'     => ($row['stock'] ?? '') === '' ? null : (int) $row['stock'],
                 'is_active' => ! empty($row['is_active']),
                 'sort'      => (int) ($row['sort'] ?? $i),
@@ -154,7 +154,7 @@ class PosController extends Controller
             'display'          => 'standalone',
             'orientation'      => 'portrait-primary',
             'background_color' => '#0A0A0A',
-            'theme_color'      => '#16A34A',
+            'theme_color'      => '#2cb809',
             'lang'             => app()->getLocale(),
             'icons'            => [
                 ['src' => route('tagtoa.pos.icon'), 'sizes' => 'any', 'type' => 'image/svg+xml', 'purpose' => 'any maskable'],
@@ -166,7 +166,7 @@ class PosController extends Controller
     public function icon()
     {
         $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">'
-            .'<rect width="512" height="512" rx="96" fill="#16A34A"/>'
+            .'<rect width="512" height="512" rx="96" fill="#2cb809"/>'
             .'<path d="M300 96 154 288h86l-28 128 160-208h-92z" fill="#fff"/>'
             .'</svg>';
 

--- a/Modules/Tagtoa/app/Http/Controllers/Site/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Site/DashboardController.php
@@ -33,7 +33,7 @@ class DashboardController extends Controller
     public function create(): View
     {
         return view('tagtoa::site.form', $this->formData(new Site([
-            'theme' => 'light', 'accent_color' => '#16A34A',
+            'theme' => 'light', 'accent_color' => '#2cb809',
         ])));
     }
 

--- a/Modules/Tagtoa/app/Models/Pay/PaymentMethod.php
+++ b/Modules/Tagtoa/app/Models/Pay/PaymentMethod.php
@@ -50,7 +50,7 @@ class PaymentMethod extends Model
 
     public function getBrandColorAttribute(): string
     {
-        return $this->meta['color'] ?? '#16A34A';
+        return $this->meta['color'] ?? '#2cb809';
     }
 
     /** Cette méthode est-elle une passerelle automatique (API) ? */

--- a/Modules/Tagtoa/app/Support/PaymentGateway.php
+++ b/Modules/Tagtoa/app/Support/PaymentGateway.php
@@ -57,10 +57,10 @@ class PaymentGateway
         'binance'     => ['mode' => self::MODE_MANUAL, 'kind' => 'crypto', 'color' => '#F0B90B', 'driver' => null],
         'crypto'      => ['mode' => self::MODE_MANUAL, 'kind' => 'crypto', 'color' => '#8a8a8a', 'driver' => null],
         // TAGTOA
-        'tagtoa_card' => ['mode' => self::MODE_MANUAL, 'kind' => 'card', 'color' => '#16A34A', 'driver' => null],
+        'tagtoa_card' => ['mode' => self::MODE_MANUAL, 'kind' => 'card', 'color' => '#2cb809', 'driver' => null],
     ];
 
-    private const DEFAULT = ['mode' => self::MODE_MANUAL, 'kind' => 'other', 'color' => '#16A34A', 'driver' => null];
+    private const DEFAULT = ['mode' => self::MODE_MANUAL, 'kind' => 'other', 'color' => '#2cb809', 'driver' => null];
 
     /** Métadonnées complètes d'un type : label + icon (METHODS) + mode/kind/color/driver. */
     public static function meta(string $type): array

--- a/Modules/Tagtoa/resources/views/billing/index.blade.php
+++ b/Modules/Tagtoa/resources/views/billing/index.blade.php
@@ -17,7 +17,7 @@
                 'commission'=>['Commission','fa-percent','Pas de forfait. TAGTOA prélève un % sur chaque vente.'],
                 'both'=>['Les deux','fa-layer-group','Forfait réduit + petite commission.'],
             ] as $k=>$v)
-                <label class="card" style="cursor:pointer;border-color:{{ $rm===$k ? 'var(--blue)' : 'var(--bd)' }};{{ $rm===$k ? 'box-shadow:0 6px 22px rgba(22,163,74,.12)' : '' }}">
+                <label class="card" style="cursor:pointer;border-color:{{ $rm===$k ? 'var(--blue)' : 'var(--bd)' }};{{ $rm===$k ? 'box-shadow:0 6px 22px rgba(44,184,9,.12)' : '' }}">
                     <div style="display:flex;align-items:center;gap:10px">
                         <input type="radio" name="revenue_model" value="{{ $k }}" @checked($rm===$k)>
                         <i class="fa-solid {{ $v[1] }}" style="color:var(--blue);font-size:18px"></i>

--- a/Modules/Tagtoa/resources/views/billing/plan.blade.php
+++ b/Modules/Tagtoa/resources/views/billing/plan.blade.php
@@ -39,7 +39,7 @@
 <div class="grid g3">
     @foreach($plans as $key=>$p)
         @php $isCur = $key === $current; @endphp
-        <div class="card" style="{{ $key==='pro' ? 'border-color:var(--blue);box-shadow:0 6px 22px rgba(22,163,74,.12)' : '' }}">
+        <div class="card" style="{{ $key==='pro' ? 'border-color:var(--blue);box-shadow:0 6px 22px rgba(44,184,9,.12)' : '' }}">
             <div style="display:flex;justify-content:space-between;align-items:center">
                 <b style="font-family:var(--fh);font-size:18px">{{ $p['label'] ?? ucfirst($key) }}</b>
                 @if($key==='pro')<span class="pill a">{{ __('Populaire') }}</span>@endif

--- a/Modules/Tagtoa/resources/views/booking/form.blade.php
+++ b/Modules/Tagtoa/resources/views/booking/form.blade.php
@@ -44,7 +44,7 @@
         <div class="h-row"><h2>{{ __('Apparence') }}</h2></div>
         <div class="row">
             <div><label class="lbl">{{ __('Thème') }}</label><select class="sel" name="theme">@foreach(['light'=>'Clair','dark'=>'Sombre'] as $k=>$v)<option value="{{ $k }}" @selected(old('theme',$page->theme ?: 'light')===$k)>{{ __($v) }}</option>@endforeach</select></div>
-            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$page->accent_color ?: '#16A34A') }}" style="height:48px;padding:6px"></div>
+            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$page->accent_color ?: '#2cb809') }}" style="height:48px;padding:6px"></div>
         </div>
         <label class="switch"><input type="hidden" name="is_active" value="0"><input type="checkbox" name="is_active" value="1" @checked(old('is_active',$page->is_active ?? true))> {{ __('Page active (visible au public)') }}</label>
     </div>

--- a/Modules/Tagtoa/resources/views/booking/show.blade.php
+++ b/Modules/Tagtoa/resources/views/booking/show.blade.php
@@ -1,7 +1,7 @@
 {{-- TAGTOA BOOKING — page publique de réservation (NFC/QR). Variables : $page, $services --}}
 @php
     $dark = $page->theme === 'dark';
-    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $page->accent_color) ? $page->accent_color : '#16A34A';
+    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $page->accent_color) ? $page->accent_color : '#2cb809';
     $bg   = $dark ? '#0A0A0A' : '#F5F5F3';
     $fg   = $dark ? '#FFFFFF' : '#0A0A0A';
     $surf = $dark ? '#161616' : '#FFFFFF';

--- a/Modules/Tagtoa/resources/views/event/badges.blade.php
+++ b/Modules/Tagtoa/resources/views/event/badges.blade.php
@@ -6,9 +6,10 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ __('Badges') }} — {{ $event->title }}</title>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
         :root{--green:#2cb809;--ink:#111;--bd:rgba(0,0,0,.14);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        .bar h1,.badge .nm{font-family:'Anton',sans-serif!important;font-weight:400!important;letter-spacing:.01em}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);color:var(--ink);background:#f4f4f5;padding:16px}
         .bar{max-width:900px;margin:0 auto 14px;display:flex;gap:10px;align-items:center}

--- a/Modules/Tagtoa/resources/views/event/order.blade.php
+++ b/Modules/Tagtoa/resources/views/event/order.blade.php
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#16A34A;--green:#1D9E75;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#2cb809;--green:#1D9E75;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--bg);color:var(--blk)}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;padding:24px 18px}
         .ok{text-align:center;padding:18px}.ok i{font-size:46px;color:var(--green)}.ok h1{font:700 22px var(--fh);margin-top:10px}.ok p{color:#666;font-size:14px;margin-top:4px}

--- a/Modules/Tagtoa/resources/views/event/scanner.blade.php
+++ b/Modules/Tagtoa/resources/views/event/scanner.blade.php
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <script src="https://unpkg.com/html5-qrcode@2.3.8/html5-qrcode.min.js"></script>
     <style>
-        :root{--blk:#0A0A0A;--blue:#16A34A;--green:#1D9E75;--red:#E0473E;--orange:#E08A1E;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#2cb809;--green:#1D9E75;--red:#E0473E;--orange:#E08A1E;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--blk);color:#fff;min-height:100vh}
         .top{padding:16px 18px;display:flex;align-items:center;gap:12px;border-bottom:1px solid rgba(255,255,255,.1)}.top h1{font:600 16px var(--fh);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.top .net{font-size:12px;padding:4px 9px;border-radius:999px;background:rgba(255,255,255,.12)}.top .net.off{background:var(--orange)}
         .stats{display:flex;gap:10px;padding:14px 18px}.stat{flex:1;background:rgba(255,255,255,.07);border-radius:12px;padding:12px;text-align:center}.stat b{font:700 22px var(--fh);display:block}.stat span{font-size:11px;opacity:.6}

--- a/Modules/Tagtoa/resources/views/event/show.blade.php
+++ b/Modules/Tagtoa/resources/views/event/show.blade.php
@@ -7,10 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#16A34A;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#2cb809;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.5}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;background:var(--bg);padding-bottom:90px}
-        .cover{height:200px;background:linear-gradient(135deg,#0A0A0A,#15803D);position:relative;overflow:hidden}.cover img{width:100%;height:100%;object-fit:cover}
+        .cover{height:200px;background:linear-gradient(135deg,#0A0A0A,#239406);position:relative;overflow:hidden}.cover img{width:100%;height:100%;object-fit:cover}
         .tb{position:absolute;top:14px;left:14px;background:var(--blue);color:#fff;font:600 11px var(--fh);letter-spacing:.1em;text-transform:uppercase;padding:5px 11px;border-radius:999px}
         .body{padding:20px 18px}h1{font:700 23px var(--fh)}
         .meta{display:flex;flex-direction:column;gap:8px;margin:14px 0;color:#555;font-size:14px}.meta i{color:var(--blue);width:18px}

--- a/Modules/Tagtoa/resources/views/event/ticket.blade.php
+++ b/Modules/Tagtoa/resources/views/event/ticket.blade.php
@@ -7,10 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#16A34A;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#2cb809;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:#0A0A0A;color:#fff;min-height:100vh;display:flex;align-items:center;justify-content:center;padding:20px}
         .tk{max-width:380px;width:100%;background:#fff;color:var(--blk);border-radius:22px;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.5)}
-        .top{background:linear-gradient(135deg,#0A0A0A,#15803D);color:#fff;padding:22px;text-align:center}.top .b{font:600 11px var(--fh);letter-spacing:.14em;text-transform:uppercase;opacity:.8}.top h1{font:700 19px var(--fh);margin-top:6px}
+        .top{background:linear-gradient(135deg,#0A0A0A,#239406);color:#fff;padding:22px;text-align:center}.top .b{font:600 11px var(--fh);letter-spacing:.14em;text-transform:uppercase;opacity:.8}.top h1{font:700 19px var(--fh);margin-top:6px}
         .qr{padding:26px;text-align:center}.qr svg,.qr img{width:220px;height:220px}
         .dash{border:0;border-top:2px dashed rgba(0,0,0,.12);margin:0 20px}
         .info{padding:18px 22px}.kv{display:flex;justify-content:space-between;padding:8px 0;font-size:14px;border-bottom:1px solid rgba(0,0,0,.06)}.kv:last-child{border:0}.kv span{color:#888}.kv b{font-family:var(--fh)}

--- a/Modules/Tagtoa/resources/views/event/wallet-receipt.blade.php
+++ b/Modules/Tagtoa/resources/views/event/wallet-receipt.blade.php
@@ -6,10 +6,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ __('Reçu') }} — {{ $txn->reference }}</title>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         :root{--green:#2cb809;--ink:#111;--muted:#666;--bd:rgba(0,0,0,.12);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        h1,.amt{font-family:'Anton',sans-serif!important;font-weight:400!important;letter-spacing:.01em}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:#f4f4f5;color:var(--ink);min-height:100vh;display:flex;align-items:center;justify-content:center;padding:18px}
         .r{background:#fff;border:1px solid var(--bd);border-radius:18px;max-width:400px;width:100%;padding:26px;box-shadow:0 14px 40px rgba(0,0,0,.08)}

--- a/Modules/Tagtoa/resources/views/event/wallet-terminal.blade.php
+++ b/Modules/Tagtoa/resources/views/event/wallet-terminal.blade.php
@@ -6,10 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{{ $event->title }} — {{ __('Terminal') }}</title>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         :root{--green:#2cb809;--ink:#0d140c;--bg:#f5f9f2;--surf:#fff;--bd:rgba(13,20,12,.10);--mut:#5d6b5a;--red:#E0473E;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        .top h1,.bal .amt,.done h2{font-family:'Anton',sans-serif!important;font-weight:400!important;letter-spacing:.01em}
         *{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent}
         body{font-family:var(--fb);background:var(--bg);color:var(--ink);min-height:100vh}
         .top{background:var(--ink);color:#fff;padding:12px 18px;display:flex;align-items:center;gap:10px}

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -9,16 +9,18 @@
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>@yield('title','TAGTOA') · TAGTOA</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
         :root{
-            --blk:#0A0A0A;--white:#fff;--bg:#F5F5F3;--surface:#fff;--blue:#16A34A;--blue-deep:#15803D;
-            --blue-pale:rgba(22,163,74,.08);--green:#1D9E75;--red:#E0473E;--amber:#E08A1E;
+            --blk:#0A0A0A;--white:#fff;--bg:#F5F5F3;--surface:#fff;--blue:#2cb809;--blue-deep:#239406;
+            --blue-pale:rgba(44,184,9,.08);--green:#1D9E75;--red:#E0473E;--amber:#E08A1E;
             --bd:rgba(0,0,0,.08);--muted:#8a8a8a;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;
-            --sb:248px;
+            --ft:'Anton',sans-serif;--sb:248px;
         }
         *{box-sizing:border-box;margin:0;padding:0}
+        /* Titres en Anton (display) */
+        .brand b,.top h1,.h-row h2,.stat .v,.card>h2,h1.pg{font-family:var(--ft)!important;font-weight:400!important;letter-spacing:.01em}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.55;-webkit-font-smoothing:antialiased}
         a{color:inherit;text-decoration:none}
         /* Sidebar */

--- a/Modules/Tagtoa/resources/views/links/show.blade.php
+++ b/Modules/Tagtoa/resources/views/links/show.blade.php
@@ -3,7 +3,7 @@
     $themes = [
         'dark'=>['bg'=>'#0A0A0A','fg'=>'#fff','card'=>'rgba(255,255,255,.08)','cfg'=>'#fff','mut'=>'rgba(255,255,255,.6)'],
         'light'=>['bg'=>'#F5F5F3','fg'=>'#0A0A0A','card'=>'#fff','cfg'=>'#0A0A0A','mut'=>'#888'],
-        'blue'=>['bg'=>'linear-gradient(160deg,#15803D,#0A0A0A)','fg'=>'#fff','card'=>'rgba(255,255,255,.12)','cfg'=>'#fff','mut'=>'rgba(255,255,255,.7)'],
+        'blue'=>['bg'=>'linear-gradient(160deg,#239406,#0A0A0A)','fg'=>'#fff','card'=>'rgba(255,255,255,.12)','cfg'=>'#fff','mut'=>'rgba(255,255,255,.7)'],
     ];
     $t = $themes[$page->theme] ?? $themes['dark'];
     $social = ['facebook','instagram','tiktok','youtube','twitter','linkedin','telegram','whatsapp','snapchat','twitch','pinterest','discord','spotify'];
@@ -18,7 +18,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blue:#16A34A;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;--bg:{{ $t['bg'] }};--fg:{{ $t['fg'] }};--card:{{ $t['card'] }};--cfg:{{ $t['cfg'] }};--mut:{{ $t['mut'] }}}
+        :root{--blue:#2cb809;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif;--bg:{{ $t['bg'] }};--fg:{{ $t['fg'] }};--card:{{ $t['card'] }};--cfg:{{ $t['cfg'] }};--mut:{{ $t['mut'] }}}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--fg);min-height:100vh}
         .wrap{max-width:480px;margin:0 auto;padding:40px 20px 60px;min-height:100vh}
@@ -28,7 +28,7 @@
         .bio{text-align:center;color:var(--mut);font-size:14.5px;margin:8px auto 0;max-width:340px}
         .links{margin-top:28px;display:flex;flex-direction:column;gap:12px}
         .lnk{display:flex;align-items:center;gap:14px;background:var(--card);color:var(--cfg);border:1px solid rgba(128,128,128,.12);border-radius:15px;padding:15px 18px;font:600 15px var(--fh);transition:transform .2s,box-shadow .2s}
-        .lnk:active{transform:scale(.98)}.lnk:hover{box-shadow:0 6px 22px rgba(22,163,74,.18)}
+        .lnk:active{transform:scale(.98)}.lnk:hover{box-shadow:0 6px 22px rgba(44,184,9,.18)}
         .lnk i{font-size:20px;width:24px;text-align:center;color:var(--blue)}
         .lnk.feat{background:var(--blue);color:#fff;border-color:transparent}.lnk.feat i{color:#fff}
         .lnk .chev{margin-left:auto;opacity:.4;font-size:13px}

--- a/Modules/Tagtoa/resources/views/loyalty/card.blade.php
+++ b/Modules/Tagtoa/resources/views/loyalty/card.blade.php
@@ -8,7 +8,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#16A34A;--blue-deep:#15803D;--blue-pale:rgba(22,163,74,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#2cb809;--blue-deep:#239406;--blue-pale:rgba(44,184,9,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.5}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;padding:22px 16px 40px}
@@ -16,8 +16,8 @@
         .brand img,.brand .ph{width:38px;height:38px;border-radius:9px;object-fit:cover}
         .brand .ph{background:var(--blk);color:#fff;display:flex;align-items:center;justify-content:center;font-size:16px}
         .brand b{font-family:var(--fh);font-weight:700;font-size:16px}.brand span{font-size:12px;color:#888;display:block}
-        .card{position:relative;border-radius:20px;padding:22px;color:#fff;overflow:hidden;background:linear-gradient(135deg,#0A0A0A 0%,#15803D 100%);box-shadow:0 14px 40px rgba(21,128,61,.28)}
-        .card::after{content:"";position:absolute;right:-50px;top:-50px;width:180px;height:180px;background:radial-gradient(circle,rgba(22,163,74,.6),transparent 70%)}
+        .card{position:relative;border-radius:20px;padding:22px;color:#fff;overflow:hidden;background:linear-gradient(135deg,#0A0A0A 0%,#239406 100%);box-shadow:0 14px 40px rgba(35,148,6,.28)}
+        .card::after{content:"";position:absolute;right:-50px;top:-50px;width:180px;height:180px;background:radial-gradient(circle,rgba(44,184,9,.6),transparent 70%)}
         .card .nfc{position:absolute;top:20px;right:20px;font-size:20px;opacity:.85;transform:rotate(90deg)}
         .chip{width:38px;height:28px;border-radius:6px;background:linear-gradient(135deg,#e9c46a,#d4a017);position:absolute;top:54px;left:22px;opacity:.9}
         .lbl{font:600 11px var(--fh);letter-spacing:.14em;text-transform:uppercase;opacity:.7}

--- a/Modules/Tagtoa/resources/views/menu/form.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/form.blade.php
@@ -44,7 +44,7 @@
         <div class="h-row"><h2>{{ __('Apparence') }}</h2></div>
         <div class="row">
             <div><label class="lbl">{{ __('Thème') }}</label><select class="sel" name="theme">@foreach(['light'=>'Clair','dark'=>'Sombre'] as $k=>$v)<option value="{{ $k }}" @selected(old('theme',$menu->theme ?: 'light')===$k)>{{ __($v) }}</option>@endforeach</select></div>
-            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$menu->accent_color ?: '#16A34A') }}" style="height:48px;padding:6px"></div>
+            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$menu->accent_color ?: '#2cb809') }}" style="height:48px;padding:6px"></div>
         </div>
         <label class="switch"><input type="hidden" name="show_prices" value="0"><input type="checkbox" name="show_prices" value="1" @checked(old('show_prices',$menu->show_prices ?? true))> {{ __('Afficher les prix') }}</label>
         <label class="switch"><input type="hidden" name="is_active" value="0"><input type="checkbox" name="is_active" value="1" @checked(old('is_active',$menu->is_active ?? true))> {{ __('Menu actif (visible au public)') }}</label>

--- a/Modules/Tagtoa/resources/views/menu/show.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/show.blade.php
@@ -1,7 +1,7 @@
 {{-- TAGTOA MENU — page publique (NFC/QR). Variables : $menu, $categories --}}
 @php
     $dark = $menu->theme === 'dark';
-    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $menu->accent_color) ? $menu->accent_color : '#16A34A';
+    $accent = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $menu->accent_color) ? $menu->accent_color : '#2cb809';
     $bg   = $dark ? '#0A0A0A' : '#F5F5F3';
     $fg   = $dark ? '#FFFFFF' : '#0A0A0A';
     $surf = $dark ? '#161616' : '#FFFFFF';

--- a/Modules/Tagtoa/resources/views/partials/lang.blade.php
+++ b/Modules/Tagtoa/resources/views/partials/lang.blade.php
@@ -24,9 +24,9 @@
     .tg-lang[open]>summary .ch{transform:rotate(180deg)}
     .tg-lang-menu{position:absolute;right:0;top:calc(100% + 6px);min-width:170px;background:#fff;color:#0A0A0A;border:1px solid rgba(0,0,0,.1);border-radius:12px;box-shadow:0 12px 34px rgba(0,0,0,.16);padding:6px;z-index:200}
     .tg-lang-menu a{display:flex;align-items:center;gap:9px;padding:9px 11px;border-radius:9px;font:600 14px 'Space Grotesk',sans-serif;color:#0A0A0A;white-space:nowrap}
-    .tg-lang-menu a:hover{background:rgba(22,163,74,.08)}
-    .tg-lang-menu a.on{color:#16A34A}
-    .tg-lang-menu a .ck{margin-left:auto;font-size:11px;color:#16A34A}
+    .tg-lang-menu a:hover{background:rgba(44,184,9,.08)}
+    .tg-lang-menu a.on{color:#2cb809}
+    .tg-lang-menu a .ck{margin-left:auto;font-size:11px;color:#2cb809}
     .tg-lang-menu .fl,.tg-lang>summary .fl{font-size:15px;line-height:1}
     @media(max-width:520px){.tg-lang>summary .lb{display:none}}
 </style>

--- a/Modules/Tagtoa/resources/views/partials/reviews.blade.php
+++ b/Modules/Tagtoa/resources/views/partials/reviews.blade.php
@@ -1,7 +1,7 @@
 {{-- TAGTOA REVIEWS — section publique réutilisable.
      Variables attendues : $subjectType, $subjectId, $subjectAlias (nullable),
      $reviews (collection d'avis approuvés), $summary (count/average/distribution).
-     Utilise les variables CSS de la page hôte avec repli (var(--acc,#16A34A)…). --}}
+     Utilise les variables CSS de la page hôte avec repli (var(--acc,#2cb809)…). --}}
 @php
     $rvAvg = $summary['average'] ?? 0;
     $rvCount = $summary['count'] ?? 0;
@@ -9,25 +9,25 @@
 <section class="sec tg-reviews" id="reviews" style="padding:22px 16px 4px">
     <style>
         .tg-reviews .rv-head{display:flex;align-items:center;gap:14px;margin-bottom:14px}
-        .tg-reviews .rv-avg{font:700 30px var(--fh,sans-serif);color:var(--acc,#16A34A);line-height:1}
-        .tg-reviews .rv-stars i{color:var(--acc,#16A34A);font-size:14px}
+        .tg-reviews .rv-avg{font:700 30px var(--fh,sans-serif);color:var(--acc,#2cb809);line-height:1}
+        .tg-reviews .rv-stars i{color:var(--acc,#2cb809);font-size:14px}
         .tg-reviews .rv-stars i.off{color:var(--bd,#ddd)}
         .tg-reviews .rv-count{color:var(--mut,#888);font-size:13px}
         .tg-reviews .rv-item{background:var(--surf,#fff);border:1.5px solid var(--bd,rgba(0,0,0,.08));border-radius:14px;padding:14px;margin-bottom:10px}
         .tg-reviews .rv-item .nm{font:700 14.5px var(--fh,sans-serif)}
         .tg-reviews .rv-item .cm{color:var(--mut,#888);font-size:14px;margin-top:6px;white-space:pre-line}
-        .tg-reviews .rv-reply{margin-top:10px;padding:10px 12px;border-left:3px solid var(--acc,#16A34A);background:rgba(0,0,0,.03);border-radius:8px;font-size:13.5px}
+        .tg-reviews .rv-reply{margin-top:10px;padding:10px 12px;border-left:3px solid var(--acc,#2cb809);background:rgba(0,0,0,.03);border-radius:8px;font-size:13.5px}
         .tg-reviews .rv-reply b{font-family:var(--fh,sans-serif)}
         .tg-reviews .rate{display:flex;flex-direction:row-reverse;justify-content:flex-end;gap:4px;margin:6px 0 10px}
         .tg-reviews .rate input{display:none}
         .tg-reviews .rate label{font-size:30px;color:var(--bd,#ddd);cursor:pointer;transition:color .12s}
         .tg-reviews .rate label:hover,.tg-reviews .rate label:hover ~ label,
-        .tg-reviews .rate input:checked ~ label{color:var(--acc,#16A34A)}
+        .tg-reviews .rate input:checked ~ label{color:var(--acc,#2cb809)}
         .tg-reviews .rv-cin{width:100%;padding:12px 14px;border:1.5px solid var(--bd,rgba(0,0,0,.08));border-radius:12px;font:15px var(--fb,sans-serif);background:var(--surf,#fff);color:var(--fg,#0a0a0a);margin-bottom:10px}
-        .tg-reviews .rv-cin:focus{outline:0;border-color:var(--acc,#16A34A)}
-        .tg-reviews .rv-btn{width:100%;border:0;background:var(--acc,#16A34A);color:#fff;border-radius:13px;padding:14px;font:700 15px var(--fh,sans-serif);cursor:pointer}
+        .tg-reviews .rv-cin:focus{outline:0;border-color:var(--acc,#2cb809)}
+        .tg-reviews .rv-btn{width:100%;border:0;background:var(--acc,#2cb809);color:#fff;border-radius:13px;padding:14px;font:700 15px var(--fh,sans-serif);cursor:pointer}
         .tg-reviews .rv-btn:disabled{opacity:.6}
-        .tg-reviews .rv-thanks{display:none;background:var(--surf,#fff);border:1.5px solid var(--acc,#16A34A);border-radius:13px;padding:16px;text-align:center;color:var(--fg,#0a0a0a)}
+        .tg-reviews .rv-thanks{display:none;background:var(--surf,#fff);border:1.5px solid var(--acc,#2cb809);border-radius:13px;padding:16px;text-align:center;color:var(--fg,#0a0a0a)}
     </style>
 
     <h2 style="font:700 18px var(--fh,sans-serif);margin-bottom:14px">{{ __('Avis clients') }}</h2>
@@ -73,7 +73,7 @@
         <textarea class="rv-cin" id="rvComment" rows="3" maxlength="1000" placeholder="{{ __('Votre commentaire (optionnel)') }}"></textarea>
         <button type="submit" class="rv-btn" id="rvBtn">{{ __('Envoyer mon avis') }}</button>
     </form>
-    <div class="rv-thanks" id="rvThanks"><i class="fa-solid fa-circle-check" style="color:var(--acc,#16A34A)"></i> {{ __('Merci ! Votre avis sera publié après validation.') }}</div>
+    <div class="rv-thanks" id="rvThanks"><i class="fa-solid fa-circle-check" style="color:var(--acc,#2cb809)"></i> {{ __('Merci ! Votre avis sera publié après validation.') }}</div>
 </section>
 
 <script>

--- a/Modules/Tagtoa/resources/views/pay/show.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/show.blade.php
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#16A34A;--blue-deep:#15803D;--blue-pale:rgba(22,163,74,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--bg:#F5F5F3;--sf:#fff;--blue:#2cb809;--blue-deep:#239406;--blue-pale:rgba(44,184,9,.08);--green:#1D9E75;--red:#E0473E;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);line-height:1.5}
         .wrap{max-width:480px;margin:0 auto;min-height:100vh;padding-bottom:90px}
@@ -22,7 +22,7 @@
         .sec{font:600 13px var(--fh);letter-spacing:.05em;text-transform:uppercase;color:#777;margin:22px 22px 12px}
         .methods{padding:0 16px;display:flex;flex-direction:column;gap:10px}
         .m{background:var(--sf);border:1px solid var(--bd);border-radius:16px;padding:15px 16px;display:flex;align-items:center;gap:14px;cursor:pointer;width:100%;text-align:left;font:inherit;transition:all .25s cubic-bezier(.4,0,.2,1)}
-        .m:active{transform:scale(.985)}.m.on{border-color:var(--blue);background:var(--blue-pale);box-shadow:0 4px 18px rgba(22,163,74,.12)}
+        .m:active{transform:scale(.985)}.m.on{border-color:var(--blue);background:var(--blue-pale);box-shadow:0 4px 18px rgba(44,184,9,.12)}
         .m-ic{width:46px;height:46px;border-radius:12px;background:var(--blk);color:#fff;display:flex;align-items:center;justify-content:center;font-size:19px;flex-shrink:0}
         .m.on .m-ic{background:var(--blue)}
         .m-tx{flex:1;min-width:0}.m-tx b{display:block;font:600 15px var(--fh)}.m-tx span{font-size:12.5px;color:#888;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;display:block}

--- a/Modules/Tagtoa/resources/views/pos/products.blade.php
+++ b/Modules/Tagtoa/resources/views/pos/products.blade.php
@@ -23,7 +23,7 @@
         <input name="products[IDX][name]" class="inp" placeholder="{{ __('Nom') }}" style="max-width:170px">
         <input name="products[IDX][price]" type="number" step="0.01" class="inp" placeholder="{{ __('Prix') }}" style="max-width:100px">
         <input name="products[IDX][stock]" type="number" class="inp" placeholder="{{ __('Stock') }}" style="max-width:90px">
-        <input name="products[IDX][color]" type="color" value="#16A34A" style="width:42px;height:42px;border:1px solid var(--bd);border-radius:8px">
+        <input name="products[IDX][color]" type="color" value="#2cb809" style="width:42px;height:42px;border:1px solid var(--bd);border-radius:8px">
         <label class="switch" style="flex:0"><input type="checkbox" name="products[IDX][is_active]" value="1" checked></label>
         <button type="button" class="btn btn-o btn-sm" style="flex:0;color:var(--red)" onclick="this.closest('.prow').remove()"><i class="fa-solid fa-trash"></i></button>
     </div>
@@ -32,7 +32,7 @@
 <script>
 var pIdx=0;
 function addP(d){var h=document.getElementById('ptpl').innerHTML.replace(/IDX/g,pIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('plist').appendChild(r);
-    if(d){r.querySelector('[name$="[emoji]"]').value=d.emoji||'';r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[stock]"]').value=d.stock==null?'':d.stock;r.querySelector('[name$="[color]"]').value=d.color||'#16A34A';r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='products['+pIdx+'][id]';i.value=d.id;r.appendChild(i);}
+    if(d){r.querySelector('[name$="[emoji]"]').value=d.emoji||'';r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[stock]"]').value=d.stock==null?'':d.stock;r.querySelector('[name$="[color]"]').value=d.color||'#2cb809';r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='products['+pIdx+'][id]';i.value=d.id;r.appendChild(i);}
     pIdx++;}
 var ex=@json($terminal->products->map(fn($p)=>['id'=>$p->id,'emoji'=>$p->emoji,'name'=>$p->name,'price'=>$p->price,'stock'=>$p->stock,'color'=>$p->color,'is_active'=>$p->is_active]));
 if(ex.length){ex.forEach(addP);}else{addP();}

--- a/Modules/Tagtoa/resources/views/pos/register.blade.php
+++ b/Modules/Tagtoa/resources/views/pos/register.blade.php
@@ -7,7 +7,7 @@
     <title>{{ $terminal->name }} — TAGTOA POS</title>
     {{-- PWA : installable + hors ligne --}}
     <link rel="manifest" href="{{ route('tagtoa.pos.manifest',$terminal->id) }}">
-    <meta name="theme-color" content="#16A34A">
+    <meta name="theme-color" content="#2cb809">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black">
@@ -15,7 +15,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--blk:#0A0A0A;--blue:#16A34A;--green:#1D9E75;--red:#E0473E;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--blk:#0A0A0A;--blue:#2cb809;--green:#1D9E75;--red:#E0473E;--bg:#F5F5F3;--bd:rgba(0,0,0,.08);--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent}
         body{font-family:var(--fb);background:var(--bg);color:var(--blk);height:100vh;overflow:hidden}
         .app{display:grid;grid-template-columns:1fr 320px;height:100vh}
@@ -29,7 +29,7 @@
         .pay{display:block;width:100%;background:var(--green);color:#fff;border:0;border-radius:14px;padding:15px;font:600 16px var(--fh);cursor:pointer;margin-top:8px}.pay:disabled{background:#bcd;cursor:not-allowed}
         .modal{position:fixed;inset:0;background:rgba(0,0,0,.5);display:none;align-items:flex-end;z-index:50}.modal.show{display:flex}
         .sheet{background:#fff;width:100%;max-width:480px;margin:0 auto;border-radius:22px 22px 0 0;padding:18px;max-height:88vh;overflow-y:auto}.sheet h3{font-family:var(--fh);margin-bottom:6px}
-        .methods{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin:12px 0}.m{border:1.5px solid var(--bd);border-radius:12px;padding:10px 6px;text-align:center;cursor:pointer;font-size:12px;background:#fff}.m.on{border-color:var(--blue);background:rgba(22,163,74,.08);color:var(--blue);font-weight:700}
+        .methods{display:grid;grid-template-columns:repeat(3,1fr);gap:8px;margin:12px 0}.m{border:1.5px solid var(--bd);border-radius:12px;padding:10px 6px;text-align:center;cursor:pointer;font-size:12px;background:#fff}.m.on{border-color:var(--blue);background:rgba(44,184,9,.08);color:var(--blue);font-weight:700}
         .split{font-size:13px;color:#666;margin:8px 0}.split input{width:90px;padding:6px;border:1px solid var(--bd);border-radius:8px;text-align:right}
         .field{width:100%;padding:11px;border:1.5px solid var(--bd);border-radius:10px;margin:6px 0;font:15px var(--fb)}
         .done{position:fixed;inset:0;background:var(--green);color:#fff;display:none;flex-direction:column;align-items:center;justify-content:center;z-index:60;text-align:center;padding:20px}.done.show{display:flex}.done i{font-size:64px}.done h2{font:700 24px var(--fh);margin:12px 0 4px}.done .acts{display:flex;gap:10px;margin-top:20px}.done .acts a,.done .acts button{background:rgba(255,255,255,.2);color:#fff;border:0;border-radius:12px;padding:12px 18px;font:600 14px var(--fh);text-decoration:none;cursor:pointer}

--- a/Modules/Tagtoa/resources/views/qr/poster.blade.php
+++ b/Modules/Tagtoa/resources/views/qr/poster.blade.php
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@600;700&family=Nunito:wght@600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <style>
-        :root{--green:#16A34A;--ink:#0A0A0A;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        :root{--green:#2cb809;--ink:#0A0A0A;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
         *{box-sizing:border-box;margin:0;padding:0}
         body{font-family:var(--fb);background:#eef0ee;color:var(--ink);display:flex;flex-direction:column;align-items:center;padding:24px}
         .bar{display:flex;gap:10px;margin-bottom:18px}

--- a/Modules/Tagtoa/resources/views/site/form.blade.php
+++ b/Modules/Tagtoa/resources/views/site/form.blade.php
@@ -23,7 +23,7 @@
         </div>
         <div class="row">
             <div><label class="lbl">{{ __('Thème') }}</label><select class="sel" name="theme">@foreach(['light'=>'Clair','dark'=>'Sombre'] as $k=>$v)<option value="{{ $k }}" @selected(old('theme',$site->theme ?: 'light')===$k)>{{ __($v) }}</option>@endforeach</select></div>
-            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$site->accent_color ?: '#16A34A') }}" style="height:48px;padding:6px"></div>
+            <div><label class="lbl">{{ __('Couleur d\'accent') }}</label><input class="inp" type="color" name="accent_color" value="{{ old('accent_color',$site->accent_color ?: '#2cb809') }}" style="height:48px;padding:6px"></div>
         </div>
     </div>
 

--- a/Modules/Tagtoa/resources/views/site/show.blade.php
+++ b/Modules/Tagtoa/resources/views/site/show.blade.php
@@ -1,7 +1,7 @@
 {{-- TAGTOA SITE — site web public (vitrine). Variables : $site. Sans emoji. --}}
 @php
     $dark = $site->theme === 'dark';
-    $acc = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $site->accent_color) ? $site->accent_color : '#16A34A';
+    $acc = preg_match('/^#[0-9A-Fa-f]{3,8}$/', (string) $site->accent_color) ? $site->accent_color : '#2cb809';
     $bg   = $dark ? '#0A0F0B' : '#FFFFFF';
     $bg2  = $dark ? '#0E1A12' : '#F5F7F5';
     $fg   = $dark ? '#FFFFFF' : '#0A0A0A';


### PR DESCRIPTION
## Résumé

Applique la charte demandée (couleur `#2cb809` + titres **Anton**) au-delà de la seule page d'accueil.

## Changements

- **Couleur de marque unifiée** : remplacement global de l'ancien vert `#16A34A` (hex + rgb `22,163,74` + `#15803D`) par **`#2cb809`** — 65 remplacements sur 32 fichiers (vues, contrôleurs, modèles, migrations, config).
- **Titres en Anton** :
  - **Dashboard** (layout partagé) → toutes les pages back-office (menu, booking, event, wallet, reviews, audit, analytics, plan, billing…).
  - Reçu wallet, badges QR, terminal vendeur.
  - (Page d'accueil : déjà en Anton.)
- Défaut d'accent des pages **marchandes** = `#2cb809` (reste personnalisable par marchand).

## Périmètre
Les pages publiques marchandes gardent leur thème personnalisable ; seul le **défaut** passe à `#2cb809`. Les surfaces **de marque TAGTOA** (dashboard, landing, reçu, badges, terminal) sont en noir & blanc + accents `#2cb809` + titres Anton.

## Tests
- `php -l` OK · aucun `#16A34A` restant · JSON i18n valides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_