### PR TITLE
TAGTOA EVENT: billet lié au tag démo (check-in NFC testable en démo)

### DIFF
--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -106,6 +106,19 @@ class TagtoaDemoSeeder extends Seeder
                 $demoTag->walletAccount, 1000, ['idempotency_key' => 'demo-topup-concert', 'payment_ref' => 'DEMO']
             );
         }
+        // Lie un billet au tag démo pour que le check-in NFC fonctionne dès la démo.
+        if (! $demoTag->ticket_id) {
+            $stdType = $event->ticketTypes()->where('name', 'Standard')->first();
+            $demoTicket = \Modules\Tagtoa\App\Models\Event\Ticket::firstOrCreate(
+                ['event_id' => $event->id, 'code' => 'TDEMO0000001'],
+                ['ticket_type_id' => $stdType?->id, 'holder_name' => 'Client Demo',
+                 'holder_phone' => '+509 3000 0000', 'status' => \Modules\Tagtoa\App\Models\Event\Ticket::STATUS_VALID]
+            );
+            $demoTag->update(['ticket_id' => $demoTicket->id]);
+            if ($demoTag->walletAccount && ! $demoTag->walletAccount->ticket_id) {
+                $demoTag->walletAccount->update(['ticket_id' => $demoTicket->id]);
+            }
+        }
 
         // 5) MENU — menu digital démo (lounge/restaurant) + catégories + produits
         $menu = Menu::firstOrCreate(


### PR DESCRIPTION
## Résumé

Rend la démo **testable de bout en bout au check-in NFC** : le tag `TAGTOA-DEMO-TAG` avait un wallet (1000 G) mais **pas de billet** — on lui associe un billet (`TDEMO0000001`), donc taper/saisir ce UID au scanner déclenche une **entrée valide**. Idempotent.

## Test après déploiement
- Scanner : `/tagtoa/event/{id}/scanner` → « Check-in NFC (tap) » → UID `TAGTOA-DEMO-TAG` → **Bienvenue** + nom.
- Terminal : `/tagtoa/event/{id}/wallet/terminal` → Bar Demo + `TAGTOA-DEMO-TAG` → solde 1000 G → encaisser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_