### PR TITLE
TAGTOA EVENT : socle staff/PIN + réconciliation offline + mode check-in (schéma + logique testée)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/composer.lock
+/.phpunit.cache/

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000082_create_tagtoa_ev_staff_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000082_create_tagtoa_ev_staff_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — comptes staff, scopés par événement (auth terrain par PIN).
+ *
+ * Multi-tenant : un staff appartient à UN événement précis (event_id), pas à
+ * toute la plateforme. Rôles opérationnels : admin | vente | checkin
+ * (PAS de rôle POS/marchand dans ce module). Le PIN sert au terrain
+ * uniquement ; toute la config/finance reste derrière le vrai login tenant.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_ev_staff', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained('tagtoa_ev_events')->cascadeOnDelete();
+            $table->string('name');
+            $table->string('pin_hash');
+            $table->string('role')->default('checkin'); // admin | vente | checkin
+            $table->boolean('active')->default(true);
+            $table->unsignedBigInteger('created_by')->nullable(); // user id du propriétaire
+            $table->timestamp('last_login_at')->nullable();
+            $table->timestamps();
+            $table->index(['event_id', 'active']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_ev_staff');
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000083_add_staff_id_to_tagtoa_ev_checkins_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000083_add_staff_id_to_tagtoa_ev_checkins_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — traçabilité : quel staff a exécuté le check-in.
+ * Colonne nullable (règle "nouvelles colonnes nullable/default", jamais casser).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('tagtoa_ev_checkins', 'staff_id')) {
+            Schema::table('tagtoa_ev_checkins', function (Blueprint $table) {
+                $table->foreignId('staff_id')->nullable()->after('gate')
+                    ->constrained('tagtoa_ev_staff')->nullOnDelete();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('tagtoa_ev_checkins', 'staff_id')) {
+            Schema::table('tagtoa_ev_checkins', function (Blueprint $table) {
+                $table->dropConstrainedForeignId('staff_id');
+            });
+        }
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000084_create_tagtoa_ev_sync_conflicts_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000084_create_tagtoa_ev_sync_conflicts_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — journal des conflits de synchronisation offline.
+ *
+ * Cas principal : double check-in offline sur 2 appareils. À la sync, le
+ * premier gagne ; le second est enregistré ici comme conflit (résolu = false)
+ * pour que l'admin le voie. `payload` conserve les données brutes reçues.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_ev_sync_conflicts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('event_id')->constrained('tagtoa_ev_events')->cascadeOnDelete();
+            $table->string('kind')->default('duplicate_checkin'); // duplicate_checkin | ...
+            $table->string('client_uuid', 64)->nullable()->index();
+            $table->foreignId('ticket_id')->nullable()->constrained('tagtoa_ev_tickets')->nullOnDelete();
+            $table->foreignId('staff_id')->nullable()->constrained('tagtoa_ev_staff')->nullOnDelete();
+            $table->json('payload')->nullable();
+            $table->boolean('resolved')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_ev_sync_conflicts');
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000085_add_checkin_mode_to_tagtoa_ev_events_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000085_add_checkin_mode_to_tagtoa_ev_events_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — mode de check-in configurable par événement (billetterie hybride).
+ *   qr   = e-billet QR direct (aucune carte physique requise)
+ *   nfc  = carte NFC physique (retrait au stand le jour J)
+ *   both = les deux acceptés au check-in (défaut recommandé côté produit : qr)
+ * Colonne nullable/default, conforme à la règle "jamais casser l'existant".
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('tagtoa_ev_events', 'checkin_mode')) {
+            Schema::table('tagtoa_ev_events', function (Blueprint $table) {
+                $table->string('checkin_mode')->default('qr')->after('notify_email'); // qr | nfc | both
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('tagtoa_ev_events', 'checkin_mode')) {
+            Schema::table('tagtoa_ev_events', function (Blueprint $table) {
+                $table->dropColumn('checkin_mode');
+            });
+        }
+    }
+};

--- a/Modules/Tagtoa/app/Models/Event/Staff.php
+++ b/Modules/Tagtoa/app/Models/Event/Staff.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Event;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * TAGTOA EVENT — compte staff terrain, scopé par événement.
+ * Auth par PIN (voir StaffPinService). `pin_hash` masqué à la sérialisation.
+ */
+class Staff extends Model
+{
+    protected $table = 'tagtoa_ev_staff';
+
+    protected $fillable = ['event_id', 'name', 'pin_hash', 'role', 'active', 'created_by', 'last_login_at'];
+
+    protected $casts = ['active' => 'boolean', 'last_login_at' => 'datetime'];
+
+    protected $hidden = ['pin_hash'];
+
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class, 'event_id');
+    }
+}

