### PR TITLE
TAGTOA : corrige le crash Blade des pages create/edit (@json + fonction fléchée)

### DIFF
--- a/Modules/Tagtoa/resources/views/booking/form.blade.php
+++ b/Modules/Tagtoa/resources/views/booking/form.blade.php
@@ -94,9 +94,15 @@ function addSvc(d){
     return row;
 }
 
-var existing = @json($page->relationLoaded('services') ? $page->services->map(fn($s)=>[
-    'id'=>$s->id,'name'=>$s->name,'duration_min'=>$s->duration_min,'price'=>$s->price,'description'=>$s->description,'is_active'=>$s->is_active,
-]) : []);
+@php
+    $svcData = $page->relationLoaded('services')
+        ? $page->services->map(fn ($s) => [
+            'id' => $s->id, 'name' => $s->name, 'duration_min' => $s->duration_min,
+            'price' => $s->price, 'description' => $s->description, 'is_active' => $s->is_active,
+        ])->values()
+        : [];
+@endphp
+var existing = @json($svcData);
 
 if (existing.length){ existing.forEach(addSvc); }
 else { addSvc(); }

--- a/Modules/Tagtoa/resources/views/event/form.blade.php
+++ b/Modules/Tagtoa/resources/views/event/form.blade.php
@@ -56,7 +56,12 @@ var ttIdx=0;
 function addTT(d){var h=document.getElementById('tttpl').innerHTML.replace(/IDX/g,ttIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('ttlist').appendChild(r);
     if(d){r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[quantity]"]').value=d.quantity==null?'':d.quantity;r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='ticket_types['+ttIdx+'][id]';i.value=d.id;r.appendChild(i);}
     ttIdx++;}
-var ex=@json($event->relationLoaded('ticketTypes') ? $event->ticketTypes->map(fn($t)=>['id'=>$t->id,'name'=>$t->name,'price'=>$t->price,'quantity'=>$t->quantity,'is_active'=>$t->is_active]) : []);
+@php
+    $ttData = $event->relationLoaded('ticketTypes')
+        ? $event->ticketTypes->map(fn ($t) => ['id' => $t->id, 'name' => $t->name, 'price' => $t->price, 'quantity' => $t->quantity, 'is_active' => $t->is_active])->values()
+        : [];
+@endphp
+var ex=@json($ttData);
 if(ex.length){ex.forEach(addTT);}else{addTT();}
 </script>
 @endpush

--- a/Modules/Tagtoa/resources/views/links/form.blade.php
+++ b/Modules/Tagtoa/resources/views/links/form.blade.php
@@ -45,7 +45,12 @@ var lIdx=0;
 function addL(d){var h=document.getElementById('ltpl').innerHTML.replace(/IDX/g,lIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('llist').appendChild(r);
     if(d){r.querySelector('[name$="[label]"]').value=d.label||'';r.querySelector('[name$="[url]"]').value=d.url||'';r.querySelector('[name$="[is_featured]"]').checked=!!d.is_featured;var i=document.createElement('input');i.type='hidden';i.name='links['+lIdx+'][id]';i.value=d.id;r.appendChild(i);}
     lIdx++;}
-var ex=@json($page->relationLoaded('links') ? $page->links->map(fn($l)=>['id'=>$l->id,'label'=>$l->label,'url'=>$l->url,'is_featured'=>$l->is_featured]) : []);
+@php
+    $linkData = $page->relationLoaded('links')
+        ? $page->links->map(fn ($l) => ['id' => $l->id, 'label' => $l->label, 'url' => $l->url, 'is_featured' => $l->is_featured])->values()
+        : [];
+@endphp
+var ex=@json($linkData);
 if(ex.length){ex.forEach(addL);}else{addL();}
 </script>
 @endpush

--- a/Modules/Tagtoa/resources/views/menu/form.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/form.blade.php
@@ -133,10 +133,15 @@ function addCat(d){
     return block;
 }
 
-var existing = @json($menu->relationLoaded('categories') ? $menu->categories->map(fn($c)=>[
-    'id'=>$c->id,'name'=>$c->name,'icon'=>$c->icon,
-    'items'=>$c->items->map(fn($i)=>['id'=>$i->id,'name'=>$i->name,'emoji'=>$i->emoji,'price'=>$i->price,'description'=>$i->description,'badge'=>$i->badge,'is_available'=>$i->is_available,'is_featured'=>$i->is_featured,'stock'=>$i->stock]),
-]) : []);
+@php
+    $catData = $menu->relationLoaded('categories')
+        ? $menu->categories->map(fn ($c) => [
+            'id' => $c->id, 'name' => $c->name, 'icon' => $c->icon,
+            'items' => $c->items->map(fn ($i) => ['id' => $i->id, 'name' => $i->name, 'emoji' => $i->emoji, 'price' => $i->price, 'description' => $i->description, 'badge' => $i->badge, 'is_available' => $i->is_available, 'is_featured' => $i->is_featured, 'stock' => $i->stock])->values(),
+        ])->values()
+        : [];
+@endphp
+var existing = @json($catData);
 
 if (existing.length){ existing.forEach(addCat); }
 else { var c = addCat(); addItem(c); }

--- a/Modules/Tagtoa/resources/views/pay/dashboard/form.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/dashboard/form.blade.php
@@ -54,7 +54,12 @@ var mIdx=0;
 function addM(d){var h=document.getElementById('mtpl').innerHTML.replace(/IDX/g,mIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('mlist').appendChild(r);
     if(d){r.querySelector('[name$="[type]"]').value=d.type;r.querySelector('[name$="[label]"]').value=d.label||'';r.querySelector('[name$="[account_holder]"]').value=d.account_holder||'';r.querySelector('[name$="[institution]"]').value=d.institution||'';r.querySelector('[name$="[account_number]"]').value=d.account_number||'';r.querySelector('[name$="[instructions]"]').value=d.instructions||'';r.querySelector('[name$="[requires_proof]"]').checked=!!d.requires_proof;r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='methods['+mIdx+'][id]';i.value=d.id;r.appendChild(i);}
     mIdx++;}
-var ex=@json($page->relationLoaded('methods') ? $page->methods->map(fn($m)=>['id'=>$m->id,'type'=>$m->type,'label'=>$m->label,'account_holder'=>$m->account_holder,'institution'=>$m->institution,'account_number'=>$m->account_number,'instructions'=>$m->instructions,'requires_proof'=>$m->requires_proof,'is_active'=>$m->is_active]) : []);
+@php
+    $methodData = $page->relationLoaded('methods')
+        ? $page->methods->map(fn ($m) => ['id' => $m->id, 'type' => $m->type, 'label' => $m->label, 'account_holder' => $m->account_holder, 'institution' => $m->institution, 'account_number' => $m->account_number, 'instructions' => $m->instructions, 'requires_proof' => $m->requires_proof, 'is_active' => $m->is_active])->values()
+        : [];
+@endphp
+var ex=@json($methodData);
 if(ex.length){ex.forEach(addM);}else{addM();}
 </script>
 @endpush

--- a/Modules/Tagtoa/resources/views/pos/products.blade.php
+++ b/Modules/Tagtoa/resources/views/pos/products.blade.php
@@ -34,7 +34,10 @@ var pIdx=0;
 function addP(d){var h=document.getElementById('ptpl').innerHTML.replace(/IDX/g,pIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('plist').appendChild(r);
     if(d){r.querySelector('[name$="[emoji]"]').value=d.emoji||'';r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[stock]"]').value=d.stock==null?'':d.stock;r.querySelector('[name$="[color]"]').value=d.color||'#2cb809';r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='products['+pIdx+'][id]';i.value=d.id;r.appendChild(i);}
     pIdx++;}
-var ex=@json($terminal->products->map(fn($p)=>['id'=>$p->id,'emoji'=>$p->emoji,'name'=>$p->name,'price'=>$p->price,'stock'=>$p->stock,'color'=>$p->color,'is_active'=>$p->is_active]));
+@php
+    $productData = $terminal->products->map(fn ($p) => ['id' => $p->id, 'emoji' => $p->emoji, 'name' => $p->name, 'price' => $p->price, 'stock' => $p->stock, 'color' => $p->color, 'is_active' => $p->is_active])->values();
+@endphp
+var ex=@json($productData);
 if(ex.length){ex.forEach(addP);}else{addP();}
 </script>
 @endpush


### PR DESCRIPTION
## Problème

`/tagtoa/event/create` (et **toutes** les pages create/edit des modules) plantaient avec :

```
Unclosed '[' does not match ')'
Modules/Tagtoa/resources/views/event/form.blade.php:59
```

C'est une **erreur de compilation Blade**, pas un bug d'exécution. L'analyseur d'arguments de la directive `@json(...)` casse quand l'expression contient une **fonction fléchée avec syntaxe tableau court** — `fn($x) => ['k' => $x->k, ...]`. Les `[ ]` à l'intérieur trompent l'extraction des parenthèses de la directive et produisent du PHP invalide.

Comme les pages n'affichaient qu'une erreur, elles **paraissaient** « non développées » alors que le back-end (contrôleurs, services, actions) existe — c'est uniquement la vue qui crashait.

## Fichiers touchés (6 vues form)

- `event/form.blade.php`
- `menu/form.blade.php` (imbriqué : `fn` dans `fn`)
- `pay/dashboard/form.blade.php`
- `links/form.blade.php`
- `booking/form.blade.php`
- `pos/products.blade.php`

## Correctif

Sortir l'expression `->map(fn ...)` dans un bloc `@php` et passer une **variable simple** à `@json($var)` — qui compile toujours, quelle que soit la complexité de l'expression.

```blade
@php
    $ttData = $event->relationLoaded('ticketTypes')
        ? $event->ticketTypes->map(fn ($t) => ['id' => $t->id, /* … */])->values()
        : [];
@endphp
var ex=@json($ttData);
```

## Vérification

Reproduit et vérifié avec le **vrai compilateur Blade** (`illuminate/view` ^10) :

| Motif | Résultat |
|---|---|
| Ancien `@json(...fn...[...])` | ❌ `Unclosed '[' does not match ')'` (reproduit le crash) |
| Ancien imbriqué (menu) | ❌ même erreur |
| Nouveau `@php` + `@json($var)` | ✅ `No syntax errors detected` |

## Pourquoi la CI ne l'a pas vu

La suite CI ne lance que les tests **Unit** (logique pure) — elle ne **rend jamais** les vues Blade, donc l'erreur de compilation passait inaperçue.

## Base de données

Aucune migration. Aucun changement de logique — uniquement la structure des vues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_