### PR TITLE
TAGTOA CI : smoke test compilation Blade de toutes les vues (plus jamais de crash silencieux)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,28 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
     + patisipan pa WhatsApp. Encodage kat: `EncodeParticipantCard` (billet+wallet+rechaj) sou
     dashboard wallet. Gid konplè: `docs/EVENT_NFC_GUIDE.md`.
   - ⏳ RES: top-up API reyèl (drivers PAY — bloke).
+- **EVENT STAFF + BIYÈT HYBRIDE** ✅ FÈT (PR #42/#44/#45, patèn « Festival Couleur » adapte multi-tenant):
+  - Tab: `tagtoa_ev_staff` (scoped event_id, wòl admin|vente|checkin, pin_hash bcrypt),
+    `tagtoa_ev_sync_conflicts`, `staff_id` sou checkins, `checkin_mode` (qr|nfc|both) sou events.
+  - Lojik pi teste: `StaffPinService` (PIN 4-6 chif, matris wòl→ekran), `SyncReconciler`
+    (dedoub client_uuid + doub antre). Nan `tests/bootstrap.php`.
+  - Òganizatè `/tagtoa/event/{id}/staff`: CRUD staff (limit pa fòfè: free=0/pro=10/ent=∞,
+    kle `staff` nan config plans), konfli sync, export CSV check-ins pa staff. Tout odite.
+  - Terminal teren `/event/staff/{alias}` (san login Laravel): PIN + rate-limit 8/min,
+    ekran pa wòl — check-in (kod/UID + Web NFC, **offline IndexedDB** + sync pa lo),
+    vant (WhatsApp obligatwa, kat NFC oswa e-biyè QR), retrè kat (lye biyè an liy → UID,
+    refize si kòmand pa peye), suivi admin. Demo: Admin/1234, Vente/2222, Checkin/3333.
+  - Kòmand an liy: bouton « Encaisser » (`orders.paid`) → markPaid + komisyon + odit.
 
 ## 6. Deplwaman & URL
 - App sèvi nan `public/`: base = **https://tagtoa.com/tapbiz/public**
-- Login admin: `/tapbiz/public/login`
+- ⚠️ **RESTRUKTIRASYON VPS AN KOU** (jiyè 2026): itilizatè a deplase app la soti
+  `public_html/tapbiz/` → sib final: app nan `/home/admin/domains/tagtoa.com/laravel/`,
+  docroot = `public_html/` (kontni `public/`). **Deplwaman KASE** jiskaske secret GitHub
+  `VPS_APP_PATH` mete ajou (= `/home/admin/domains/tagtoa.com/laravel`) — rsync echwe
+  (`mkdir .../Modules/Tagtoa failed`). Tout merge depi #41 (fix crash Blade create/edit)
+  poko live. `.env` te ekspoze piblik: DB_PASSWORD dwe woule, APP_DEBUG=false obligatwa.
+- Login admin: `/tapbiz/public/login` (ap chanje apre restrukturasyon)
 - **Paj akèy piblik** (`LandingController` → `landing.blade.php`) sou wout rasin `/`
   (modil la override akèy Biztap la — wout anrejistre apre). Parèt sou `<base>/`.
   Pou l parèt sou **bare tagtoa.com**: pwente docroot domèn nan sou dosye `public/`
@@ -157,3 +175,7 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
 - `route:list` kase sou VPS akoz yon GooglePlayService Biztap (pa pwoblèm TAGTOA).
 - Tès Unit = `PHPUnit\Framework\TestCase` pi (san Laravel) → klas teste yo dwe
   tolerab (gade `Money`).
+- **PA JANM** mete `fn(...)=>[...]` (fonksyon flèch + tablo) andedan `@json(...)` oswa
+  lòt direktiv Blade — parser la kase (« Unclosed '[' ») e paj la crash an prod (PR #41).
+  Mete lojik la nan `@php ... @endphp` (san `use` — non konplè klas), pase yon varyab senp.
+  AVAN chak push vue: konpile ak vrè konpilatè Blade (illuminate/view) + `php -l` rezilta a.

--- a/Modules/Tagtoa/tests/Unit/ViewCompileTest.php
+++ b/Modules/Tagtoa/tests/Unit/ViewCompileTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Smoke test : TOUTES les vues Blade du module doivent compiler en PHP valide.
+ *
+ * Leçon du PR #41 : un `fn(...)=>[...]` dans `@json(...)` produisait du PHP
+ * cassé (« Unclosed '[' ») et les pages create/edit crashaient en prod sans
+ * que la CI (logique pure seulement) ne le voie. Ce test compile chaque vue
+ * avec le VRAI compilateur Blade puis vérifie la syntaxe du PHP généré.
+ */
+class ViewCompileTest extends TestCase
+{
+    public function test_all_module_views_compile_to_valid_php(): void
+    {
+        if (! class_exists(BladeCompiler::class)) {
+            $this->markTestSkipped('illuminate/view absent (composer install requis).');
+        }
+
+        $viewsDir = __DIR__.'/../../resources/views';
+        $cacheDir = sys_get_temp_dir().'/tagtoa-blade-cache';
+        @mkdir($cacheDir, 0777, true);
+
+        $compiler = new BladeCompiler(new Filesystem, $cacheDir);
+
+        $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($viewsDir));
+        $failures = [];
+        $count = 0;
+
+        foreach ($files as $file) {
+            if (! $file->isFile() || ! str_ends_with($file->getFilename(), '.blade.php')) {
+                continue;
+            }
+            $count++;
+
+            try {
+                $php = $compiler->compileString(file_get_contents($file->getPathname()));
+            } catch (\Throwable $e) {
+                $failures[] = $file->getPathname().' — compile: '.$e->getMessage();
+
+                continue;
+            }
+
+            $tmp = tempnam(sys_get_temp_dir(), 'bl').'.php';
+            file_put_contents($tmp, $php);
+            $out = (string) shell_exec('php -l '.escapeshellarg($tmp).' 2>&1');
+            @unlink($tmp);
+
+            if (! str_contains($out, 'No syntax errors detected')) {
+                $rel = str_replace($viewsDir.'/', '', $file->getPathname());
+                $failures[] = $rel.' — '.trim($out);
+            }
+        }
+
+        $this->assertGreaterThan(0, $count, 'Aucune vue trouvée — chemin des vues cassé ?');
+        $this->assertSame([], $failures, "Vues Blade qui compilent en PHP invalide :\n".implode("\n", $failures));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
     "name": "tagtoa/workspace",
-    "description": "TAGTOA module workspace — dev tooling (lint + unit tests for pure logic).",
+    "description": "TAGTOA module workspace \u2014 dev tooling (lint + unit tests for pure logic).",
     "type": "project",
     "require-dev": {
-        "phpunit/phpunit": "^10.5"
+        "phpunit/phpunit": "^10.5",
+        "illuminate/view": "^10.0",
+        "illuminate/filesystem": "^10.0",
+        "illuminate/events": "^10.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
## Problème visé

Le crash du PR #41 (« Unclosed '[' » — toutes les pages create/edit cassées **en prod**) était une erreur de **compilation Blade** que la CI ne pouvait pas voir : elle ne teste que la logique pure, jamais les vues.

## Solution

Nouveau test **`ViewCompileTest`** (suite Unit existante, aucun changement de workflow) :

1. Parcourt **tous** les `.blade.php` de `Modules/Tagtoa/resources/views/` (récursif).
2. Compile chacun avec le **vrai compilateur Blade** (`illuminate/view`).
3. `php -l` sur le PHP généré.
4. Échec CI si une seule vue produit du PHP invalide — **avant** le merge, plus jamais en prod.

Ce même procédé (manuel) a déjà attrapé 2 bugs réels cette semaine : le `@json(fn...)` du #41 et un `use` illégal dans `@php` avant le push du #44.

## Changements

- `Modules/Tagtoa/tests/Unit/ViewCompileTest.php` (se skip proprement si `illuminate/view` absent)
- `composer.json` (workspace) : `illuminate/view` en **require-dev** — outillage seulement, rien de déployé (le deploy ne rsync que `Modules/Tagtoa/`).

## Vérification

Suite Unit locale : **59 tests / 407 assertions OK** — toutes les vues actuelles compilent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_