--- a/Modules/Tagtoa/app/Models/Event/SyncConflict.php
+++ b/Modules/Tagtoa/app/Models/Event/SyncConflict.php
@@ -6,15 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
- * TAGTOA Event — enregistrement de check-in / check-out.
+ * TAGTOA EVENT — conflit de synchronisation offline (ex. double check-in).
  */
-class Checkin extends Model
+class SyncConflict extends Model
 {
-    protected $table = 'tagtoa_ev_checkins';
+    protected $table = 'tagtoa_ev_sync_conflicts';
 
-    protected $fillable = ['event_id', 'ticket_id', 'direction', 'method', 'gate', 'staff_id', 'client_uuid', 'scanned_at'];
+    protected $fillable = ['event_id', 'kind', 'client_uuid', 'ticket_id', 'staff_id', 'payload', 'resolved'];
 
-    protected $casts = ['scanned_at' => 'datetime'];
+    protected $casts = ['payload' => 'array', 'resolved' => 'boolean'];
 
     public function ticket(): BelongsTo
     {

--- a/Modules/Tagtoa/app/Services/Event/StaffPinService.php
+++ b/Modules/Tagtoa/app/Services/Event/StaffPinService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Modules\Tagtoa\App\Services\Event;
+
+/**
+ * TAGTOA EVENT — logique d'authentification staff par PIN (terrain).
+ *
+ * Toute la logique ici est PURE (testable sans Laravel) : normalisation,
+ * validation, hachage bcrypt natif (password_hash), et matrice
+ * rôle → écran. Le PIN est opérationnel seulement (vente carte / check-in) —
+ * jamais un accès financier ou de configuration.
+ */
+class StaffPinService
+{
+    /** Rôles autorisés dans ce module (pas de POS/marchand). */
+    public const ROLES = ['admin', 'vente', 'checkin'];
+
+    /** Écrans terrain adressables. */
+    public const SCREENS = ['staff', 'sales', 'pickup', 'checkin', 'dashboard', 'sync'];
+
+    /** Matrice rôle → écrans autorisés. 'admin' a accès à tout. */
+    protected const ACCESS = [
+        'vente'   => ['sales', 'pickup'],
+        'checkin' => ['checkin'],
+    ];
+
+    /** Garde seulement les chiffres du PIN saisi. PUR. */
+    public static function normalizePin(string $pin): string
+    {
+        return preg_replace('/\D+/', '', $pin) ?? '';
+    }
+
+    /** PIN valide = 4 à 6 chiffres (après normalisation). PUR. */
+    public static function isValidPinFormat(string $pin): bool
+    {
+        $len = strlen(self::normalizePin($pin));
+
+        return $len >= 4 && $len <= 6;
+    }
+
+    /** Rôle connu ? PUR. */
+    public static function isValidRole(string $role): bool
+    {
+        return in_array($role, self::ROLES, true);
+    }
+
+    /** Hachage bcrypt natif du PIN (sans façade Laravel). PUR. */
+    public static function hashPin(string $pin): string
+    {
+        return password_hash(self::normalizePin($pin), PASSWORD_BCRYPT);
+    }
+
+    /** Vérifie un PIN contre son hash. Hash vide => false. PUR. */
+    public static function verifyPin(string $pin, string $hash): bool
+    {
+        if ($hash === '') {
+            return false;
+        }
+
+        return password_verify(self::normalizePin($pin), $hash);
+    }
+
+    /** Le rôle a-t-il accès à cet écran ? admin = tout. PUR. */
+    public static function canAccess(string $role, string $screen): bool
+    {
+        if ($role === 'admin') {
+            return true;
+        }
+
+        return in_array($screen, self::ACCESS[$role] ?? [], true);
+    }
+}

--- a/Modules/Tagtoa/app/Services/Event/SyncReconciler.php
+++ b/Modules/Tagtoa/app/Services/Event/SyncReconciler.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Modules\Tagtoa\App\Services\Event;
+
+/**
+ * TAGTOA EVENT — logique pure de réconciliation offline → serveur.
+ *
+ * Idempotence via `client_uuid` (même convention que Menu/Booking/Review/POS).
+ * Rien ici ne dépend de Laravel : c'est la logique décidable en amont de
+ * l'écriture en base.
+ */
+class SyncReconciler
+{
+    /**
+     * Partitionne un lot d'enregistrements offline selon leur `client_uuid`.
+     *
+     * - un uuid déjà connu du serveur ($seenUuids) => doublon (à ignorer) ;
+     * - un uuid répété DANS le lot lui-même => seul le premier est "fresh" ;
+     * - un enregistrement sans uuid passe toujours (traité comme unique).
+     *
+     * @param  array  $records     liste d'items ayant (au besoin) une clé 'client_uuid'
+     * @param  array  $seenUuids   uuids déjà présents côté serveur
+     * @return array{fresh: array, duplicates: array}  PUR
+     */
+    public static function partition(array $records, array $seenUuids): array
+    {
+        $seen = array_fill_keys(array_values($seenUuids), true);
+        $fresh = [];
+        $duplicates = [];
+
+        foreach ($records as $r) {
+            $uuid = is_array($r) ? ($r['client_uuid'] ?? null) : null;
+
+            if ($uuid !== null && isset($seen[$uuid])) {
+                $duplicates[] = $r;
+
+                continue;
+            }
+
+            if ($uuid !== null) {
+                $seen[$uuid] = true; // déduplique aussi à l'intérieur du lot
+            }
+            $fresh[] = $r;
+        }
+
+        return ['fresh' => $fresh, 'duplicates' => $duplicates];
+    }
+
+    /**
+     * Double check-in : un billet déjà entré qu'on re-scanne en entrée = conflit
+     * (le premier gagne). Une sortie ('out') n'est pas un conflit d'entrée. PUR.
+     */
+    public static function isDuplicateEntry(bool $alreadyEntered, string $direction = 'in'): bool
+    {
+        return $alreadyEntered && $direction === 'in';
+    }
+}

--- a/Modules/Tagtoa/tests/Unit/StaffPinTest.php
+++ b/Modules/Tagtoa/tests/Unit/StaffPinTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Services\Event\StaffPinService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Auth staff par PIN (logique pure : normalisation, hachage, matrice d'accès).
+ */
+class StaffPinTest extends TestCase
+{
+    public function test_normalize_and_format(): void
+    {
+        $this->assertSame('1234', StaffPinService::normalizePin(' 12-34 '));
+        $this->assertTrue(StaffPinService::isValidPinFormat('1234'));
+        $this->assertTrue(StaffPinService::isValidPinFormat('123456'));
+        $this->assertFalse(StaffPinService::isValidPinFormat('123'));      // trop court
+        $this->assertFalse(StaffPinService::isValidPinFormat('1234567'));  // trop long
+        $this->assertFalse(StaffPinService::isValidPinFormat('ab'));       // pas de chiffres
+    }
+
+    public function test_hash_verify_roundtrip(): void
+    {
+        $hash = StaffPinService::hashPin('4821');
+
+        $this->assertNotSame('4821', $hash);
+        $this->assertTrue(StaffPinService::verifyPin('4821', $hash));
+        $this->assertTrue(StaffPinService::verifyPin('48-21', $hash)); // normalisé avant vérif
+        $this->assertFalse(StaffPinService::verifyPin('0000', $hash));
+        $this->assertFalse(StaffPinService::verifyPin('4821', ''));    // hash vide
+    }
+
+    public function test_role_screen_access_matrix(): void
+    {
+        // admin = accès total
+        $this->assertTrue(StaffPinService::canAccess('admin', 'staff'));
+        $this->assertTrue(StaffPinService::canAccess('admin', 'checkin'));
+        $this->assertTrue(StaffPinService::canAccess('admin', 'sales'));
+
+        // vente = vente de cartes + retrait NFC uniquement
+        $this->assertTrue(StaffPinService::canAccess('vente', 'sales'));
+        $this->assertTrue(StaffPinService::canAccess('vente', 'pickup'));
+        $this->assertFalse(StaffPinService::canAccess('vente', 'checkin'));
+        $this->assertFalse(StaffPinService::canAccess('vente', 'staff'));
+
+        // checkin = porte uniquement
+        $this->assertTrue(StaffPinService::canAccess('checkin', 'checkin'));
+        $this->assertFalse(StaffPinService::canAccess('checkin', 'sales'));
+        $this->assertFalse(StaffPinService::canAccess('checkin', 'dashboard'));
+    }
+
+    public function test_role_validation(): void
+    {
+        $this->assertTrue(StaffPinService::isValidRole('admin'));
+        $this->assertTrue(StaffPinService::isValidRole('vente'));
+        $this->assertTrue(StaffPinService::isValidRole('checkin'));
+        $this->assertFalse(StaffPinService::isValidRole('pos'));   // pas de POS ici
+        $this->assertFalse(StaffPinService::isValidRole(''));
+    }
+}

--- a/Modules/Tagtoa/tests/Unit/SyncReconcilerTest.php
+++ b/Modules/Tagtoa/tests/Unit/SyncReconcilerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Services\Event\SyncReconciler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Réconciliation offline → serveur (idempotence par client_uuid, conflits).
+ */
+class SyncReconcilerTest extends TestCase
+{
+    public function test_partition_filters_seen_uuids(): void
+    {
+        $records = [
+            ['client_uuid' => 'a', 'x' => 1],
+            ['client_uuid' => 'b', 'x' => 2],
+            ['client_uuid' => 'c', 'x' => 3],
+        ];
+
+        $res = SyncReconciler::partition($records, ['b']);
+
+        $this->assertCount(2, $res['fresh']);
+        $this->assertCount(1, $res['duplicates']);
+        $this->assertSame('b', $res['duplicates'][0]['client_uuid']);
+    }
+
+    public function test_partition_dedupes_within_batch(): void
+    {
+        $records = [
+            ['client_uuid' => 'a'],
+            ['client_uuid' => 'a'], // répété dans le même lot
+            ['client_uuid' => 'd'],
+        ];
+
+        $res = SyncReconciler::partition($records, []);
+
+        $this->assertCount(2, $res['fresh']);      // a (1×) + d
+        $this->assertCount(1, $res['duplicates']); // le 2e « a »
+    }
+
+    public function test_records_without_uuid_pass_through(): void
+    {
+        $res = SyncReconciler::partition([['x' => 1], ['x' => 2]], ['a']);
+
+        $this->assertCount(2, $res['fresh']);
+        $this->assertCount(0, $res['duplicates']);
+    }
+
+    public function test_duplicate_entry_detection(): void
+    {
+        $this->assertTrue(SyncReconciler::isDuplicateEntry(true, 'in'));
+        $this->assertFalse(SyncReconciler::isDuplicateEntry(false, 'in'));
+        $this->assertFalse(SyncReconciler::isDuplicateEntry(true, 'out')); // sortie ≠ conflit d'entrée
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,5 +19,7 @@ require_once $base.'/Services/Notifications/NotificationService.php';
 require_once $base.'/Services/Review/ReviewService.php';
 require_once $base.'/Services/Inventory/StockService.php';
 require_once $base.'/Services/Audit/AuditService.php';
+require_once $base.'/Services/Event/StaffPinService.php';
+require_once $base.'/Services/Event/SyncReconciler.php';
 require_once $base.'/Support/Event/Ledger.php';
 require_once $base.'/Support/Money.php';


### PR DESCRIPTION
## Contexte

Étape **1** (gatée) de l'intégration des 3 patterns du prototype *Festival Couleur* dans TAGTOA EVENT, **adaptés au multi-tenant**. Conforme au process validé : *plan → schéma → implémentation par étapes → tests par étape*. Ce PR livre **uniquement le socle** (schéma + logique pure testée) ; les terminaux/controllers/vues et le checkout en ligne viennent ensuite, après revue du schéma.

Décisions validées en amont : wallet marchand gardé séparé (staff = `admin|vente|checkin`, **pas de POS**) · billetterie **hybride** QR/NFC configurable · paiement en ligne **preuve manuelle** en interim → auto quand les crédentiels PAY arrivent · **plan gating** du nombre de staff.

## Migrations (`tagtoa_ev_*`, nullable/default — jamais casser l'existant)

| # | Table / colonne | Rôle |
|---|---|---|
| 000082 | `tagtoa_ev_staff` | Comptes staff **scopés `event_id`** (multi-tenant). `role` = admin\|vente\|checkin, `pin_hash`, `active`, `created_by`, `last_login_at` |
| 000083 | `staff_id` (nullable) sur `tagtoa_ev_checkins` | Traçabilité : quel staff a fait le check-in |
| 000084 | `tagtoa_ev_sync_conflicts` | Journal des conflits offline (double check-in : premier gagne, second tracé) |
| 000085 | `checkin_mode` sur `tagtoa_ev_events` | `qr\|nfc\|both` (défaut `qr`) — billetterie hybride |

## Modèles

`Staff` (`pin_hash` masqué à la sérialisation), `SyncConflict` ; `Checkin` gagne `staff_id` + relation.

## Logique PURE (sans Laravel, testée)

- **`StaffPinService`** — normalisation/validation PIN (4–6 chiffres), **hash bcrypt natif** (`password_hash`, pas de façade), matrice **rôle→écran** (admin=tout, vente=`sales`/`pickup`, checkin=`checkin`).
- **`SyncReconciler`** — partition idempotente par `client_uuid` (dédup **intra-lot** + vs serveur, même convention que Menu/Booking/Review/POS), détection double entrée.

## Tests

`StaffPinTest` + `SyncReconcilerTest` enregistrés dans `tests/bootstrap.php`. Suite Unit complète exécutée en local : **58 tests / 405 assertions — OK**.

## Divers

Ajout d'un `.gitignore` (`vendor/`, `composer.lock`, `.phpunit.cache/`).

## Prochaine étape (après ta revue du schéma)

Middleware session staff + terminaux (vente carte / check-in) offline IndexedDB, endpoint sync par lot (dédup + conflits), écran admin (staff + pending-sync + CSV), puis checkout billetterie en ligne (QR e-billet + retrait NFC optionnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_