### PR TITLE
TAGTOA sécurité : rate-limit écritures publiques + plafonds montants wallet + registre des risques

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Event/WalletController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/WalletController.php
@@ -180,7 +180,7 @@ class WalletController extends Controller
         $event = $this->own($id);
         $data = $request->validate([
             'uid'         => ['required', 'string', 'max:120'],
-            'amount'      => ['required', 'numeric', 'min:0.01'],
+            'amount'      => ['required', 'numeric', 'min:0.01', 'max:1000000'],
             'payment_ref' => ['nullable', 'string', 'max:120'],
         ]);
         $participant = app(ResolveNfcTag::class)->handle($event, $data['uid']);
@@ -249,7 +249,7 @@ class WalletController extends Controller
         $data = $request->validate([
             'uid'         => ['required', 'string', 'max:120'],
             'vendor_id'   => ['required', 'integer'],
-            'amount'      => ['required', 'numeric', 'min:0.01'],
+            'amount'      => ['required', 'numeric', 'min:0.01', 'max:1000000'],
             'client_uuid' => ['nullable', 'string', 'max:64'],
         ]);
 

--- a/Modules/Tagtoa/docs/SECURITY.md
+++ b/Modules/Tagtoa/docs/SECURITY.md
@@ -1,0 +1,54 @@
+# TAGTOA — Sécurité (audit & risques connus)
+
+> Registre vivant des risques de sécurité. Mettre à jour à chaque décision.
+
+## Modèle de menace — carte NFC closed-loop
+
+La carte physique (TAGTOA Pay / wallet événement) est identifiée par l'**UID**
+de la puce NFC (stocké haché SHA-256 dans `tagtoa_ev_nfc_tags.uid_hash`).
+
+### 🔴 RISQUE ACCEPTÉ (v1) — clonage d'UID
+
+Les UID de la plupart des puces NFC (NTAG213/215/216, MIFARE Classic) sont
+**lisibles par n'importe quel téléphone et copiables** sur une puce vierge.
+Un attaquant qui approche la carte d'une victime peut cloner l'UID et
+dépenser son solde.
+
+**Pourquoi c'est acceptable en v1 (risque borné) :**
+- Le débit (`charge`) n'a lieu que sur un **terminal vendeur authentifié**
+  (l'organisateur doit être connecté) — pas d'endpoint public de débit.
+- La perte maximale = le **solde chargé sur la carte** (closed-loop, pas de
+  lien bancaire). Recommandation produit : plafonner la recharge par carte.
+- Toutes les transactions sont **tracées** (ledger + audit) → détection.
+
+**Feuille de route pour lever le risque (v2, production à grande échelle) :**
+1. **NTAG424 DNA** : UID dynamique + signature CMAC (SUN) à chaque tap —
+   cryptographiquement **non clonable**. Vérifier le CMAC côté serveur dans
+   `ResolveNfcTag` avant tout débit.
+2. **PIN de dépense** au-dessus d'un seuil configurable par événement.
+3. Plafond de solde par carte + alertes sur vélocité anormale.
+
+## Protections en place (vérifiées)
+
+- **Ledger double-entrée** atomique : `lockForUpdate`, vérification de fonds
+  SOUS le verrou, `amount > 0`, devise identique source/dest, `source ≠ dest`.
+- **Idempotence** avec contrainte DB `UNIQUE` sur `idempotency_key` (+ gestion
+  de la course `QueryException`). Écritures **immuables**.
+- **Isolation multi-tenant** : chaque action dashboard passe par un helper
+  `own*()` filtrant sur `tenant_id` (pas d'IDOR cross-tenant constaté).
+- **Rate-limiting** sur toutes les écritures publiques (`throttle:20,1`) et le
+  terminal staff (`throttle:120,1`) + rate-limit dédié sur le login PIN.
+- **Plafonds** `max` sur les montants wallet (recharge/achat).
+- **Uploads** de preuves : `image` + `mimes` + `max:5120`, nom de fichier
+  aléatoire.
+- **Aucune XSS** : les `{!! !!}` sont des SVG serveur ou `nl2br(e())`.
+
+## À faire (backlog sécurité)
+
+- [ ] Déplacer les preuves de paiement du disque `public` vers un disque privé
+      + route de service authentifiée (aujourd'hui : URL non devinable mais
+      publique si fuitée).
+- [ ] Ops VPS : `APP_DEBUG=false`, `APP_ENV=production`, **rotation de
+      `DB_PASSWORD`** (exposé lors de la restructuration), vérifier que
+      `tagtoa.com/.env` renvoie 404.
+- [ ] Migration NTAG424 DNA (voir feuille de route ci-dessus).

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -35,21 +35,30 @@ use Modules\Tagtoa\App\Http\Controllers\Site\PublicController as SitePublic;
 // Biztap (ex. page de login qui plantait avec « Route [home] not defined »).
 Route::get('/', [LandingController::class, 'index'])->name('home');
 Route::get('/pay/{alias}', [PayPublic::class, 'show'])->name('tagtoa.pay.show');
-Route::post('/pay/{alias}/submit-proof', [PayPublic::class, 'submitProof'])->name('tagtoa.pay.submit-proof');
 Route::get('/pay/{alias}/checkout/{method}', [PayPublic::class, 'checkout'])->name('tagtoa.pay.checkout');
 Route::get('/loyalty/card/{token}', [LoyaltyPublic::class, 'show'])->name('tagtoa.loyalty.card');
 Route::get('/links/{alias}', [LinksPublic::class, 'show'])->name('tagtoa.links.show');
 Route::get('/links/go/{link}', [LinksPublic::class, 'go'])->name('tagtoa.links.go');
 Route::get('/site/{alias}', [SitePublic::class, 'show'])->name('tagtoa.site.show');
 Route::get('/menu/{alias}', [MenuPublic::class, 'show'])->name('tagtoa.menu.show');
-Route::post('/menu/{alias}/order', [MenuPublic::class, 'order'])->name('tagtoa.menu.order');
 Route::get('/event/{alias}', [EventPublic::class, 'show'])->name('tagtoa.event.show');
-Route::post('/event/{alias}/buy', [EventPublic::class, 'buy'])->name('tagtoa.event.buy');
 Route::get('/event/order/{reference}', [EventPublic::class, 'order'])->name('tagtoa.event.order');
 Route::get('/event/ticket/{code}', [EventPublic::class, 'ticket'])->name('tagtoa.event.ticket');
 Route::get('/event/wallet/receipt/{reference}', [EventPublic::class, 'walletReceipt'])->name('tagtoa.event.wallet.receipt');
+Route::get('/book/{alias}', [BookingPublic::class, 'show'])->name('tagtoa.booking.show');
+
+// Écritures publiques : rate-limit (anti-spam / anti-DoS / anti-épuisement disque).
+Route::middleware('throttle:20,1')->group(function () {
+    Route::post('/pay/{alias}/submit-proof', [PayPublic::class, 'submitProof'])->name('tagtoa.pay.submit-proof');
+    Route::post('/menu/{alias}/order', [MenuPublic::class, 'order'])->name('tagtoa.menu.order');
+    Route::post('/event/{alias}/buy', [EventPublic::class, 'buy'])->name('tagtoa.event.buy');
+    Route::post('/book/{alias}/reserve', [BookingPublic::class, 'reserve'])->name('tagtoa.booking.reserve');
+    Route::post('/reviews', [\Modules\Tagtoa\App\Http\Controllers\Review\PublicController::class, 'store'])->name('tagtoa.reviews.store');
+});
+
 // Terminal STAFF terrain (auth par PIN scopée événement — pas de login Laravel).
-Route::prefix('event/staff/{alias}')->name('tagtoa.event.staff.')->group(function () {
+// Rate-limit plus large : le check-in aux portes est intense mais borné par appareil.
+Route::prefix('event/staff/{alias}')->name('tagtoa.event.staff.')->middleware('throttle:120,1')->group(function () {
     $staffTerminal = \Modules\Tagtoa\App\Http\Controllers\Event\StaffTerminalController::class;
     Route::get('/', [$staffTerminal, 'terminal'])->name('terminal');
     Route::post('/login', [$staffTerminal, 'login'])->name('login');
@@ -59,9 +68,6 @@ Route::prefix('event/staff/{alias}')->name('tagtoa.event.staff.')->group(functio
     Route::post('/sell', [$staffTerminal, 'sell'])->name('sell');
     Route::post('/pickup', [$staffTerminal, 'pickup'])->name('pickup');
 });
-Route::get('/book/{alias}', [BookingPublic::class, 'show'])->name('tagtoa.booking.show');
-Route::post('/book/{alias}/reserve', [BookingPublic::class, 'reserve'])->name('tagtoa.booking.reserve');
-Route::post('/reviews', [\Modules\Tagtoa\App\Http\Controllers\Review\PublicController::class, 'store'])->name('tagtoa.reviews.store');
 
 // ---------- DASHBOARD (back-office marchand) ----------
 // Middleware aligné sur le back-office Biztap (confirmé dans routes/web.php) :


### PR DESCRIPTION
## Contexte — audit de sécurité (closed-loop NFC)

Audit complet du chemin de l'argent, des endpoints publics/terminaux, de l'isolation multi-tenant et des vues. **Le cœur monétaire est solide** (ledger double-entrée sous verrou, vérification de fonds sous lock, idempotence contrainte `UNIQUE` en DB, isolation tenant cohérente via helpers `own*()`, aucune XSS). Ce PR ferme les **gaps systémiques** trouvés.

## Corrigé

### 🟠 Rate-limiting (manquait totalement, sauf login PIN)
- **Écritures publiques** → `throttle:20,1` : `menu/order`, `event/buy`, `book/reserve`, `reviews`, `pay/submit-proof`. Empêche le spam, le DoS, et surtout l'**épuisement de disque** via uploads de preuves répétés.
- **Terminal staff** → `throttle:120,1` : check-in intense mais borné par appareil.

### 🟡 Plafonds montants wallet
`max:1000000` sur `topup` et `charge` — défense en profondeur contre montants aberrants.

### 📄 `docs/SECURITY.md` — registre des risques
- **Modèle de menace carte NFC** + **RISQUE ACCEPTÉ v1** : clonage d'UID (les UID NTAG213/MIFARE sont copiables). Borné car : débit uniquement sur **terminal authentifié**, perte plafonnée au **solde chargé** (closed-loop), transactions tracées.
- **Feuille de route** : NTAG424 DNA (UID dynamique + CMAC, non clonable) / PIN de dépense.
- **Backlog** : preuves de paiement à déplacer sur disque **privé** ; ops VPS (`APP_DEBUG=false`, rotation `DB_PASSWORD` exposé, `.env` → 404).

## Ce qui reste (hors code, action utilisateur)
- Rotation `DB_PASSWORD` + `APP_DEBUG=false` sur le VPS.
- Décision produit : plafond de solde par carte / migration NTAG424 pour la v2.

## Vérifications
`php -l` OK · suite Unit **59 tests / 407 assertions** OK.

## Base de données
Aucune migration. Aucune table modifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_