### PR TITLE
TAGTOA: hotfix — restaure route('home') (page login Biztap cassée)

### DIFF
--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -30,7 +30,10 @@ use Modules\Tagtoa\App\Http\Controllers\Site\PublicController as SitePublic;
 
 // ---------- PUBLIC (NFC / QR, pas d'auth) ----------
 // Page d'accueil TAGTOA à la racine (remplace l'accueil par défaut).
-Route::get('/', [LandingController::class, 'index'])->name('tagtoa.landing');
+// La landing TAGTOA remplace l'accueil Biztap sur `/`. On CONSERVE le nom `home`
+// (un seul route sur `/`) pour ne pas casser les `route('home')` du back-office
+// Biztap (ex. page de login qui plantait avec « Route [home] not defined »).
+Route::get('/', [LandingController::class, 'index'])->name('home');
 Route::get('/pay/{alias}', [PayPublic::class, 'show'])->name('tagtoa.pay.show');
 Route::post('/pay/{alias}/submit-proof', [PayPublic::class, 'submitProof'])->name('tagtoa.pay.submit-proof');
 Route::get('/pay/{alias}/checkout/{method}', [PayPublic::class, 'checkout'])->name('tagtoa.pay.checkout');


### PR DESCRIPTION
## Problème

La page de login Biztap plantait avec **« Route [home] not defined »** (`auth/login.blade.php:24` utilise `route('home')`).

**Cause** : la landing TAGTOA (`Route::get('/')->name('tagtoa.landing')`) partage l'URI `/` avec la route d'accueil de Biztap et, au rebuild du `nameList` de la RouteCollection, écrasait/supprimait le nom `home`.

## Correctif

Nommer l'unique route `/` de la landing **`home`** (au lieu de `tagtoa.landing`, qui n'était référencé nulle part). `route('home')` résout de nouveau — vers la landing, qui **est** l'accueil.

## Impact
- Page de login de nouveau accessible.
- Landing inchangée (toujours sur `/`).
- Aucune référence à `tagtoa.landing` dans le module (vérifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_