### PR TITLE
Konesyon VPS pou klasyo.org via GitHub Actions (klasyo-ops)

### DIFF
--- a/.github/scripts/KLASYO_BLUEPRINT.md
+++ b/.github/scripts/KLASYO_BLUEPRINT.md
@@ -1,0 +1,468 @@
+# KLASYO.ORG — Blueprint Produit, UX & Architecture Technique
+
+> **Version 1.0 — 14 juillet 2026**
+> Basé sur l'audit RÉEL de l'installation (inspections SSH v1→v4 via le canal `klasyo-ops`) :
+> LMSZAI build 31 (Laravel 9, 139 tables) sur `/platform`, eSchool SaaS v1.9.3 (Laravel 10, 45 tables) sur `/school`.
+> **Contraintes non négociables : conserver SaaS, Multi-organisation, Multi-instructeurs, Affiliate System.**
+
+---
+
+## 0. Résumé exécutif
+
+KLASYO.ORG devient l'écosystème éducatif d'Haïti et des Caraïbes, en deux produits sur un même compte :
+
+| Produit | URL | Rôle | Script de base |
+|---|---|---|---|
+| **KLASYO Aprann** (platform) | `klasyo.org/platform` | Marketplace de formations et cours en ligne (vente, abonnements, affiliation) | LMSZAI b31 |
+| **KLASYO Lekòl** (school) | `klasyo.org/school` | Gestion d'établissements scolaires (SaaS multi-écoles) | eSchool SaaS 1.9.3 |
+| **KLASYO Connect** | transversal | 1 seul compte, SSO entre les deux, onboarding guidé | à construire (custom) |
+
+Stratégie en 3 phases : **MVP (6-8 semaines)** — stabiliser, rebrander, simplifier, encaisser (MonCash + Stripe) ; **PRO (3-4 mois)** — dashboards premium, présentiel/hybride, certificats QR, IA de base, SSO complet ; **ENTERPRISE (6-9 mois)** — IA complète, marketplace, paiements échelonnés, analytics avancé, PWA offline.
+
+---
+
+## 1. Vision & positionnement
+
+- **Marché primaire** : Haïti (mobile-first, connexions instables, HTG + MonCash/NatCash, français/créole).
+- **Marché secondaire** : diaspora + Caraïbes (USD, Stripe/PayPal/Zelle, anglais/espagnol).
+- **Différenciateurs** : paiements locaux réels, offline-first, créole natif, formations présentiel+hybride avec QR de présence, certificats vérifiables publiquement, prix en HTG.
+- **Références UX** : Coursera (catalogue/parcours), Udemy (fiche cours/player), Skillshare (communauté), Kajabi/Thinkific/Teachable (dashboards créateurs) — avec l'identité KLASYO (voir §11).
+
+---
+
+## 2. État des lieux technique (audit du 14/07/2026)
+
+### 2.1 Ce qui existe
+
+| Élément | Constat |
+|---|---|
+| Landing racine | `index.html` statique, déjà brandée KLASYO (bleu #1d4ed8, vert #16a34a, Sora + DM Sans) — sert de source du design system |
+| PLATFORM | LMSZAI b31 fonctionne (`/platform/index.php` → 200). 7 thèmes frontend (`frontend`…`frontend-theme-7`), settings en DB (`settings.option_key/option_value`) |
+| SCHOOL | **EN PANNE** : timeout sur toutes les URLs. Logs : `No application encryption key has been specified` + `Your configuration files are not serializable` → APP_KEY manquante + cache config corrompu |
+| Comptes | 1 seul user dans chaque app (installations fraîches) — le moment idéal pour restructurer |
+| Inscription | `Auth::routes(['register' => false])` — **l'inscription publique est désactivée** sur platform |
+| Contenu | 100 % démo LMSZAI (app_name=LMSZAI, logos démo, textes anglais lorem) |
+
+### 2.2 Problèmes critiques (P0 — avant tout le reste)
+
+1. **Zips de code source dans public_html** : `platform/klasyo.zip` (147 Mo), `school/school.zip` (568 Mo), `source_code.zip`, zips d'install/update → à déplacer hors web (`~/backups_klasyo/`). ~770 Mo de code + configs potentiellement téléchargeables.
+2. **school/.env : `APP_DEBUG=true`** en production → fuite de secrets à la moindre erreur.
+3. **platform/.env : `APP_URL="webetud.com"`, `APP_ENV=local`** → URLs générées cassées, comportements de dev en prod.
+4. **Réparer school** : générer APP_KEY (`php artisan key:generate`), `config:clear`, corriger la connexion DB au runtime, `APP_DEBUG=false`.
+5. **403 externe** : le firewall (Imunify360) bloque les IPs datacenter ; vérifier que les vrais navigateurs passent, et whitelister les IPs de monitoring.
+6. Fichier parasite `platform/index.html` (titre « webetud.com ») → supprimer.
+
+*Priorité P0 · Difficulté faible · 1-2 jours (déjà outillé via le workflow klasyo-ops).*
+
+---
+
+## 3. Architecture cible de l'écosystème
+
+```
+                    klasyo.org (landing brandée)
+                              │
+              ┌───────────────┼────────────────┐
+              ▼               ▼                ▼
+     /platform (Aprann)   /school (Lekòl)   /verify/{code}
+     LMSZAI Laravel 9     eSchool Laravel 10  (certificats publics)
+              │               │
+              └──── KLASYO Connect (SSO) ────┘
+                    compte maître : platform
+                    jeton HMAC signé, 60 s
+                    auto-provisioning par email
+```
+
+### 3.1 KLASYO Connect — 1 compte pour tout (réponse à la demande SSO)
+
+- **Compte maître** : `users` de platform (email unique). L'inscription se fait UNE fois, côté platform, via l'onboarding guidé (§6).
+- **Pont SSO** (addon, sans toucher au cœur des scripts) :
+  - platform : `GET /klasyo-sso/authorize?redirect=…` (auth requise) → génère `token = base64(payload).HMAC_SHA256(payload, KLASYO_SSO_SECRET)` avec `{email, name, exp: now+60s, nonce}`.
+  - school : `GET /klasyo-sso/callback?token=…` → vérifie signature + expiration + nonce anti-rejeu → `User::firstOrCreate(email)` (mot de passe aléatoire, `school_id` par défaut « KLASYO », rôle élève) → `Auth::login()`.
+  - Bouton « Se connecter avec KLASYO » sur l'écran de login de school ; lien inverse possible.
+- **Secret partagé** `KLASYO_SSO_SECRET` dans les deux `.env` (généré sur le VPS, jamais dans le repo/logs).
+- **Livré comme addon** : 1 contrôleur + 1 fichier de routes + 1 ServiceProvider par app → survit aux mises à jour des scripts achetés.
+- Évolution Enterprise : promouvoir Connect en vrai serveur OAuth2 (Laravel Passport) quand un 3e produit arrivera.
+
+*Priorité P1 · Difficulté moyenne · 4-6 jours (mapping école/rôle par défaut à confirmer).*
+
+---
+
+## 4. Analyse module par module (LMSZAI /platform)
+
+Légende : **P0** critique · **P1** MVP · **P2** Pro · **P3** Enterprise. Difficulté : ⚙ faible / ⚙⚙ moyenne / ⚙⚙⚙ élevée. Temps = dev·jours estimés.
+
+### Vue d'ensemble
+
+| # | Module | Verdict | Priorité | Diff. | Temps |
+|---|---|---|---|---|---|
+| 1 | Auth & Onboarding | **Refondre** (inscription désactivée !) | P0 | ⚙⚙ | 6 |
+| 2 | Catalogue & recherche | Conserver + simplifier | P1 | ⚙⚙ | 8 |
+| 3 | Fiche cours & player | Conserver + moderniser | P1 | ⚙⚙⚙ | 12 |
+| 4 | Quiz / Devoirs / Examens | Conserver + IA | P2 | ⚙⚙ | 8 |
+| 5 | Certificats | Refondre (QR + vérif publique) | P1 | ⚙⚙ | 6 |
+| 6 | Live class (Agora/Zoom/GMeet) | Conserver tel quel | P2 | ⚙ | 2 |
+| 7 | SCORM | Conserver (niche B2B) | P3 | ⚙ | 1 |
+| 8 | Forum / Communauté | Simplifier (Q&R par cours) | P2 | ⚙⚙ | 5 |
+| 9 | Blog / Pages / FAQ | Conserver (SEO) | P2 | ⚙ | 3 |
+| 10 | Consultation 1:1 | Conserver + calendrier | P2 | ⚙⚙ | 5 |
+| 11 | Bundles | Conserver | P2 | ⚙ | 2 |
+| 12 | **Subscription SaaS** | **CONSERVER (obligatoire)** + clarifier | P1 | ⚙⚙ | 5 |
+| 13 | **Organization (multi-org)** | **CONSERVER (obligatoire)** + simplifier UX | P1 | ⚙⚙ | 6 |
+| 14 | **Multi-instructeurs** | **CONSERVER (obligatoire)** + dashboard simple | P1 | ⚙⚙ | 8 |
+| 15 | **Affiliate System** | **CONSERVER (obligatoire)** + moderniser | P1 | ⚙⚙ | 5 |
+| 16 | Wallet & recharge | Conserver (clé pour Haïti) | P1 | ⚙⚙ | 4 |
+| 17 | Paiements | **Refondre** (architecture §7) | P0-P1 | ⚙⚙⚙ | 20 |
+| 18 | Demandes de retrait | Conserver + traçabilité | P1 | ⚙ | 3 |
+| 19 | Messages / Chat | Simplifier | P2 | ⚙⚙ | 4 |
+| 20 | Notifications | Refondre (Email+SMS+WhatsApp §9) | P1 | ⚙⚙ | 6 |
+| 21 | Admin settings / i18n / devises | Conserver + créole | P1 | ⚙ | 4 |
+| 22 | Avis & notes | Conserver + modération | P2 | ⚙ | 2 |
+
+### 4.1 Auth & Onboarding
+- **Utilité** : porte d'entrée de tout l'écosystème.
+- **État** : login Laravel classique, **register désactivé**, pas de social login actif, pas de guidage.
+- **Faiblesses** : impossible de s'inscrire ; formulaires bruts Bootstrap ; aucun choix de profil ; pas de vérification téléphone (essentiel en Haïti où l'email est faible).
+- **Améliorations** : réactiver l'inscription via le **wizard KLASYO Connect** (§6) ; login par email OU téléphone ; OTP WhatsApp/SMS en option ; « Se souvenir de moi » par défaut ; réinitialisation par WhatsApp.
+- **Maquette** : écran unique centré, logo KLASYO, 2 champs max par étape, gros boutons (44 px), gradient héro `--grad-main` en fond.
+
+### 4.2 Catalogue & recherche
+- **Utilité** : découverte des cours — le « magasin ».
+- **Forces** : filtres LMSZAI riches (catégorie, niveau, prix, langue), 7 thèmes disponibles.
+- **Faiblesses** : trop d'éléments par écran (sliders multiples, achievements démo, 3 carrousels) ; cartes cours chargées ; recherche non tolérante aux fautes ; images démo lourdes.
+- **Améliorations** : page d'accueil = héro + recherche + 8 cours vedettes + catégories + preuve sociale, rien d'autre ; recherche instantanée (Laravel Scout + Meilisearch en P2, LIKE optimisé en P1) ; cartes épurées : image 16:9, titre 2 lignes, instructeur, note ★, prix HTG/USD ; badges « Nouveau / Populaire / Gratuit ».
+- **Maquette** : grille 1 col (mobile) → 2 (tablette) → 4 (desktop), skeleton loaders, scroll infini.
+
+### 4.3 Fiche cours & player
+- **Utilité** : conversion (fiche) + rétention (player).
+- **Forces** : player LMSZAI complet (vidéo, sections, pièces jointes, progression, notes).
+- **Faiblesses** : fiche cours très longue et désordonnée ; player chargé (sidebar dense) ; pas de reprise « Continuer là où j'étais » mise en avant ; vidéos servies localement (bande passante VPS).
+- **Améliorations** : fiche = sticky card d'achat (prix, CTA, garanties, paiement local) + curriculum accordéon + avis ; player plein écran mobile avec vitesse ×0.75-×2, qualité adaptative, marquage auto « terminé » ; téléchargement audio des leçons (offline Haïti, P2) ; hébergement vidéo Bunny Stream/Cloudflare Stream (§12).
+- **Maquette player** : barre de progression du cours en haut, vidéo, onglets « Aperçu / Notes / Q&R / Fichiers », bouton flottant « Leçon suivante ».
+
+### 4.4 Quiz / Devoirs / Examens
+- Conserver le moteur LMSZAI ; ajouter : banque de questions réutilisable, minuterie visible, correction immédiate optionnelle, tentatives configurables, anti-triche léger (mélange questions/réponses), **génération par IA** (§10).
+
+### 4.5 Certificats → voir §9.1 (QR + vérification publique + badges).
+
+### 4.6–4.11 (Live, SCORM, Forum, Blog, Consultation, Bundles)
+- **Live** : conserver Agora intégré ; documenter Zoom/GMeet ; P2.
+- **Forum** : remplacer le forum global par des **Q&R par leçon** (comme Udemy) — moins de modération, plus de valeur ; conserver la table, changer l'UX.
+- **Consultation 1:1** : pépite pour coachs haïtiens — brancher un vrai calendrier de disponibilités + rappels WhatsApp.
+- **Bundles** : conserver, utile pour « parcours métier ».
+
+### 4.12 Subscription SaaS (OBLIGATOIRE — ne jamais supprimer)
+- **Utilité** : revenus récurrents ; les organisations/écoles paient un forfait pour vendre sur KLASYO.
+- **Améliorations** : 3 plans clairs (Gratis / Pro / Biznis) avec tableau comparatif simple ; facturation HTG et USD ; relance automatique J-7/J-3/J0 par WhatsApp+email ; période de grâce 7 jours ; page « Mon forfait » avec jauge d'utilisation (modèle déjà éprouvé sur TAGTOA `PlanService`/`EnforcesPlan`).
+- *P1 · ⚙⚙ · 5 j.*
+
+### 4.13 Multi-organisation (OBLIGATOIRE)
+- **Utilité** : une école/entreprise vend sous sa marque, gère ses instructeurs, partage les revenus.
+- **Faiblesses UX** : le rôle « organization » de LMSZAI est un dashboard admin allégé, confus.
+- **Améliorations** : onboarding org dédié (logo, page vitrine `platform/org/{slug}`, invitation d'instructeurs par lien) ; répartition des revenus visible (org ↔ instructeur ↔ plateforme) ; **pont naturel vers school** : « Votre organisation est une école ? Activez KLASYO Lekòl » (cross-sell SSO).
+- *P1 · ⚙⚙ · 6 j.*
+
+### 4.14 Multi-instructeurs (OBLIGATOIRE) → dashboard refondu en §5.2.
+
+### 4.15 Affiliate System (OBLIGATOIRE)
+- **Utilité** : croissance virale à coût maîtrisé — crucial en Haïti où la recommandation domine.
+- **État** : LMSZAI gère `is_affiliator`, commissions, retraits.
+- **Améliorations** : lien + QR d'affiliation par cours ; page publique « Devenez ambassadeur KLASYO » ; tableau de bord affilié simple (clics, ventes, gains, bouton retrait MonCash) ; commissions à 2 niveaux optionnelles ; paiement des commissions via le même moteur de retraits que les instructeurs ; partage direct WhatsApp (« Pataje sou WhatsApp »).
+- *P1 · ⚙⚙ · 5 j.*
+
+### 4.16 Wallet
+- Conserver — c'est l'astuce anti-friction : l'utilisateur recharge une fois (dépôt MonCash validé) puis achète en 1 clic. Ajouter : historique clair, recharge par code revendeur (P3, réseau de points de vente physiques).
+
+---
+
+## 5. Refonte des dashboards
+
+Principes communs : sidebar fixe (desktop) / bottom-nav 5 icônes (mobile) ; cartes KPI uniformes ; design system §11 ; **chaque dashboard doit être utilisable sur un téléphone à 25 USD**.
+
+### 5.1 Dashboard ADMIN (premium, niveau international)
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ ⌂ KLASYO Admin      [Recherche globale…]        🔔  👤     │
+├──────────┬─────────────────────────────────────────────────┤
+│ Accueil  │  Revenus (mois)   Inscriptions   Nouv. étudiants│
+│ Ventes   │  ┌─────────┐      ┌─────────┐    ┌─────────┐    │
+│ Cours    │  │ 245 000 │      │  1 240  │    │   318   │    │
+│ Étudiants│  │ HTG ▲12%│      │  ▲ 8%   │    │  ▲ 15%  │    │
+│ Instruct.│  └─────────┘      └─────────┘    └─────────┘    │
+│ Organis. │  Nouv. instructeurs   Cours actifs   Paiements  │
+│ Paiements│  ───────────────────────────────────────────────│
+│ Retraits │  📈 Revenus 30 jours (graphique aires, HTG/USD) │
+│ Affiliés │  📊 Top 5 cours │ 🍩 Répartition par passerelle │
+│ Marketing│  ───────────────────────────────────────────────│
+│ Rapports │  ⏳ À traiter : 4 retraits · 2 preuves MonCash  │
+│ Support  │     3 cours en attente d'approbation            │
+│ Paramètres│                                                │
+└──────────┴─────────────────────────────────────────────────┘
+```
+
+- **KPI (8 tuiles)** : Revenus (mois, avec devise commutables HTG/USD), Inscriptions, Nouveaux étudiants, Nouveaux instructeurs, Paiements reçus, Cours actifs, Taux de complétion, MRR abonnements.
+- **Graphiques** : revenus 30 j (aire), inscriptions 30 j (barres), répartition passerelles (donut), top cours (barres horizontales). Chart.js suffit (léger).
+- **File « À traiter »** : retraits en attente, preuves de paiement manuelles à valider, cours à approuver, tickets support — le vrai travail quotidien de l'admin haïtien, en premier.
+- **Sections** : Ventes/Paiements (journal + filtres + export CSV), Retraits (workflow approuver→payer→prouver), Marketing (coupons, bannières, emailing), Rapports (revenus par période/instructeur/org, export), Support (tickets simples), Paramètres regroupés en 6 onglets max (au lieu des ~30 pages LMSZAI).
+- *P1 · ⚙⚙⚙ · 15 j.*
+
+### 5.2 Dashboard INSTRUCTEUR (simplicité radicale)
+
+Menu EXACT (11 entrées, demande client) :
+**Dashboard · Mes cours · Créer un cours · Leçons · Quiz · Étudiants · Revenus · Demandes de retrait · Messages · Avis · Paramètres**
+
+- **Accueil** : 4 tuiles — Étudiants totaux, Revenus du mois, Note moyenne ★, Cours publiés — puis graphique « inscriptions 14 jours », « progression moyenne de mes étudiants », top 3 cours populaires, derniers avis à répondre.
+- **Créer un cours** : wizard 4 étapes (Infos → Curriculum → Prix → Publier), sauvegarde auto brouillon, upload vidéo par leçon avec barre de progression, **assistant IA** (« Génère-moi un plan de cours », §10).
+- **Revenus** : solde disponible en gros, historique ventes, bouton « Demander un retrait » (MonCash/virement/Zelle), statut du retrait suivi comme un colis (Demandé → Approuvé → Payé).
+- *P1 · ⚙⚙⚙ · 12 j.*
+
+### 5.3 Dashboard ÉTUDIANT (le plus simple possible)
+
+Menu : **Continuer le cours · Mes formations · Ma progression · Mes certificats · Mes paiements · Mes téléchargements · Mes favoris · Support · Profil**
+
+- **Écran d'accueil** = 1 grande carte « **Continuer : [dernière leçon]** » avec bouton play + barre de progression, puis « Mes formations » en cartes avec % complété, puis prochains événements (sessions live / présentiel).
+- **Ma progression** : anneaux de progression par cours, série de jours d'étude (streak), badges gagnés.
+- **Mes certificats** : cartes avec aperçu, QR, boutons Télécharger PDF / Partager LinkedIn / WhatsApp.
+- **Mes paiements** : reçus simples, statut des preuves manuelles (« En vérification »).
+- Mobile : bottom-nav `⌂ Aprann · 📚 Kou · 🏆 Sètifika · 💬 Sipò · 👤 Pwofil`.
+- *P1 · ⚙⚙ · 8 j.*
+
+---
+
+## 6. Login unifié & onboarding « étape par étape vers son besoin »
+
+Wizard unique sur `klasyo.org` (3 écrans max, 1 question par écran) :
+
+1. **« Kisa ou vle fè ? / Que voulez-vous faire ? »**
+   - 🎓 *Aprann* (suivre des formations) → compte étudiant platform
+   - 👨‍🏫 *Anseye* (vendre mes cours) → compte instructeur platform (validation admin)
+   - 🏫 *Jere yon lekòl* (gérer mon établissement) → school (+ compte platform lié via SSO)
+   - 🏢 *Òganizasyon* (académie/entreprise) → organisation platform
+2. **Identité** : nom + (email OU téléphone) + mot de passe. OTP WhatsApp si téléphone.
+3. **Personnalisation** : langue (Kreyòl/Français/English/Español → fixe aussi la devise HTG/EUR/USD/DOP), centres d'intérêt (étudiant) ou nom d'école (school).
+
+→ Redirection directe vers le bon espace, déjà connecté partout (SSO). Un seul couple identifiant/mot de passe pour platform ET school.
+
+*P1 · ⚙⚙ · 6 j (dépend du pont SSO §3.1).*
+
+---
+
+## 7. Architecture Paiements (le nerf de la guerre)
+
+### 7.1 Design : un « Payment Hub » à drivers
+
+Pattern éprouvé (déjà validé sur TAGTOA) : une interface unique + un driver par passerelle, un webhook par driver, un **ledger** central.
+
+```php
+interface PaymentDriver {
+    public function initiate(Payment $p): RedirectResponse|array; // URL ou instructions
+    public function verifyWebhook(Request $r): PaymentResult;     // IPN/webhook
+    public function verifyManualProof(Payment $p): void;          // preuves manuelles
+    public function currencies(): array;                          // ['HTG','USD']
+    public function mode(): string;                               // 'auto' | 'manual'
+}
+```
+
+- Table `klasyo_payments` (ledger) : `id, user_id, payable_type/payable_id (cours|abonnement|wallet|acompte), gateway, currency, amount_minor, fee_minor, status (pending|processing|paid|failed|refunded), proof_path, external_ref, meta JSON, idempotency_key`.
+- **Montants en unités mineures (centimes)**, jamais de float.
+- Chaque driver = 1 classe + 1 route webhook + 1 vue « instructions » → ajout d'une passerelle sans toucher au reste.
+- Sélecteur intelligent : la devise de l'utilisateur filtre les passerelles proposées (HTG → MonCash/NatCash/banques ; USD → Stripe/PayPal/Zelle/crypto).
+
+### 7.2 Les 9 passerelles
+
+| Passerelle | Mode | Devises | Intégration | Priorité | Temps |
+|---|---|---|---|---|---|
+| **MonCash** (Digicel) | Auto (API REST OAuth) | HTG | `POST /v1/CreatePayment` → redirect → webhook retour | **P0** | 4 j |
+| **Stripe** | Auto (Checkout + webhooks) | USD/EUR/+ | stripe-php, Payment Element, 3DS | **P0** | 3 j |
+| **PayPal** | Auto (Orders v2 + webhooks) | USD | Smart Buttons (couvre aussi cartes) | P1 | 3 j |
+| **NatCash** (Natcom) | Manuel → auto si API dispo | HTG | n° marchand + preuve (screenshot/ref) validée par admin | P1 | 2 j |
+| **Zelle** | Manuel | USD | email/téléphone Zelle + preuve + rapprochement admin | P1 | 1 j |
+| **Binance Pay** | Auto (merchant API) | USDT/BUSD | QR + webhook signature | P2 | 3 j |
+| **CoinPayments** | Auto (IPN) | BTC/ETH/USDT | invoice + IPN HMAC | P2 | 3 j |
+| **Unibank Online** | Manuel | HTG | virement + référence + preuve | P2 | 1 j |
+| **Sogebank Online** | Manuel | HTG | idem | P2 | 1 j |
+
+- **Mode manuel unifié** : une seule UX pour NatCash/Zelle/banques — instructions claires (n° de compte, montant exact, référence unique `KLA-XXXX`), upload de preuve, écran « En vérification », validation admin en 1 clic (file « À traiter » du dashboard admin), notification WhatsApp à la validation.
+- **Webhooks** : vérification de signature systématique, idempotence par `external_ref`, retry queue.
+- **Multi-devise** : prix pivot en USD + taux HTG administrable (mise à jour manuelle ou API) ; affichage dans la devise de la langue.
+- Taxes/commissions : répartition automatique plateforme/instructeur/affilié/org au moment du `paid` (event `PaymentSucceeded`).
+
+*Total paiements : P0-P2 · ⚙⚙⚙ · ~21 j répartis sur les phases.*
+
+---
+
+## 8. Formations En ligne / Présentiel / Hybride
+
+Nouvelles tables (préfixe `klasyo_*`, zéro modification des tables LMSZAI — colonnes ajoutées uniquement nullable) :
+
+- `klasyo_course_sessions` : `course_id, type (online|onsite|hybrid), title, starts_at, ends_at, location_name, address, gps, seats_total, seats_reserved, price_override, status`.
+- `klasyo_session_registrations` : `session_id, user_id, status (registered|present|absent|cancelled), checkin_at, checkin_by`.
+- **Calendrier** : vue mensuelle publique par cours + iCal export ; côté étudiant « Prochaines sessions » sur l'accueil.
+- **Places** : jauge `seats_reserved/seats_total`, blocage à guichet fermé, liste d'attente (P3).
+- **Liste de présence** : écran instructeur (mobile) avec la liste des inscrits, pointage tactile + **scan QR**.
+- **QR de présence** : chaque inscription génère un QR signé (`session_id:user_id:HMAC`) affiché dans l'espace étudiant ; l'instructeur scanne (caméra web, lib html5-qrcode) → `checkin_at` horodaté ; anti-rejeu (un scan par session). Mode inverse possible : QR affiché en salle, scanné par l'étudiant (géo-vérifié P3).
+- La présence alimente la **progression** et conditionne le **certificat** pour les formations présentielles.
+
+*P2 · ⚙⚙ · 10 j.*
+
+---
+
+## 9. Nouvelles fonctionnalités
+
+### 9.1 Certificats, badges, vérification publique
+- **Certificat auto** à 100 % de complétion (ou présence validée) : PDF généré (DomPDF), gabarit KLASYO (bilingue FR/HT), n° unique `KLA-2026-XXXXXX`.
+- **QR sur le certificat** → `klasyo.org/verify/{code}` : page publique (nom, cours, date, statut valide/révoqué) — anti-falsification, gratuite, indexable.
+- **Badges numériques** : table `klasyo_badges` + attribution par règles (1er cours, 5 cours, streak 30 j, top quiz) ; standard Open Badges v2 (JSON-LD) pour LinkedIn (P3).
+- **Carte étudiante numérique** : carte verticale mobile (photo, nom, ID, QR de vérification, validité) dans l'espace étudiant ; format wallet Apple/Google en P3 ; sert aussi de carte de présence en présentiel. Synergie directe avec le savoir-faire NFC TAGTOA (carte physique NFC en option payante).
+- *P1 (certificats+QR) / P2 (badges, carte) · ⚙⚙ · 10 j.*
+
+### 9.2 Notifications multicanal
+- Service central `NotificationService` (pattern TAGTOA éprouvé) : canaux **email** (SMTP), **WhatsApp** (Twilio — déjà maîtrisé), **SMS** (Twilio SMS, fallback), préférences par utilisateur, queue Laravel, tolérant aux pannes (no-op si non configuré).
+- Événements branchés : achat confirmé, preuve validée/refusée, nouveau cours d'un instructeur suivi, rappel session J-1/H-2, certificat émis, retrait payé, relance panier (P3).
+- **WhatsApp intégré** : en Haïti c'est LE canal — bouton « Sipò WhatsApp » flottant sur le public, notifications transactionnelles via templates approuvés.
+- *P1 · ⚙⚙ · 6 j.*
+
+### 9.3 Analytics
+- Dashboard admin (§5.1) + page Analytics dédiée : entonnoir visite→fiche→achat, cohortes de complétion, revenus par passerelle/devise/instructeur/affilié, CSV export. Événements stockés dans `klasyo_events` (léger, sans dépendance externe) ; Plausible/Matomo self-hosted en option P3.
+- *P2 · ⚙⚙ · 6 j.*
+
+### 9.4 Marketplace, coupons, paiements flexibles
+- **Marketplace** : le multi-instructeurs/multi-org EST la marketplace — l'améliorer : page instructeur publique soignée, classements (« Top formateurs Haïti »), commission par catégorie, programme « KLASYO Select » (badge qualité).
+- **Coupons** : `klasyo_coupons` (%, montant fixe, périmètre cours/instructeur/global, quota, expiration, 1/usager) + champ code au checkout + stats d'usage. *P1 · ⚙ · 3 j.*
+- **Paiement en plusieurs fois** : `klasyo_payment_plans` (échéancier 2-4 tranches) ; accès au cours maintenu si échéances à jour, suspendu sinon ; rappels WhatsApp J-3/J0 ; auto-charge si carte (Stripe), manuel sinon. *P2 · ⚙⚙⚙ · 8 j.*
+- **Acompte (présentiel)** : réservation de place à X %, solde avant J-1 ; statuts `deposit_paid → fully_paid` ; intégré aux sessions §8. *P2 · ⚙⚙ · 4 j (avec plans).*
+
+---
+
+## 10. Intelligence Artificielle (Claude API)
+
+### 10.1 Architecture
+
+- **Un service central `KlasyoAi`** (addon Laravel) qui encapsule le SDK PHP officiel Anthropic (`composer require anthropic-ai/sdk`) : gestion clé API (`.env`), retries, quotas par plan SaaS (l'IA devient un argument de vente des forfaits Pro/Biznis), journalisation des coûts par organisation.
+- **Modèles** : `claude-opus-4-8` par défaut (génération de cours/quiz/examens — qualité maximale, $5/$25 par MTok) ; `claude-haiku-4-5` pour les tâches légères à fort volume (traduction UI, chatbot support, reformulations — $1/$5 par MTok). Streaming SSE pour l'assistant/chatbot (réponse progressive) ; **Batch API** (-50 %) pour les traductions massives de contenu ; **prompt caching** sur les prompts système (catalogue, contexte du cours) pour réduire les coûts.
+- Sorties **structurées** (`output_config.format` JSON schema) pour tout ce qui remplit la base (quiz, plans de cours) → zéro parsing fragile.
+- File d'attente Laravel pour les générations longues ; l'UI affiche « Jenerasyon an ap fèt… » avec polling.
+
+### 10.2 Fonctionnalités par phase
+
+| Fonction | Description | Modèle | Phase | Temps |
+|---|---|---|---|---|
+| **AI Course Generator** | Titre+public+objectifs → plan complet (sections, leçons, durées, descriptions) inséré en brouillon | opus-4-8 | P2 | 5 j |
+| **AI Lesson Generator** | Plan de leçon → contenu texte structuré + script vidéo + ressources | opus-4-8 | P2 | 3 j |
+| **AI Quiz Generator** | Contenu de leçon → QCM/V-F avec distracteurs plausibles + corrigés (JSON schema → banque de questions) | opus-4-8 | P2 | 3 j |
+| **AI Assignment/Exam Generator** | Devoirs + grilles de correction ; examens équilibrés par difficulté | opus-4-8 | P2 | 3 j |
+| **AI Assistant (instructeur)** | Panneau latéral dans le wizard de création : améliorer titre/description SEO, suggérer prix marché | opus-4-8 | P2 | 3 j |
+| **AI Tutor (étudiant)** | Chat contextuel dans le player : répond en se basant SEULEMENT sur le contenu du cours (contexte injecté, garde-fous), explique en créole simple | opus-4-8 (haiku si volume) | P3 | 6 j |
+| **AI Translator** | Traduction FR↔HT↔EN↔ES des cours/descriptions/UI en lot (Batch API) ; le créole est un différenciateur majeur | haiku-4-5 / opus pour HT | P2 | 4 j |
+| **AI Content Improver** | Reformuler/raccourcir/corriger descriptions et leçons | haiku-4-5 | P2 | 2 j |
+| **AI Resume Generator** | CV de compétences généré depuis les cours complétés + certificats (PDF export) | opus-4-8 | P3 | 3 j |
+| **AI Chatbot (support public)** | FAQ + navigation guidée (« Kijan pou m peye ak MonCash ? »), escalade humaine WhatsApp | haiku-4-5 | P3 | 4 j |
+| **AI Voice** | Lecture audio des leçons texte (TTS externe type ElevenLabs/Polly — Claude ne fait pas de TTS) ; utile offline/faible littératie | TTS tiers | P3 | 4 j |
+| Sous-titres/transcription vidéo | Whisper/AssemblyAI puis résumé Claude par leçon | tiers + haiku | P3 | 4 j |
+
+**Garde-fous** : l'IA propose, l'instructeur valide (jamais de publication auto) ; mention « Généré avec l'aide de l'IA » optionnelle ; quotas mensuels par plan ; pas de données personnelles dans les prompts.
+
+---
+
+## 11. UX/UI — Système de design KLASYO
+
+### 11.1 Fondations (extraites de la landing existante — déjà en prod)
+
+```css
+:root{
+  --blue:#1d4ed8; --blue-dark:#1e3a8a; --blue-mid:#2563eb; --blue-light:#3b82f6;
+  --blue-pale:#eff6ff; --green:#16a34a; --green-dark:#166534; --green-light:#22c55e;
+  --bg:#f8faff; --dark:#0c1524; --white:#fff;
+  --grad-main:linear-gradient(135deg,#1d4ed8,#1e3a8a);
+  --grad-hero:linear-gradient(135deg,#1d4ed8 0%,#0f2d6b 60%,#16a34a 100%);
+  --radius:18px; --radius-lg:28px;
+  --shadow-sm:0 2px 12px rgba(29,78,216,.08); --shadow-md:0 8px 40px rgba(29,78,216,.12);
+  --font-display:'Sora',sans-serif; --font-body:'DM Sans',sans-serif;
+}
+```
+
+- **Bleu** = confiance/action (CTA primaires), **vert** = succès/argent/validation, **rouge #ef4444** réservé aux erreurs. Contraste AA minimum (texte #374151 sur blanc).
+- **Typo** : Sora (titres, chiffres KPI), DM Sans (corps). Échelle 12/14/16/20/24/32/40.
+- **Composants** : boutons pleins arrondis (radius 12, hauteur 44 px), cartes blanches ombre `--shadow-sm`, inputs à gros labels, badges pilules, toasts, skeletons.
+- **Implémentation sur LMSZAI sans fork** : `public/frontend/assets/css/klasyo-theme.css` chargé APRÈS `style.css`/`extra.css` dans `frontend/layouts/app.blade.php` (+ variables injectées via `dynamic-style.blade.php`) → on écrase couleurs, typos, radius, boutons, cartes. Les 6 autres thèmes LMSZAI sont désactivés (source de confusion).
+
+### 11.2 Audit UX écran par écran (platform)
+
+| Écran | Problèmes UX/UI constatés (démo LMSZAI) | Correctifs |
+|---|---|---|
+| Accueil | 8+ sections, 3 carrousels, textes lorem anglais, achievements démo | 5 sections max, contenu réel bilingue, 1 seul carrousel |
+| Header/nav | 2 niveaux de menus, liens morts démo, sélecteur devise confus | 1 barre : logo, recherche, Catégories, Enseigner, langue, panier, avatar |
+| Fiche cours | CTA noyé sous le fold, méta dispersées | carte d'achat sticky, hiérarchie prix→CTA→contenu |
+| Checkout | multi-étapes, champs inutiles, passerelles en vrac | 1 page : récap + choix passerelle filtré par devise + bouton unique |
+| Formulaires | labels flottants illisibles, erreurs en anglais | labels au-dessus, messages FR/HT, validation inline |
+| Player | sidebar dense, petits liens | onglets, cibles tactiles 44 px, plein écran mobile |
+| Dashboards | menus 20+ entrées, tableaux non responsives | §5 ; tableaux → cartes empilées en mobile |
+| Icônes | mélange FontAwesome/Feather | un seul set (Lucide/Feather), taille 20/24 |
+| Images | JPEG lourds non dimensionnés | WebP + `srcset` + lazy loading |
+
+### 11.3 Mobile-first & offline
+- Breakpoints : base = 360 px ; enrichissement progressif.
+- **PWA** (pattern TAGTOA POS déjà éprouvé) : manifest + service worker — app shell cache-first, pages cours network-first, **file d'attente hors-ligne** pour progression/quiz (IndexedDB, sync au retour réseau), téléchargement des leçons texte/audio pour lecture offline (P2-P3).
+- Poids cible première visite < 300 Ko CSS+JS (hors vidéo).
+
+---
+
+## 12. Performance, sécurité, SEO
+
+| Domaine | Actions | Phase |
+|---|---|---|
+| **Laravel** | `config:cache`, `route:cache`, `view:cache` au déploiement ; OPcache ; upgrade PHP 8.0→8.2 (platform) ; queues en `database` puis Redis | P1→P2 |
+| **Base de données** | index sur FK/colonnes filtrées (audit slow query log) ; éliminer les N+1 (eager loading) sur catalogue/dashboards ; pagination partout | P1 |
+| **Cache applicatif** | cache 5-15 min sur accueil/catalogue/settings (`Cache::remember`) ; Redis en P2 | P1 |
+| **Vidéo** | migrer vers **Bunny Stream** (ou Cloudflare Stream) : encodage adaptatif, CDN, protection des liens signés — le VPS ne doit JAMAIS servir la vidéo | P2 |
+| **Assets** | WebP, minification, `defer`, purge CSS des thèmes morts ; CDN statique (BunnyCDN) | P1-P2 |
+| **API/mobile** | endpoints JSON propres (LMSZAI a déjà une base API) ; rate limiting ; pagination cursor | P2 |
+| **SEO** | métas dynamiques par cours (title/description/OG), sitemap.xml, schema.org `Course`/`Organization`, URLs propres, hreflang fr/ht/en/es, blog actif | P1-P2 |
+| **Sécurité** | P0 §2.2 + : rotation des secrets exposés, HTTPS forcé + HSTS, headers CSP/X-Frame, 2FA admin, rate limit login/OTP, sauvegardes quotidiennes DB+uploads hors serveur (test de restauration mensuel !), audit log des actions admin (pattern TAGTOA `AuditService`), validation stricte des uploads de preuves | P0-P1 |
+| **Monitoring** | uptime (UptimeRobot), erreurs (Sentry/Flare ou log alerting), smoke tests post-deploy via klasyo-ops | P1 |
+
+---
+
+## 13. Feuille de route
+
+### PHASE 1 — MVP « Louvri pòt la » (6-8 semaines, ~45 j·dev)
+> Objectif : plateforme sûre, brandée KLASYO, achetable en HTG et USD.
+
+1. **Semaine 1** : P0 sécurité (§2.2) — zips hors web, .env corrigés, school réparé, APP_KEY, debug off. ✔ mesurable : school en ligne, scan sécurité propre.
+2. **S1-2** : rebranding complet (logo, `settings` DB, `klasyo-theme.css`, traduction FR + HT des textes publics, purge contenu démo, 1 seul thème actif).
+3. **S2-3** : Auth + onboarding wizard (§6) — inscription réactivée, choix de profil, comptes fonctionnels.
+4. **S3-5** : Paiements P0 — Payment Hub + **MonCash** + **Stripe** + mode manuel unifié (NatCash/Zelle) + file de validation admin.
+5. **S4-6** : dashboards simplifiés v1 (menus réduits, KPI de base) + certificats PDF avec QR + page `/verify`.
+6. **S6-8** : coupons, notifications email+WhatsApp de base, SEO on-page, monitoring, formation de l'équipe. **Lancement.**
+
+### PHASE 2 — PRO « Grandi » (3-4 mois, ~80 j·dev)
+1. Dashboards premium complets (§5, graphiques, rapports, marketing).
+2. SSO KLASYO Connect platform↔school + cross-sell org→école.
+3. Formations présentiel/hybride + calendrier + QR présence (§8).
+4. Paiements P1-P2 : PayPal, Binance Pay, CoinPayments, banques haïtiennes ; paiement en plusieurs fois + acompte.
+5. IA vague 1 : Course/Lesson/Quiz/Exam Generator + Translator + Content Improver (§10).
+6. Vidéo sur Bunny Stream ; Redis ; recherche Meilisearch ; PWA v1 ; analytics ; affiliation modernisée ; badges.
+
+### PHASE 3 — ENTERPRISE « Domine » (6-9 mois, ~120 j·dev)
+1. IA vague 2 : AI Tutor, Chatbot support, Resume Generator, Voice/TTS, transcription.
+2. Marketplace avancée (KLASYO Select, classements, pages instructeurs premium).
+3. Offline complet (leçons téléchargeables), apps mobiles (wrapper Capacitor ou Flutter sur l'API).
+4. Cartes étudiantes wallet + NFC (synergie TAGTOA), Open Badges, liste d'attente, géo-checkin.
+5. KLASYO Connect → OAuth2 complet ; API publique partenaires ; SLA, multi-serveur si trafic (séparation DB/web, load balancer).
+6. Conformité : factures normalisées, exports comptables, RGPD-like pour la diaspora.
+
+### Récapitulatif des estimations
+
+| Phase | Durée calendrier | Charge dev | Focus |
+|---|---|---|---|
+| MVP | 6-8 semaines | ~45 j | Sécurité, marque, paiements HT, simplicité |
+| PRO | 3-4 mois | ~80 j | Dashboards, SSO, présentiel, IA v1, vidéo CDN |
+| ENTERPRISE | 6-9 mois | ~120 j | IA v2, marketplace, offline, NFC, échelle |
+
+---
+
+## Annexe A — Règles d'ingénierie (pour toute la suite du chantier)
+1. **Jamais de modification destructive** des tables des scripts achetés : nouvelles tables `klasyo_*`, colonnes ajoutées nullable, addons en ServiceProviders séparés.
+2. Tout déploiement passe par le canal `klasyo-ops` (backup avant écriture, aucun secret dans les logs publics).
+3. Chaque phase livre des incréments testables chaque semaine ; smoke test public après chaque déploiement.
+4. Montants en unités mineures ; idempotence sur tout ce qui encaisse ; audit log sur tout ce qui touche l'argent.

--- a/.github/scripts/KLASYO_PLAN.md
+++ b/.github/scripts/KLASYO_PLAN.md
@@ -1,0 +1,53 @@
+# KLASYO.ORG — Plan de travail (platform + school)
+
+> Canal d'exécution : workflow `.github/workflows/klasyo-ops.yml` (SSH vers le VPS
+> avec les secrets du deploy TAGTOA). Les logs Actions sont PUBLICS : aucun secret
+> ne doit jamais y apparaître.
+
+## État des lieux (inspection 2026-07-14)
+
+| App | Chemin | Script | Framework | DB |
+|---|---|---|---|---|
+| Landing | `public_html/index.html` | statique « KLASYO — La Plateforme Éducative du Futur en Haïti » | — | — |
+| PLATFORM | `public_html/platform/` | **LMSZAI** build 31 (Zainik Themes) — vente de cours/formations | Laravel 9 / PHP 8.0 | 139 tables, `users` (1) |
+| SCHOOL | `public_html/school/` | **eSchool SaaS v1.9.3** — gestion d'établissements scolaires (multi-écoles, `school_id`) | Laravel 10 / PHP 8.1 | 45 tables, `users` (1) |
+
+### Problèmes détectés (en attente de décision utilisateur)
+1. **Zips de code source téléchargeables dans public_html** : `platform/klasyo.zip` (147 MB),
+   `school/school.zip` (568 MB), `school/source_code.zip`, zips d'installation/update.
+   → À déplacer hors du web (ex. `~/backups_klasyo/`).
+2. `school/.env` : `APP_DEBUG=true` en production (fuite de secrets sur erreur).
+3. `platform/.env` : `APP_URL="webetud.com"` (mauvais domaine), `APP_ENV=local`.
+4. `https://klasyo.org` renvoie 403 depuis l'extérieur (à confirmer navigateur / firewall).
+
+## Chantier A — SSO « KLASYO Connect » (1 compte pour les 2 apps)
+
+Décision : platform (LMSZAI) = compte maître. Pont SSO signé (HMAC, jeton 60 s) :
+- platform : route `GET /klasyo-sso/authorize?redirect=...` (auth requise) → génère
+  `token = base64(payload) + HMAC_SHA256(payload, KLASYO_SSO_SECRET)` avec
+  `{email, name, exp}` → redirige vers school.
+- school : route `GET /klasyo-sso/callback?token=...` → vérifie signature + exp →
+  `User::firstOrCreate` par email (mot de passe aléatoire, rôle/école par défaut —
+  **mapping à confirmer par l'utilisateur**) → `Auth::login` → redirect dashboard.
+- Bouton « Se connecter avec KLASYO » sur l'écran de login school.
+- Secret partagé `KLASYO_SSO_SECRET` ajouté aux deux `.env` (généré sur le VPS,
+  jamais dans les logs).
+- Fichiers déposés en **addon** (nouveau ServiceProvider + routes dédiées) pour ne
+  pas casser les mises à jour des scripts achetés.
+
+## Chantier B — Frontend platform (LMSZAI) aux couleurs KLASYO
+
+Approche : thème par-dessus (override), pas de fork lourd du vendor :
+1. Extraire la marque de la landing racine (couleurs, polices) — inspection v3.
+2. `public/frontend/css/klasyo-theme.css` : variables CSS + overrides (boutons,
+   cartes cours, header/footer, typographie, espacement).
+3. Ajuster les vues Blade clés (header/footer/home) au minimum nécessaire ;
+   logo + textes via les settings LMSZAI en DB quand possible.
+4. Simplification UX : nav allégée, hero clair, parcours « voir cours → acheter »
+   en moins de clics.
+5. Vérifier après chaque déploiement : page publique OK (HTTP 200 + smoke).
+
+## Règles de sécurité du canal klasyo-ops
+- Lecture seule par défaut ; toute écriture = script dédié, revu, idempotent.
+- Jamais de `cat .env`, de credentials ni de dumps DB dans la sortie.
+- Backup avant modification (`cp -a fichier fichier.bak-YYYYMMDD`).

--- a/.github/scripts/klasyo-inspect.sh
+++ b/.github/scripts/klasyo-inspect.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Inspection LECTURE SEULE du domaine klasyo.org sur le VPS.
+# Exécuté via GitHub Actions (workflow klasyo-ops.yml) : ssh ... bash -s < ce_script
+# Ne modifie rien ; n'affiche jamais de secrets (.env exclu volontairement).
+set -uo pipefail
+
+echo "== Utilisateur SSH =="
+whoami
+echo "HOME=$HOME"
+
+echo
+echo "== Domaines présents (tous comptes visibles) =="
+ls -d /home/*/domains/*/ 2>/dev/null || true
+ls -d "$HOME"/domains/*/ 2>/dev/null || true
+
+echo
+echo "== Racine klasyo.org =="
+FOUND=""
+for d in /home/*/domains/klasyo.org "$HOME/domains/klasyo.org"; do
+  if [ -d "$d" ]; then
+    FOUND="$d"
+    echo "--- $d"
+    ls -la "$d"
+    echo
+    echo "--- Arborescence (2 niveaux, .env masqué) :"
+    find "$d" -maxdepth 2 -name '.env*' -prune -o -print 2>/dev/null | head -80
+  fi
+done
+
+if [ -z "$FOUND" ]; then
+  echo "(!) Aucun dossier domains/klasyo.org trouvé pour cet utilisateur."
+  echo "    Recherche large :"
+  find /home -maxdepth 4 -iname '*klasyo*' 2>/dev/null | head -20
+fi
+
+echo
+echo "== public_html de klasyo.org =="
+for p in /home/*/domains/klasyo.org/public_html "$HOME/domains/klasyo.org/public_html"; do
+  if [ -d "$p" ]; then
+    echo "--- $p"
+    ls -la "$p"
+  fi
+done
+
+echo
+echo "== Config web visible (DirectAdmin/Apache/Nginx) pour klasyo.org =="
+grep -rls "klasyo" /usr/local/directadmin/data/users/*/domains/ 2>/dev/null | head -10 || true
+grep -rls "klasyo" /etc/nginx /etc/httpd /etc/apache2 2>/dev/null | head -10 || true
+
+echo
+echo "== Fin de l'inspection =="

--- a/.github/scripts/klasyo-inspect.sh
+++ b/.github/scripts/klasyo-inspect.sh
@@ -1,51 +1,125 @@
 #!/usr/bin/env bash
-# Inspection LECTURE SEULE du domaine klasyo.org sur le VPS.
-# Exécuté via GitHub Actions (workflow klasyo-ops.yml) : ssh ... bash -s < ce_script
-# Ne modifie rien ; n'affiche jamais de secrets (.env exclu volontairement).
+# Inspection LECTURE SEULE v2 : identifier les scripts platform/ et school/ de klasyo.org.
+# Exécuté via GitHub Actions (klasyo-ops.yml) : ssh ... bash -s < ce_script
+#
+# SÉCURITÉ (le repo est PUBLIC, les logs Actions aussi) :
+# - ne JAMAIS afficher .env, mots de passe, clés, credentials DB
+# - n'afficher que : structure, frameworks, versions, noms de tables/colonnes
 set -uo pipefail
 
-echo "== Utilisateur SSH =="
-whoami
-echo "HOME=$HOME"
+ROOT="$HOME/domains/klasyo.org/public_html"
 
-echo
-echo "== Domaines présents (tous comptes visibles) =="
-ls -d /home/*/domains/*/ 2>/dev/null || true
-ls -d "$HOME"/domains/*/ 2>/dev/null || true
+echo "== Fichiers racine (identité du site) =="
+head -c 200 "$ROOT/documentation.txt" 2>/dev/null; echo
+head -c 600 "$ROOT/update_note.json" 2>/dev/null; echo
+echo "--- <title> de index.html :"
+grep -o -m1 '<title>[^<]*</title>' "$ROOT/index.html" 2>/dev/null || true
 
-echo
-echo "== Racine klasyo.org =="
-FOUND=""
-for d in /home/*/domains/klasyo.org "$HOME/domains/klasyo.org"; do
-  if [ -d "$d" ]; then
-    FOUND="$d"
-    echo "--- $d"
-    ls -la "$d"
-    echo
-    echo "--- Arborescence (2 niveaux, .env masqué) :"
-    find "$d" -maxdepth 2 -name '.env*' -prune -o -print 2>/dev/null | head -80
+# Petit assistant PHP : identifie la DB depuis .env (Laravel) ou config CI,
+# se connecte, et n'affiche QUE des noms de tables/colonnes (jamais de credentials).
+PHPTMP="$(mktemp /tmp/klasyo_dbinfo_XXXX.php)"
+cat > "$PHPTMP" <<'PHPEOF'
+<?php
+$dir = $argv[1];
+$host='localhost'; $db=null; $user=null; $pass=null;
+$envfile = "$dir/.env";
+if (is_file($envfile)) {
+    foreach (file($envfile, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $l) {
+        if (preg_match('/^(DB_HOST|DB_DATABASE|DB_USERNAME|DB_PASSWORD)\s*=\s*(.*)$/', $l, $m)) {
+            $v = trim($m[2], " \t\"'");
+            if ($m[1]=='DB_HOST') $host=$v;
+            if ($m[1]=='DB_DATABASE') $db=$v;
+            if ($m[1]=='DB_USERNAME') $user=$v;
+            if ($m[1]=='DB_PASSWORD') $pass=$v;
+        }
+    }
+} elseif (is_file("$dir/application/config/database.php")) {
+    if (!defined('BASEPATH')) define('BASEPATH', '1');
+    if (!defined('ENVIRONMENT')) define('ENVIRONMENT', 'production');
+    @include "$dir/application/config/database.php";
+    if (isset($db_config)) { /* rien */ }
+    if (isset($db) && is_array($db) && isset($db['default'])) {
+        $c = $db['default'];
+        $host = $c['hostname'] ?? 'localhost';
+        $dbn  = $c['database'] ?? null;
+        $user = $c['username'] ?? null;
+        $pass = $c['password'] ?? null;
+        $db = $dbn;
+    }
+}
+if (!$db || !$user) { echo "DB: introuvable/illisible pour $dir\n"; exit(0); }
+echo "DB: config trouvée (credentials masqués)\n";
+mysqli_report(MYSQLI_REPORT_OFF);
+$m = @mysqli_connect($host, $user, $pass, $db);
+if (!$m) { echo "DB: connexion impossible (".mysqli_connect_errno().")\n"; exit(0); }
+$res = mysqli_query($m, 'SHOW TABLES');
+$tables = [];
+while ($r = mysqli_fetch_row($res)) $tables[] = $r[0];
+echo "DB: ".count($tables)." tables au total\n";
+$interest = array_values(array_filter($tables, function($t){
+    return preg_match('/user|student|staff|admin|role|login|auth|enrol|purchase|payment/i', $t);
+}));
+echo "Tables auth/vente pertinentes:\n";
+foreach (array_slice($interest, 0, 30) as $t) echo "  - $t\n";
+foreach ($tables as $t) {
+    if (preg_match('/^(users|user|tbl_users|staff)$/i', $t)) {
+        echo "Colonnes de `$t`:\n";
+        $rc = mysqli_query($m, "SHOW COLUMNS FROM `$t`");
+        while ($c = mysqli_fetch_assoc($rc)) echo "    ".$c['Field']." (".$c['Type'].")\n";
+        $cnt = mysqli_fetch_row(mysqli_query($m, "SELECT COUNT(*) FROM `$t`"));
+        echo "    => ".$cnt[0]." lignes\n";
+    }
+}
+PHPEOF
+
+for APP in platform school; do
+  D="$ROOT/$APP"
+  echo
+  echo "########################################"
+  echo "== APPLICATION: $APP ($D) =="
+  echo "########################################"
+  [ -d "$D" ] || { echo "(absent)"; continue; }
+
+  echo "--- Contenu racine :"
+  ls -la "$D" | head -40
+
+  echo "--- Détection framework :"
+  [ -f "$D/artisan" ] && echo "  * Laravel (artisan présent)"
+  [ -d "$D/application" ] && [ -f "$D/index.php" ] && echo "  * CodeIgniter (application/ présent)"
+  [ -f "$D/wp-config.php" ] && echo "  * WordPress"
+
+  if [ -f "$D/composer.json" ]; then
+    echo "--- composer.json (name/description/laravel) :"
+    grep -E '"(name|description|laravel/framework|php)"' "$D/composer.json" | head -8
   fi
+  if [ -f "$D/package.json" ]; then
+    echo "--- package.json (name/version) :"
+    grep -E '"(name|version)"' "$D/package.json" | head -4
+  fi
+
+  echo "--- Indices d'identité du script :"
+  for f in "$D/documentation.txt" "$D/update_note.json" "$D/version.php" "$D/VERSION" "$D/readme.txt" "$D/README.md"; do
+    [ -f "$f" ] && { echo "  [$f]"; head -c 400 "$f" | tr -d '\r'; echo; }
+  done
+  # title de la page d'accueil ou du login (vues Laravel/CI)
+  grep -rlo -m1 --include='*.blade.php' 'APP_NAME\|config(.app.name' "$D/resources/views" 2>/dev/null | head -2 || true
+  if [ -d "$D/application" ]; then
+    ls "$D/application/config" 2>/dev/null | head -20
+    grep -o "\$config\['version'\][^;]*;" "$D/application/config/"*.php 2>/dev/null | head -3
+  fi
+
+  echo "--- Config publique (.env : clés NON sensibles uniquement) :"
+  if [ -f "$D/.env" ]; then
+    grep -E '^(APP_NAME|APP_ENV|APP_DEBUG|APP_URL|DB_CONNECTION|PURCHASE_CODE)=' "$D/.env" | sed 's/PURCHASE_CODE=.*/PURCHASE_CODE=(masqué)/'
+    echo "  (toutes les autres clés .env sont volontairement masquées)"
+  else
+    echo "  (pas de .env)"
+  fi
+
+  echo "--- Base de données (tables/colonnes seulement) :"
+  php "$PHPTMP" "$D" 2>&1 | head -80
 done
 
-if [ -z "$FOUND" ]; then
-  echo "(!) Aucun dossier domains/klasyo.org trouvé pour cet utilisateur."
-  echo "    Recherche large :"
-  find /home -maxdepth 4 -iname '*klasyo*' 2>/dev/null | head -20
-fi
-
+rm -f "$PHPTMP"
 echo
-echo "== public_html de klasyo.org =="
-for p in /home/*/domains/klasyo.org/public_html "$HOME/domains/klasyo.org/public_html"; do
-  if [ -d "$p" ]; then
-    echo "--- $p"
-    ls -la "$p"
-  fi
-done
-
-echo
-echo "== Config web visible (DirectAdmin/Apache/Nginx) pour klasyo.org =="
-grep -rls "klasyo" /usr/local/directadmin/data/users/*/domains/ 2>/dev/null | head -10 || true
-grep -rls "klasyo" /etc/nginx /etc/httpd /etc/apache2 2>/dev/null | head -10 || true
-
-echo
-echo "== Fin de l'inspection =="
+echo "== Fin de l'inspection v2 =="

--- a/.github/scripts/klasyo-inspect.sh
+++ b/.github/scripts/klasyo-inspect.sh
@@ -1,125 +1,107 @@
 #!/usr/bin/env bash
-# Inspection LECTURE SEULE v2 : identifier les scripts platform/ et school/ de klasyo.org.
+# Inspection LECTURE SEULE v3 : frontend LMSZAI (platform), routing web, marque KLASYO.
 # Exécuté via GitHub Actions (klasyo-ops.yml) : ssh ... bash -s < ce_script
 #
-# SÉCURITÉ (le repo est PUBLIC, les logs Actions aussi) :
-# - ne JAMAIS afficher .env, mots de passe, clés, credentials DB
-# - n'afficher que : structure, frameworks, versions, noms de tables/colonnes
+# SÉCURITÉ (logs publics) : jamais de contenu .env / credentials / clés.
+# Les tests HTTP n'affichent QUE des codes de statut.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
+P="$ROOT/platform"
+S="$ROOT/school"
 
-echo "== Fichiers racine (identité du site) =="
-head -c 200 "$ROOT/documentation.txt" 2>/dev/null; echo
-head -c 600 "$ROOT/update_note.json" 2>/dev/null; echo
-echo "--- <title> de index.html :"
-grep -o -m1 '<title>[^<]*</title>' "$ROOT/index.html" 2>/dev/null || true
+echo "== 1. Tests HTTP depuis le VPS (codes de statut seulement) =="
+for u in "https://klasyo.org/" "https://klasyo.org/platform/" "https://klasyo.org/platform/public/" \
+         "https://klasyo.org/school/" "https://klasyo.org/school/public/" ; do
+  code=$(curl -sk -o /dev/null -m 15 -w "%{http_code}" "$u")
+  echo "  $u -> $code"
+done
+echo "  -- exposition potentielle (on veut 403/404 partout ici) :"
+for u in "https://klasyo.org/platform/.env" "https://klasyo.org/school/.env" \
+         "https://klasyo.org/platform/klasyo.zip" "https://klasyo.org/school/school.zip" \
+         "https://klasyo.org/school/source_code.zip"; do
+  code=$(curl -sk -o /dev/null -m 15 -r 0-0 -w "%{http_code}" "$u")
+  echo "  $u -> $code"
+done
 
-# Petit assistant PHP : identifie la DB depuis .env (Laravel) ou config CI,
-# se connecte, et n'affiche QUE des noms de tables/colonnes (jamais de credentials).
-PHPTMP="$(mktemp /tmp/klasyo_dbinfo_XXXX.php)"
+echo
+echo "== 2. Réécriture d'URL (comment /platform est servi) =="
+echo "--- $ROOT/.htaccess :"
+cat "$ROOT/.htaccess" 2>/dev/null || echo "(absent)"
+echo "--- $P/.htaccess :"
+cat "$P/.htaccess" 2>/dev/null || echo "(absent)"
+echo "--- titre de $P/index.html (fichier statique à la racine platform) :"
+grep -o -m1 '<title>[^<]*</title>' "$P/index.html" 2>/dev/null || echo "(pas de title)"
+
+echo
+echo "== 3. Marque KLASYO (extraite de la landing racine) =="
+echo "--- Couleurs les plus utilisées :"
+grep -oE '#[0-9a-fA-F]{6}\b' "$ROOT/index.html" | tr 'A-F' 'a-f' | sort | uniq -c | sort -rn | head -12
+echo "--- Variables CSS :"
+grep -oE '\-\-[a-z0-9-]+:\s*[^;}]{1,60}' "$ROOT/index.html" | sort -u | head -25
+echo "--- Polices :"
+grep -oE 'font-family:[^;}]{1,80}' "$ROOT/index.html" | sort -u | head -8
+grep -oE 'fonts.googleapis.com/css2?\?family=[^"'\'' ]*' "$ROOT/index.html" | sort -u | head -5
+
+echo
+echo "== 4. Structure frontend LMSZAI (platform) =="
+echo "--- resources/views (niveau 1) :"
+ls "$P/resources/views" 2>/dev/null
+echo "--- resources/views/frontend (si présent) :"
+ls "$P/resources/views/frontend" 2>/dev/null | head -40
+echo "--- thèmes éventuels :"
+ls -d "$P"/resources/views/*/ 2>/dev/null | head -20
+echo "--- public/ (niveau 1) :"
+ls "$P/public" 2>/dev/null
+echo "--- public/frontend (assets du thème) :"
+ls "$P/public/frontend" 2>/dev/null | head -30
+
+echo
+echo "== 5. Routing LMSZAI (60 premières lignes de routes/web.php) =="
+head -60 "$P/routes/web.php" 2>/dev/null
+
+echo
+echo "== 6. Page d'accueil LMSZAI : quel contrôleur/vue ? =="
+grep -rn "function index" "$P/app/Http/Controllers/Frontend"*.php 2>/dev/null | head -5 || true
+ls "$P/app/Http/Controllers" 2>/dev/null | head -25
+echo "--- vues home probables :"
+find "$P/resources/views" -maxdepth 3 -iname '*home*' -o -maxdepth 3 -iname '*landing*' -o -maxdepth 3 -iname '*index*' 2>/dev/null | grep -v vendor | head -15
+
+echo
+echo "== 7. Réglages d'apparence stockés en DB (LMSZAI settings) =="
+PHPTMP="$(mktemp /tmp/klasyo_settings_XXXX.php)"
 cat > "$PHPTMP" <<'PHPEOF'
 <?php
 $dir = $argv[1];
 $host='localhost'; $db=null; $user=null; $pass=null;
-$envfile = "$dir/.env";
-if (is_file($envfile)) {
-    foreach (file($envfile, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $l) {
-        if (preg_match('/^(DB_HOST|DB_DATABASE|DB_USERNAME|DB_PASSWORD)\s*=\s*(.*)$/', $l, $m)) {
-            $v = trim($m[2], " \t\"'");
-            if ($m[1]=='DB_HOST') $host=$v;
-            if ($m[1]=='DB_DATABASE') $db=$v;
-            if ($m[1]=='DB_USERNAME') $user=$v;
-            if ($m[1]=='DB_PASSWORD') $pass=$v;
-        }
-    }
-} elseif (is_file("$dir/application/config/database.php")) {
-    if (!defined('BASEPATH')) define('BASEPATH', '1');
-    if (!defined('ENVIRONMENT')) define('ENVIRONMENT', 'production');
-    @include "$dir/application/config/database.php";
-    if (isset($db_config)) { /* rien */ }
-    if (isset($db) && is_array($db) && isset($db['default'])) {
-        $c = $db['default'];
-        $host = $c['hostname'] ?? 'localhost';
-        $dbn  = $c['database'] ?? null;
-        $user = $c['username'] ?? null;
-        $pass = $c['password'] ?? null;
-        $db = $dbn;
+foreach (file("$dir/.env", FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $l) {
+    if (preg_match('/^(DB_HOST|DB_DATABASE|DB_USERNAME|DB_PASSWORD)\s*=\s*(.*)$/', $l, $m)) {
+        $v = trim($m[2], " \t\"'");
+        if ($m[1]=='DB_HOST') $host=$v;
+        if ($m[1]=='DB_DATABASE') $db=$v;
+        if ($m[1]=='DB_USERNAME') $user=$v;
+        if ($m[1]=='DB_PASSWORD') $pass=$v;
     }
 }
-if (!$db || !$user) { echo "DB: introuvable/illisible pour $dir\n"; exit(0); }
-echo "DB: config trouvée (credentials masqués)\n";
 mysqli_report(MYSQLI_REPORT_OFF);
 $m = @mysqli_connect($host, $user, $pass, $db);
-if (!$m) { echo "DB: connexion impossible (".mysqli_connect_errno().")\n"; exit(0); }
-$res = mysqli_query($m, 'SHOW TABLES');
-$tables = [];
-while ($r = mysqli_fetch_row($res)) $tables[] = $r[0];
-echo "DB: ".count($tables)." tables au total\n";
-$interest = array_values(array_filter($tables, function($t){
-    return preg_match('/user|student|staff|admin|role|login|auth|enrol|purchase|payment/i', $t);
-}));
-echo "Tables auth/vente pertinentes:\n";
-foreach (array_slice($interest, 0, 30) as $t) echo "  - $t\n";
-foreach ($tables as $t) {
-    if (preg_match('/^(users|user|tbl_users|staff)$/i', $t)) {
-        echo "Colonnes de `$t`:\n";
-        $rc = mysqli_query($m, "SHOW COLUMNS FROM `$t`");
-        while ($c = mysqli_fetch_assoc($rc)) echo "    ".$c['Field']." (".$c['Type'].")\n";
-        $cnt = mysqli_fetch_row(mysqli_query($m, "SELECT COUNT(*) FROM `$t`"));
-        echo "    => ".$cnt[0]." lignes\n";
+if (!$m) { echo "DB: connexion impossible\n"; exit(0); }
+// tables de réglages fréquentes dans LMSZAI
+foreach (['settings','general_settings','home_settings','theme_settings'] as $t) {
+    $r = @mysqli_query($m, "SHOW COLUMNS FROM `$t`");
+    if (!$r) continue;
+    $cols = [];
+    while ($c = mysqli_fetch_assoc($r)) $cols[] = $c['Field'];
+    echo "table `$t`: ".implode(', ', array_slice($cols,0,20))."\n";
+    // n'afficher que des clés/valeurs d'apparence, jamais de secrets
+    if (in_array('key', $cols) && in_array('value', $cols)) {
+        $q = mysqli_query($m, "SELECT `key`, LEFT(`value`,80) v FROM `$t` WHERE `key` REGEXP 'logo|color|colour|theme|title|name|favicon|font' LIMIT 25");
+        while ($row = mysqli_fetch_assoc($q)) echo "    {$row['key']} = {$row['v']}\n";
     }
 }
 PHPEOF
-
-for APP in platform school; do
-  D="$ROOT/$APP"
-  echo
-  echo "########################################"
-  echo "== APPLICATION: $APP ($D) =="
-  echo "########################################"
-  [ -d "$D" ] || { echo "(absent)"; continue; }
-
-  echo "--- Contenu racine :"
-  ls -la "$D" | head -40
-
-  echo "--- Détection framework :"
-  [ -f "$D/artisan" ] && echo "  * Laravel (artisan présent)"
-  [ -d "$D/application" ] && [ -f "$D/index.php" ] && echo "  * CodeIgniter (application/ présent)"
-  [ -f "$D/wp-config.php" ] && echo "  * WordPress"
-
-  if [ -f "$D/composer.json" ]; then
-    echo "--- composer.json (name/description/laravel) :"
-    grep -E '"(name|description|laravel/framework|php)"' "$D/composer.json" | head -8
-  fi
-  if [ -f "$D/package.json" ]; then
-    echo "--- package.json (name/version) :"
-    grep -E '"(name|version)"' "$D/package.json" | head -4
-  fi
-
-  echo "--- Indices d'identité du script :"
-  for f in "$D/documentation.txt" "$D/update_note.json" "$D/version.php" "$D/VERSION" "$D/readme.txt" "$D/README.md"; do
-    [ -f "$f" ] && { echo "  [$f]"; head -c 400 "$f" | tr -d '\r'; echo; }
-  done
-  # title de la page d'accueil ou du login (vues Laravel/CI)
-  grep -rlo -m1 --include='*.blade.php' 'APP_NAME\|config(.app.name' "$D/resources/views" 2>/dev/null | head -2 || true
-  if [ -d "$D/application" ]; then
-    ls "$D/application/config" 2>/dev/null | head -20
-    grep -o "\$config\['version'\][^;]*;" "$D/application/config/"*.php 2>/dev/null | head -3
-  fi
-
-  echo "--- Config publique (.env : clés NON sensibles uniquement) :"
-  if [ -f "$D/.env" ]; then
-    grep -E '^(APP_NAME|APP_ENV|APP_DEBUG|APP_URL|DB_CONNECTION|PURCHASE_CODE)=' "$D/.env" | sed 's/PURCHASE_CODE=.*/PURCHASE_CODE=(masqué)/'
-    echo "  (toutes les autres clés .env sont volontairement masquées)"
-  else
-    echo "  (pas de .env)"
-  fi
-
-  echo "--- Base de données (tables/colonnes seulement) :"
-  php "$PHPTMP" "$D" 2>&1 | head -80
-done
-
+php "$PHPTMP" "$P" 2>&1 | head -60
 rm -f "$PHPTMP"
+
 echo
-echo "== Fin de l'inspection v2 =="
+echo "== Fin de l'inspection v3 =="

--- a/.github/scripts/klasyo-inspect.sh
+++ b/.github/scripts/klasyo-inspect.sh
@@ -1,74 +1,13 @@
 #!/usr/bin/env bash
-# Inspection LECTURE SEULE v3 : frontend LMSZAI (platform), routing web, marque KLASYO.
-# Exécuté via GitHub Actions (klasyo-ops.yml) : ssh ... bash -s < ce_script
-#
-# SÉCURITÉ (logs publics) : jamais de contenu .env / credentials / clés.
-# Les tests HTTP n'affichent QUE des codes de statut.
+# Inspection LECTURE SEULE v4 : thème actif LMSZAI + diagnostic /school/ qui ne répond pas.
+# Exécuté via GitHub Actions (klasyo-ops.yml). Logs publics : jamais de secrets.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
 S="$ROOT/school"
 
-echo "== 1. Tests HTTP depuis le VPS (codes de statut seulement) =="
-for u in "https://klasyo.org/" "https://klasyo.org/platform/" "https://klasyo.org/platform/public/" \
-         "https://klasyo.org/school/" "https://klasyo.org/school/public/" ; do
-  code=$(curl -sk -o /dev/null -m 15 -w "%{http_code}" "$u")
-  echo "  $u -> $code"
-done
-echo "  -- exposition potentielle (on veut 403/404 partout ici) :"
-for u in "https://klasyo.org/platform/.env" "https://klasyo.org/school/.env" \
-         "https://klasyo.org/platform/klasyo.zip" "https://klasyo.org/school/school.zip" \
-         "https://klasyo.org/school/source_code.zip"; do
-  code=$(curl -sk -o /dev/null -m 15 -r 0-0 -w "%{http_code}" "$u")
-  echo "  $u -> $code"
-done
-
-echo
-echo "== 2. Réécriture d'URL (comment /platform est servi) =="
-echo "--- $ROOT/.htaccess :"
-cat "$ROOT/.htaccess" 2>/dev/null || echo "(absent)"
-echo "--- $P/.htaccess :"
-cat "$P/.htaccess" 2>/dev/null || echo "(absent)"
-echo "--- titre de $P/index.html (fichier statique à la racine platform) :"
-grep -o -m1 '<title>[^<]*</title>' "$P/index.html" 2>/dev/null || echo "(pas de title)"
-
-echo
-echo "== 3. Marque KLASYO (extraite de la landing racine) =="
-echo "--- Couleurs les plus utilisées :"
-grep -oE '#[0-9a-fA-F]{6}\b' "$ROOT/index.html" | tr 'A-F' 'a-f' | sort | uniq -c | sort -rn | head -12
-echo "--- Variables CSS :"
-grep -oE '\-\-[a-z0-9-]+:\s*[^;}]{1,60}' "$ROOT/index.html" | sort -u | head -25
-echo "--- Polices :"
-grep -oE 'font-family:[^;}]{1,80}' "$ROOT/index.html" | sort -u | head -8
-grep -oE 'fonts.googleapis.com/css2?\?family=[^"'\'' ]*' "$ROOT/index.html" | sort -u | head -5
-
-echo
-echo "== 4. Structure frontend LMSZAI (platform) =="
-echo "--- resources/views (niveau 1) :"
-ls "$P/resources/views" 2>/dev/null
-echo "--- resources/views/frontend (si présent) :"
-ls "$P/resources/views/frontend" 2>/dev/null | head -40
-echo "--- thèmes éventuels :"
-ls -d "$P"/resources/views/*/ 2>/dev/null | head -20
-echo "--- public/ (niveau 1) :"
-ls "$P/public" 2>/dev/null
-echo "--- public/frontend (assets du thème) :"
-ls "$P/public/frontend" 2>/dev/null | head -30
-
-echo
-echo "== 5. Routing LMSZAI (60 premières lignes de routes/web.php) =="
-head -60 "$P/routes/web.php" 2>/dev/null
-
-echo
-echo "== 6. Page d'accueil LMSZAI : quel contrôleur/vue ? =="
-grep -rn "function index" "$P/app/Http/Controllers/Frontend"*.php 2>/dev/null | head -5 || true
-ls "$P/app/Http/Controllers" 2>/dev/null | head -25
-echo "--- vues home probables :"
-find "$P/resources/views" -maxdepth 3 -iname '*home*' -o -maxdepth 3 -iname '*landing*' -o -maxdepth 3 -iname '*index*' 2>/dev/null | grep -v vendor | head -15
-
-echo
-echo "== 7. Réglages d'apparence stockés en DB (LMSZAI settings) =="
+echo "== 1. Réglages d'apparence LMSZAI (option_key/option_value) =="
 PHPTMP="$(mktemp /tmp/klasyo_settings_XXXX.php)"
 cat > "$PHPTMP" <<'PHPEOF'
 <?php
@@ -86,22 +25,45 @@ foreach (file("$dir/.env", FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $l) {
 mysqli_report(MYSQLI_REPORT_OFF);
 $m = @mysqli_connect($host, $user, $pass, $db);
 if (!$m) { echo "DB: connexion impossible\n"; exit(0); }
-// tables de réglages fréquentes dans LMSZAI
-foreach (['settings','general_settings','home_settings','theme_settings'] as $t) {
-    $r = @mysqli_query($m, "SHOW COLUMNS FROM `$t`");
-    if (!$r) continue;
-    $cols = [];
-    while ($c = mysqli_fetch_assoc($r)) $cols[] = $c['Field'];
-    echo "table `$t`: ".implode(', ', array_slice($cols,0,20))."\n";
-    // n'afficher que des clés/valeurs d'apparence, jamais de secrets
-    if (in_array('key', $cols) && in_array('value', $cols)) {
-        $q = mysqli_query($m, "SELECT `key`, LEFT(`value`,80) v FROM `$t` WHERE `key` REGEXP 'logo|color|colour|theme|title|name|favicon|font' LIMIT 25");
-        while ($row = mysqli_fetch_assoc($q)) echo "    {$row['key']} = {$row['v']}\n";
-    }
-}
+$q = mysqli_query($m, "SELECT option_key, LEFT(option_value,70) v FROM settings WHERE option_key REGEXP 'theme|logo|color|colour|title|site|name|favicon|font|version' ORDER BY option_key LIMIT 40");
+if ($q) while ($row = mysqli_fetch_assoc($q)) echo "  {$row['option_key']} = {$row['v']}\n";
 PHPEOF
-php "$PHPTMP" "$P" 2>&1 | head -60
+php "$PHPTMP" "$P" 2>&1 | head -50
 rm -f "$PHPTMP"
 
 echo
-echo "== Fin de l'inspection v3 =="
+echo "== 2. Diagnostic /school/ (ne répond pas) =="
+echo "--- $S/.htaccess :"
+cat "$S/.htaccess" 2>/dev/null || echo "(absent)"
+echo "--- $S/public (niveau 1, 20 max) :"
+ls "$S/public" 2>/dev/null | head -20
+echo "--- Test HTTP avec suivi de redirections (codes + URL finale, max 8s) :"
+for u in "https://klasyo.org/school/public/index.php" "https://klasyo.org/school/index.php"; do
+  out=$(curl -sk -o /dev/null -m 8 -w "%{http_code} redir=%{redirect_url}" "$u" 2>&1)
+  echo "  $u -> $out"
+done
+echo "--- Dernières erreurs Laravel school (message seulement, 5 lignes) :"
+L=$(ls -t "$S"/storage/logs/*.log 2>/dev/null | head -1)
+if [ -n "$L" ]; then
+  grep -oE '^\[[0-9 :-]+\] \w+\.\w+: [^{]{0,140}' "$L" | tail -5
+else
+  echo "(pas de log)"
+fi
+
+echo
+echo "== 3. Diagnostic /platform/ (000) : test avec redirections =="
+out=$(curl -sk -o /dev/null -m 8 -w "%{http_code} redir=%{redirect_url}" "https://klasyo.org/platform/index.php" 2>&1)
+echo "  /platform/index.php -> $out"
+out=$(curl -skL -o /dev/null -m 12 -w "final=%{http_code} url=%{url_effective} redirs=%{num_redirects}" "https://klasyo.org/platform/public/" 2>&1)
+echo "  /platform/public/ (suivi) -> $out"
+
+echo
+echo "== 4. Layout frontend LMSZAI : où le CSS est chargé =="
+for f in "$P/resources/views/frontend/layouts/app.blade.php" "$P/resources/views/frontend/layouts/master.blade.php" "$P/resources/views/layouts/app.blade.php"; do
+  [ -f "$f" ] && { echo "--- $f (balises link/css, 15 max) :"; grep -oE '<link[^>]{0,140}' "$f" | head -15; }
+done
+echo "--- fichiers layout frontend disponibles :"
+ls "$P/resources/views/frontend/layouts" 2>/dev/null | head -15
+
+echo
+echo "== Fin de l'inspection v4 =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,60 +1,50 @@
 #!/usr/bin/env bash
-# KLASYO — Étape H : platform/public/.htaccess garde le bloc LMSZAI d'origine
-# <FilesMatch ...>SetHandler application/x-lsphp80</FilesMatch> (PHP 8.0 = inactif ici),
-# qui prime sur mon AddHandler lsphp83 -> source. On convertit TOUTE référence lsphpNN
-# en lsphp83 dans les .htaccess de platform. Validation du corps HTML.
+# KLASYO — Diagnostic I : platform sert du source malgré une config .htaccess désormais
+# équivalente à school (qui exécute). On compare tout et on teste le cache LiteSpeed.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
-P="$ROOT/platform"
-STAMP="$(date +%Y%m%d-%H%M%S)"
+P="$ROOT/platform"; S="$ROOT/school"
 
-echo "== Références lsphp AVANT (platform) =="
-grep -rniE 'lsphp[0-9]+' "$P/.htaccess" "$P/public/.htaccess" 2>/dev/null || echo "  (aucune)"
+echo "== I1. /platform/public/ DIRECT (sans passer par le rewrite racine) — corps ? =="
+b=$(curl -sk -m 15 "https://klasyo.org/platform/public/" 2>/dev/null)
+echo "  code=$(curl -sk -o /dev/null -m 15 -w '%{http_code}' 'https://klasyo.org/platform/public/')"
+printf '%s' "$b" | grep -qiE '<\?php|Illuminate\\Contracts' && echo "  -> SOURCE" || { printf '%s' "$b" | grep -qiE '<!doctype|<html' && echo "  -> HTML" || echo "  -> autre: $(printf '%s' "$b" | head -c 40)"; }
 
-for f in "$P/.htaccess" "$P/public/.htaccess"; do
-  [ -f "$f" ] || continue
-  cp -a "$f" "$f.bak-H-$STAMP"
-  # Toute version lsphpNN -> lsphp83 (corrige le bloc FilesMatch LMSZAI d'origine)
-  sed -i -E 's#(application/x-lsphp)[0-9]+#\183#g' "$f"
-  echo "  corrigé : $(basename "$(dirname "$f")")/.htaccess"
+echo
+echo "== I2. Cache-buster : /platform/login?nocache=timestamp =="
+b=$(curl -sk -m 15 "https://klasyo.org/platform/login?nocache=$(date +%s)" 2>/dev/null)
+printf '%s' "$b" | grep -qiE '<\?php|Illuminate\\Contracts' && echo "  -> SOURCE (pas du cache)" || { printf '%s' "$b" | grep -qiE '<!doctype|<html' && echo "  -> HTML (c'était le cache !)" || echo "  -> autre"; }
+
+echo
+echo "== I3. En-têtes LiteSpeed cache (X-LiteSpeed-Cache / X-Powered-By) =="
+curl -skI -m 12 "https://klasyo.org/platform/login" 2>/dev/null | grep -iE 'x-litespeed|x-powered|x-lsadc|content-type|server:' | head -8
+
+echo
+echo "== I4. index.php à la racine de platform ? (servirait en source directement) =="
+ls -la "$P"/index.php 2>/dev/null && echo "  !!! index.php EXISTE à la racine platform" || echo "  pas d'index.php à la racine (OK)"
+echo "  --- fichiers .php à la racine platform :"
+ls "$P"/*.php 2>/dev/null | xargs -n1 basename 2>/dev/null | head -10
+
+echo
+echo "== I5. COMPARAISON root .htaccess : platform vs school =="
+echo "--- platform/.htaccess :"; cat -A "$P/.htaccess" | head -40
+echo "--- school/.htaccess :"; cat -A "$S/.htaccess" | head -40
+
+echo
+echo "== I6. COMPARAISON public/.htaccess : platform vs school =="
+echo "--- platform/public/.htaccess :"; cat "$P/public/.htaccess"
+echo "--- school/public/.htaccess :"; cat "$S/public/.htaccess"
+
+echo
+echo "== I7. Contexte PHP par répertoire (DirectAdmin/CloudLinux .user.ini, php version) =="
+for d in "$P" "$P/public" "$S" "$S/public"; do
+  for cfg in .htaccess.php_version .user.ini; do
+    [ -f "$d/$cfg" ] && { echo "  [$d/$cfg]"; head -5 "$d/$cfg"; }
+  done
 done
-
-echo "== Références lsphp APRÈS (platform, doivent toutes être 83) =="
-grep -rniE 'lsphp[0-9]+' "$P/.htaccess" "$P/public/.htaccess" 2>/dev/null
-
-echo
-echo "== Purge caches platform =="
-(cd "$P" && php artisan config:clear 2>&1 | tail -1)
-(cd "$P" && php artisan view:clear   2>&1 | tail -1)
+echo "  --- date de modif des public/index.php :"
+stat -c '%y %n' "$P/public/index.php" "$S/public/index.php" 2>/dev/null
 
 echo
-echo "== VALIDATION (corps HTML, jamais du source) =="
-check() {
-  local url="$1"
-  local body; body=$(curl -skL -m 15 "$url" 2>/dev/null)
-  local code; code=$(curl -skL -o /dev/null -m 15 -w "%{http_code}" "$url" 2>/dev/null)
-  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|Taylor Otwell|require_once __DIR__'; then
-    echo "  $url -> [$code] !!! SOURCE PHP"
-  elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
-    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
-  else
-    echo "  $url -> [$code] ? $(printf '%s' "$body" | head -c 45 | tr -d '\n\r')"
-  fi
-}
-check "https://klasyo.org/platform/"
-check "https://klasyo.org/platform/login"
-check "https://klasyo.org/platform/register"
-
-echo
-echo "== Rebrand : KLASYO / LMSzai dans la page d'accueil platform =="
-curl -skL -m 15 "https://klasyo.org/platform/" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | sort -u | head -3 || echo "  (aucun des deux)"
-
-echo
-echo "== Non-régression =="
-for u in "https://klasyo.org/" "https://klasyo.org/school/login"; do
-  echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
-done
-
-echo
-echo "== FIN étape H =="
+echo "== FIN diagnostic I =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,61 +1,44 @@
 #!/usr/bin/env bash
-# KLASYO — Étape J : la SEULE différence restante entre platform (source) et school (exécute)
-# est le bloc <FilesMatch "\.(php...)">SetHandler</FilesMatch> présent dans
-# platform/public/.htaccess et ABSENT de school/public/.htaccess. Sur ce LiteSpeed,
-# SetHandler + AddHandler cohabitent mal -> source. On retire le bloc SetHandler,
-# on garde uniquement AddHandler (config identique à school). Validation du corps.
+# KLASYO — Diagnostic K : confirmer que les apps FONCTIONNENT via /public/ (le 404 est
+# purement un souci de sous-dossier vs racine), et évaluer l'option sous-domaines.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
-P="$ROOT/platform"
-STAMP="$(date +%Y%m%d-%H%M%S)"
-PHTA="$P/public/.htaccess"
 
-cp -a "$PHTA" "$PHTA.bak-J-$STAMP" && echo "backup: platform/public/.htaccess.bak-J-$STAMP"
-
-echo "== AVANT (lignes handler) :"
-grep -niE 'filesmatch.*php|sethandler|addhandler' "$PHTA" || echo "  (aucune)"
-
-# Supprime le bloc FilesMatch qui cible les extensions PHP (celui avec SetHandler),
-# sans toucher un éventuel FilesMatch d'images.
-perl -0pi -e 's/<FilesMatch\s+"\\\.\(php[^"]*"\s*>\s*\n\s*SetHandler[^\n]*\n\s*<\/FilesMatch>\s*\n?//g' "$PHTA"
-
-echo "== APRÈS (lignes handler ; doit rester seulement AddHandler) :"
-grep -niE 'filesmatch.*php|sethandler|addhandler' "$PHTA" || echo "  (aucune)"
-
-echo
-echo "== Purge caches platform =="
-(cd "$P" && php artisan config:clear 2>&1 | tail -1)
-(cd "$P" && php artisan view:clear   2>&1 | tail -1)
-
-echo
-echo "== VALIDATION (corps HTML, jamais du source) — + cache-buster =="
+echo "== K1. Les apps rendent-elles la VRAIE page via /public/ ? =="
 check() {
   local url="$1"
   local body; body=$(curl -sk -m 15 "$url" 2>/dev/null)
   local code; code=$(curl -sk -o /dev/null -m 15 -w "%{http_code}" "$url" 2>/dev/null)
-  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|Taylor Otwell|require_once __DIR__'; then
-    echo "  $url -> [$code] !!! SOURCE PHP"
-  elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
-    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
+  local title; title=$(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)
+  local hasform; printf '%s' "$body" | grep -qiE '<form|password|login|connexion|sign in' && hasform="[formulaire présent]" || hasform=""
+  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts'; then
+    echo "  $url -> [$code] SOURCE"
   else
-    echo "  $url -> [$code] ? $(printf '%s' "$body" | head -c 45 | tr -d '\n\r')"
+    echo "  $url -> [$code] $title $hasform"
   fi
 }
 check "https://klasyo.org/platform/public/"
-check "https://klasyo.org/platform/?cb=$(date +%s)"
-check "https://klasyo.org/platform/login?cb=$(date +%s)"
-check "https://klasyo.org/platform/register?cb=$(date +%s)"
+check "https://klasyo.org/platform/public/login"
+check "https://klasyo.org/platform/public/register"
+check "https://klasyo.org/school/public/"
+check "https://klasyo.org/school/public/login"
 
 echo
-echo "== Rebrand KLASYO visible sur la page login ? =="
-curl -sk -m 15 "https://klasyo.org/platform/login?cb=$(date +%s)" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | sort -u | head -3 || echo "  (aucun)"
+echo "== K2. Sous-domaines déjà présents ? (domains/ du compte) =="
+ls -d /home/*/domains/*/ 2>/dev/null | sed 's#.*/domains/##' | head -40
 
 echo
-echo "== Non-régression =="
-for u in "https://klasyo.org/" "https://klasyo.org/school/login"; do
-  echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
+echo "== K3. Outil DirectAdmin CLI dispo pour créer un sous-domaine ? =="
+for b in /usr/local/directadmin/directadmin /usr/local/bin/da; do
+  [ -x "$b" ] && echo "  trouvé: $b" || echo "  absent: $b"
 done
+echo "  --- structure d'un sous-domaine existant (sub-dir sous public_html ?) :"
+ls -la "$ROOT" 2>/dev/null | grep -iE 'sub|platform|school|store|studio|app' | head -10
 
 echo
-echo "== FIN étape J =="
+echo "== K4. APP_URL actuels (indice de config racine attendue) =="
+grep -h '^APP_URL=' "$ROOT/platform/.env" "$ROOT/school/.env" 2>/dev/null
+
+echo
+echo "== FIN diagnostic K =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,104 +1,65 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 1, passe 2 : réparer le routing de /school (.htaccess)
-# + vérifier le format APP_KEY de platform.
-# Exécuté sur le VPS via GitHub Actions (klasyo-ops.yml). Logs publics : aucun secret.
-# Idempotent ; backups avant toute écriture.
+# KLASYO — Phase 1 / Semaine 1, passe 3 : DIAGNOSTIC du blocage /school (triangulation).
+# 1) statique  2) PHP minimal  3) Laravel via CLI — pour localiser la couche fautive.
+# Logs publics : aucun secret. Fichier de test supprimé en fin de script.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
-P="$ROOT/platform"
 S="$ROOT/school"
-STAMP="$(date +%Y%m%d-%H%M%S)"
 
-echo "########################################"
-echo "== ÉTAPE 1 : .htaccess de /school (boucle de réécriture en sous-dossier) =="
-echo "########################################"
-if grep -q 'KLASYO-SUBDIR-SAFE' "$S/.htaccess" 2>/dev/null; then
-  echo "  Déjà remplacé (marqueur présent) — rien à faire."
-else
-  cp -a "$S/.htaccess" "$S/.htaccess.bak-$STAMP" 2>/dev/null && echo "  backup : .htaccess.bak-$STAMP"
-  cat > "$S/.htaccess" <<'HTA'
-# KLASYO-SUBDIR-SAFE — Laravel servi depuis le sous-dossier /school/
-# (l'original, prévu pour une racine de domaine, bouclait sur public/public/…)
-<IfModule mod_rewrite.c>
-    <IfModule mod_negotiation.c>
-        Options -MultiViews -Indexes
-    </IfModule>
-
-    RewriteEngine On
-
-    # 1) Ce qui est déjà sous public/ n'est PAS réécrit (stoppe la boucle)
-    RewriteRule ^public/ - [L]
-
-    # 2) Fichier statique existant dans public/ -> le servir
-    RewriteCond %{DOCUMENT_ROOT}/school/public/$1 -f
-    RewriteRule ^(.*)$ public/$1 [L]
-
-    # 3) Tout le reste -> front controller Laravel
-    RewriteRule ^ public/index.php [L]
-
-    # En-tête Authorization pour l'API
-    RewriteCond %{HTTP:Authorization} .
-    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-    # En-tête school-code (multi-écoles eSchool)
-    RewriteCond %{HTTP:school-code} ^(.*)
-    RewriteRule .* - [E=HTTP_SCHOOL_CODE:%1]
-</IfModule>
-HTA
-  echo "  Nouveau .htaccess écrit."
-fi
-echo "  --- public/.htaccess de school présent ? "
-[ -f "$S/public/.htaccess" ] && echo "  oui ($(wc -c < "$S/public/.htaccess") octets)" || echo "  (!) NON — front controller sans réécriture interne"
+echo "== T1. Fichier STATIQUE dans school/public (robots.txt) =="
+out=$(curl -sk -o /dev/null -m 10 -w "%{http_code} time=%{time_total}s" "https://klasyo.org/school/public/robots.txt" 2>&1)
+echo "  /school/public/robots.txt -> $out"
+out=$(curl -sk -o /dev/null -m 10 -w "%{http_code} time=%{time_total}s" "https://klasyo.org/school/robots.txt" 2>&1)
+echo "  /school/robots.txt (via rewrite) -> $out"
 
 echo
-echo "########################################"
-echo "== ÉTAPE 2 : APP_KEY de platform (contrôle de format, valeur jamais affichée) =="
-echo "########################################"
-if grep -q '^APP_KEY=.\+' "$P/.env"; then
-  KEYLEN=$(grep '^APP_KEY=' "$P/.env" | head -1 | cut -d= -f2- | tr -d '"' | wc -c)
-  if grep -q '^APP_KEY=base64:' "$P/.env"; then
-    echo "  APP_KEY présente au format base64 (longueur $KEYLEN)."
-  else
-    echo "  APP_KEY présente au format LEGACY (longueur $KEYLEN) — fonctionnelle, ne pas régénérer."
-  fi
-else
-  echo "  (!) APP_KEY réellement vide — génération…"
-  cp -a "$P/.env" "$P/.env.bak-key-$STAMP"
-  (cd "$P" && php artisan key:generate --force 2>&1 | grep -iv 'base64')
-fi
+echo "== T2. PHP MINIMAL dans school/public =="
+TESTF="$S/public/klasyo_diag_$(date +%s).php"
+echo '<?php echo "OK-PHP-".PHP_VERSION;' > "$TESTF"
+BN=$(basename "$TESTF")
+out=$(curl -sk -m 15 -w " [%{http_code} time=%{time_total}s]" "https://klasyo.org/school/public/$BN" 2>&1 | head -c 120)
+echo "  /school/public/$BN -> $out"
+rm -f "$TESTF"
 
 echo
-echo "########################################"
-echo "== ÉTAPE 3 : santé de school côté CLI (sans secrets) =="
-echo "########################################"
-(cd "$S" && php artisan about 2>/dev/null | grep -E 'Environment|Debug Mode|Cache|Laravel Version' | head -6) \
-  || echo "  (artisan about indisponible)"
+echo "== T3. Même PHP minimal dans platform/public (référence qui marche) =="
+TESTP="$ROOT/platform/public/klasyo_diag_$(date +%s).php"
+echo '<?php echo "OK-PHP-".PHP_VERSION;' > "$TESTP"
+BNP=$(basename "$TESTP")
+out=$(curl -sk -m 15 -w " [%{http_code} time=%{time_total}s]" "https://klasyo.org/platform/public/$BNP" 2>&1 | head -c 120)
+echo "  /platform/public/$BNP -> $out"
+rm -f "$TESTP"
 
 echo
-echo "########################################"
-echo "== ÉTAPE 4 : vérification HTTP (codes + redirections) =="
-echo "########################################"
-for u in "https://klasyo.org/school" \
-         "https://klasyo.org/school/" \
-         "https://klasyo.org/school/public/index.php" \
-         "https://klasyo.org/school/login" \
-         "https://klasyo.org/platform/index.php" \
-         "https://klasyo.org/" ; do
-  out=$(curl -sk -o /dev/null -m 12 -w "%{http_code} redir=%{redirect_url}" "$u" 2>&1)
-  echo "  $u -> $out"
+echo "== T4. Laravel school exécuté DIRECTEMENT en CLI (simulate GET /) =="
+cd "$S/public"
+START=$(date +%s)
+timeout 30 php -d display_errors=1 -r '
+  $_SERVER["REQUEST_URI"] = "/school/";
+  $_SERVER["REQUEST_METHOD"] = "GET";
+  $_SERVER["HTTP_HOST"] = "klasyo.org";
+  $_SERVER["SCRIPT_NAME"] = "/school/public/index.php";
+  $_SERVER["SCRIPT_FILENAME"] = __DIR__ . "/index.php";
+  require "index.php";
+' > /tmp/klasyo_school_cli.html 2>&1
+RC=$?
+END=$(date +%s)
+echo "  exit=$RC durée=$((END-START))s taille=$(wc -c < /tmp/klasyo_school_cli.html) octets"
+echo "  --- premiers 200 caractères de la réponse :"
+head -c 200 /tmp/klasyo_school_cli.html | tr -d '\r' | head -5
+echo
+echo "  --- indices d'erreur éventuels :"
+grep -oiE '(fatal|exception|error|timed? ?out|curl|guzzle|connection)[^<]{0,80}' /tmp/klasyo_school_cli.html | head -5 || echo "  (aucun)"
+rm -f /tmp/klasyo_school_cli.html
+
+echo
+echo "== T5. Config PHP par répertoire (sélecteur DirectAdmin) =="
+for f in "$S/.user.ini" "$S/public/.user.ini" "$S/php.ini" "$ROOT/.htaccess"; do
+  [ -f "$f" ] && { echo "  --- $f :"; head -10 "$f"; } || echo "  (absent) $f"
 done
-echo "  -- avec suivi de redirections :"
-out=$(curl -skL -o /dev/null -m 15 -w "final=%{http_code} url=%{url_effective} redirs=%{num_redirects}" "https://klasyo.org/school/" 2>&1)
-echo "  /school/ -> $out"
+echo "  --- Handlers/SetHandler dans les .htaccess school :"
+grep -riE 'sethandler|addhandler|php' "$S/.htaccess" "$S/public/.htaccess" 2>/dev/null | head -10 || echo "  (rien)"
 
 echo
-echo "== ÉTAPE 5 : nouvelles erreurs Laravel school depuis aujourd'hui (messages tronqués) =="
-L=$(ls -t "$S"/storage/logs/*.log 2>/dev/null | head -1)
-if [ -n "$L" ]; then
-  grep -oE "^\[$(date +%Y-%m-%d)[0-9 :]*\] \w+\.\w+: [^{]{0,120}" "$L" | tail -5 || echo "  (aucune erreur aujourd'hui)"
-else
-  echo "  (pas de log)"
-fi
-
-echo
-echo "== FIN passe 2 =="
+echo "== FIN diagnostic passe 3 =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,50 +1,61 @@
 #!/usr/bin/env bash
-# KLASYO — Diagnostic I : platform sert du source malgré une config .htaccess désormais
-# équivalente à school (qui exécute). On compare tout et on teste le cache LiteSpeed.
+# KLASYO — Étape J : la SEULE différence restante entre platform (source) et school (exécute)
+# est le bloc <FilesMatch "\.(php...)">SetHandler</FilesMatch> présent dans
+# platform/public/.htaccess et ABSENT de school/public/.htaccess. Sur ce LiteSpeed,
+# SetHandler + AddHandler cohabitent mal -> source. On retire le bloc SetHandler,
+# on garde uniquement AddHandler (config identique à school). Validation du corps.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
-P="$ROOT/platform"; S="$ROOT/school"
+P="$ROOT/platform"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+PHTA="$P/public/.htaccess"
 
-echo "== I1. /platform/public/ DIRECT (sans passer par le rewrite racine) — corps ? =="
-b=$(curl -sk -m 15 "https://klasyo.org/platform/public/" 2>/dev/null)
-echo "  code=$(curl -sk -o /dev/null -m 15 -w '%{http_code}' 'https://klasyo.org/platform/public/')"
-printf '%s' "$b" | grep -qiE '<\?php|Illuminate\\Contracts' && echo "  -> SOURCE" || { printf '%s' "$b" | grep -qiE '<!doctype|<html' && echo "  -> HTML" || echo "  -> autre: $(printf '%s' "$b" | head -c 40)"; }
+cp -a "$PHTA" "$PHTA.bak-J-$STAMP" && echo "backup: platform/public/.htaccess.bak-J-$STAMP"
 
-echo
-echo "== I2. Cache-buster : /platform/login?nocache=timestamp =="
-b=$(curl -sk -m 15 "https://klasyo.org/platform/login?nocache=$(date +%s)" 2>/dev/null)
-printf '%s' "$b" | grep -qiE '<\?php|Illuminate\\Contracts' && echo "  -> SOURCE (pas du cache)" || { printf '%s' "$b" | grep -qiE '<!doctype|<html' && echo "  -> HTML (c'était le cache !)" || echo "  -> autre"; }
+echo "== AVANT (lignes handler) :"
+grep -niE 'filesmatch.*php|sethandler|addhandler' "$PHTA" || echo "  (aucune)"
 
-echo
-echo "== I3. En-têtes LiteSpeed cache (X-LiteSpeed-Cache / X-Powered-By) =="
-curl -skI -m 12 "https://klasyo.org/platform/login" 2>/dev/null | grep -iE 'x-litespeed|x-powered|x-lsadc|content-type|server:' | head -8
+# Supprime le bloc FilesMatch qui cible les extensions PHP (celui avec SetHandler),
+# sans toucher un éventuel FilesMatch d'images.
+perl -0pi -e 's/<FilesMatch\s+"\\\.\(php[^"]*"\s*>\s*\n\s*SetHandler[^\n]*\n\s*<\/FilesMatch>\s*\n?//g' "$PHTA"
 
-echo
-echo "== I4. index.php à la racine de platform ? (servirait en source directement) =="
-ls -la "$P"/index.php 2>/dev/null && echo "  !!! index.php EXISTE à la racine platform" || echo "  pas d'index.php à la racine (OK)"
-echo "  --- fichiers .php à la racine platform :"
-ls "$P"/*.php 2>/dev/null | xargs -n1 basename 2>/dev/null | head -10
+echo "== APRÈS (lignes handler ; doit rester seulement AddHandler) :"
+grep -niE 'filesmatch.*php|sethandler|addhandler' "$PHTA" || echo "  (aucune)"
 
 echo
-echo "== I5. COMPARAISON root .htaccess : platform vs school =="
-echo "--- platform/.htaccess :"; cat -A "$P/.htaccess" | head -40
-echo "--- school/.htaccess :"; cat -A "$S/.htaccess" | head -40
+echo "== Purge caches platform =="
+(cd "$P" && php artisan config:clear 2>&1 | tail -1)
+(cd "$P" && php artisan view:clear   2>&1 | tail -1)
 
 echo
-echo "== I6. COMPARAISON public/.htaccess : platform vs school =="
-echo "--- platform/public/.htaccess :"; cat "$P/public/.htaccess"
-echo "--- school/public/.htaccess :"; cat "$S/public/.htaccess"
+echo "== VALIDATION (corps HTML, jamais du source) — + cache-buster =="
+check() {
+  local url="$1"
+  local body; body=$(curl -sk -m 15 "$url" 2>/dev/null)
+  local code; code=$(curl -sk -o /dev/null -m 15 -w "%{http_code}" "$url" 2>/dev/null)
+  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|Taylor Otwell|require_once __DIR__'; then
+    echo "  $url -> [$code] !!! SOURCE PHP"
+  elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
+    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
+  else
+    echo "  $url -> [$code] ? $(printf '%s' "$body" | head -c 45 | tr -d '\n\r')"
+  fi
+}
+check "https://klasyo.org/platform/public/"
+check "https://klasyo.org/platform/?cb=$(date +%s)"
+check "https://klasyo.org/platform/login?cb=$(date +%s)"
+check "https://klasyo.org/platform/register?cb=$(date +%s)"
 
 echo
-echo "== I7. Contexte PHP par répertoire (DirectAdmin/CloudLinux .user.ini, php version) =="
-for d in "$P" "$P/public" "$S" "$S/public"; do
-  for cfg in .htaccess.php_version .user.ini; do
-    [ -f "$d/$cfg" ] && { echo "  [$d/$cfg]"; head -5 "$d/$cfg"; }
-  done
+echo "== Rebrand KLASYO visible sur la page login ? =="
+curl -sk -m 15 "https://klasyo.org/platform/login?cb=$(date +%s)" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | sort -u | head -3 || echo "  (aucun)"
+
+echo
+echo "== Non-régression =="
+for u in "https://klasyo.org/" "https://klasyo.org/school/login"; do
+  echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
 done
-echo "  --- date de modif des public/index.php :"
-stat -c '%y %n' "$P/public/index.php" "$S/public/index.php" 2>/dev/null
 
 echo
-echo "== FIN diagnostic I =="
+echo "== FIN étape J =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,65 +1,55 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 1, passe 3 : DIAGNOSTIC du blocage /school (triangulation).
-# 1) statique  2) PHP minimal  3) Laravel via CLI — pour localiser la couche fautive.
-# Logs publics : aucun secret. Fichier de test supprimé en fin de script.
+# KLASYO — Phase 1 / Semaine 1, passe 4 : isoler la cause du hang PHP dans /school.
+# Le PHP direct dans school/public timeout (000/15s) alors que platform/public répond.
+# On teste : (a) contenu du .htaccess de school/public vs platform/public,
+# (b) réponse PHP quand on met school/public/.htaccess de côté.
+# Logs publics : aucun secret (ces .htaccess ne contiennent pas de secrets).
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 S="$ROOT/school"
+P="$ROOT/platform"
+STAMP="$(date +%Y%m%d-%H%M%S)"
 
-echo "== T1. Fichier STATIQUE dans school/public (robots.txt) =="
-out=$(curl -sk -o /dev/null -m 10 -w "%{http_code} time=%{time_total}s" "https://klasyo.org/school/public/robots.txt" 2>&1)
-echo "  /school/public/robots.txt -> $out"
-out=$(curl -sk -o /dev/null -m 10 -w "%{http_code} time=%{time_total}s" "https://klasyo.org/school/robots.txt" 2>&1)
-echo "  /school/robots.txt (via rewrite) -> $out"
-
+echo "== A. school/public/.htaccess (intégral) =="
+cat "$S/public/.htaccess" 2>/dev/null || echo "(absent)"
 echo
-echo "== T2. PHP MINIMAL dans school/public =="
-TESTF="$S/public/klasyo_diag_$(date +%s).php"
-echo '<?php echo "OK-PHP-".PHP_VERSION;' > "$TESTF"
-BN=$(basename "$TESTF")
-out=$(curl -sk -m 15 -w " [%{http_code} time=%{time_total}s]" "https://klasyo.org/school/public/$BN" 2>&1 | head -c 120)
-echo "  /school/public/$BN -> $out"
-rm -f "$TESTF"
+echo "== B. platform/public/.htaccess (intégral, référence qui marche) =="
+cat "$P/public/.htaccess" 2>/dev/null || echo "(absent)"
 
 echo
-echo "== T3. Même PHP minimal dans platform/public (référence qui marche) =="
-TESTP="$ROOT/platform/public/klasyo_diag_$(date +%s).php"
-echo '<?php echo "OK-PHP-".PHP_VERSION;' > "$TESTP"
-BNP=$(basename "$TESTP")
-out=$(curl -sk -m 15 -w " [%{http_code} time=%{time_total}s]" "https://klasyo.org/platform/public/$BNP" 2>&1 | head -c 120)
-echo "  /platform/public/$BNP -> $out"
-rm -f "$TESTP"
+echo "== C. Test décisif : PHP direct SANS le .htaccess de school/public =="
+DIAG="$S/public/klasyo_diag2.php"
+echo '<?php echo "OK-NOHTA-".PHP_VERSION;' > "$DIAG"
+if [ -f "$S/public/.htaccess" ]; then
+  mv "$S/public/.htaccess" "$S/public/.htaccess.OFF-$STAMP"
+  echo "  .htaccess mis de côté (.htaccess.OFF-$STAMP)"
+fi
+out=$(curl -sk -m 15 -w " [%{http_code} time=%{time_total}s]" "https://klasyo.org/school/public/klasyo_diag2.php" 2>&1 | head -c 100)
+echo "  résultat SANS .htaccess -> $out"
+# Restaurer immédiatement
+if [ -f "$S/public/.htaccess.OFF-$STAMP" ]; then
+  mv "$S/public/.htaccess.OFF-$STAMP" "$S/public/.htaccess"
+  echo "  .htaccess restauré."
+fi
+rm -f "$DIAG"
 
 echo
-echo "== T4. Laravel school exécuté DIRECTEMENT en CLI (simulate GET /) =="
-cd "$S/public"
-START=$(date +%s)
-timeout 30 php -d display_errors=1 -r '
-  $_SERVER["REQUEST_URI"] = "/school/";
-  $_SERVER["REQUEST_METHOD"] = "GET";
-  $_SERVER["HTTP_HOST"] = "klasyo.org";
-  $_SERVER["SCRIPT_NAME"] = "/school/public/index.php";
-  $_SERVER["SCRIPT_FILENAME"] = __DIR__ . "/index.php";
-  require "index.php";
-' > /tmp/klasyo_school_cli.html 2>&1
-RC=$?
-END=$(date +%s)
-echo "  exit=$RC durée=$((END-START))s taille=$(wc -c < /tmp/klasyo_school_cli.html) octets"
-echo "  --- premiers 200 caractères de la réponse :"
-head -c 200 /tmp/klasyo_school_cli.html | tr -d '\r' | head -5
-echo
-echo "  --- indices d'erreur éventuels :"
-grep -oiE '(fatal|exception|error|timed? ?out|curl|guzzle|connection)[^<]{0,80}' /tmp/klasyo_school_cli.html | head -5 || echo "  (aucun)"
-rm -f /tmp/klasyo_school_cli.html
+echo "== D. Comparaison des handlers PHP (school vs platform) au niveau du domaine =="
+echo "  --- lignes PHP/handler dans TOUS les .htaccess de school :"
+grep -rniE 'php|handler|fcgi|lsapi|application/x-httpd' "$S"/.htaccess "$S"/public/.htaccess 2>/dev/null | head -15 || echo "  (rien)"
+echo "  --- idem platform (référence) :"
+grep -rniE 'php|handler|fcgi|lsapi|application/x-httpd' "$P"/.htaccess "$P"/public/.htaccess 2>/dev/null | head -15 || echo "  (rien)"
 
 echo
-echo "== T5. Config PHP par répertoire (sélecteur DirectAdmin) =="
-for f in "$S/.user.ini" "$S/public/.user.ini" "$S/php.ini" "$ROOT/.htaccess"; do
-  [ -f "$f" ] && { echo "  --- $f :"; head -10 "$f"; } || echo "  (absent) $f"
+echo "== E. Différence de permissions / propriété entre les deux public/ =="
+stat -c '%A %U:%G %n' "$S/public" "$S/public/index.php" "$P/public" "$P/public/index.php" 2>/dev/null
+
+echo
+echo "== F. .htaccess éventuels plus haut dans l'arborescence (hériteraient sur school) =="
+for d in "$ROOT" "$HOME"; do
+  [ -f "$d/.htaccess" ] && { echo "  --- $d/.htaccess :"; grep -niE 'php|handler|rewrite|deny|require' "$d/.htaccess" | head -10; } || echo "  (pas de .htaccess dans $d)"
 done
-echo "  --- Handlers/SetHandler dans les .htaccess school :"
-grep -riE 'sethandler|addhandler|php' "$S/.htaccess" "$S/public/.htaccess" 2>/dev/null | head -10 || echo "  (rien)"
 
 echo
-echo "== FIN diagnostic passe 3 =="
+echo "== FIN passe 4 =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,52 +1,30 @@
 #!/usr/bin/env bash
-# KLASYO — Étape E : platform sert le PHP en SOURCE car son handler lsphp80 n'exécute pas
-# (PHP 8.0 non enregistré sur ce LiteSpeed). School marche avec lsphp83.
-# On DÉTECTE le handler qui EXÉCUTE réellement (on valide le CORPS, pas le code HTTP),
-# on l'applique à platform/public/.htaccess, puis on valide que les pages rendent du HTML.
+# KLASYO — Étape F : la pièce manquante. lsphp83 exécute bien un .php DIRECT dans
+# platform/public, mais /platform/ (rewrite root -> public/index.php) sert du SOURCE
+# car le .htaccess RACINE n'a pas de handler (LiteSpeed applique le handler du contexte
+# où la règle de rewrite se déclenche). School marche car son .htaccess racine a lsphp83.
+# -> On pose lsphp83 dans platform/.htaccess (racine) et on VALIDE le HTML rendu.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
-PUB="$P/public"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-PHTA="$PUB/.htaccess"
+RHTA="$P/.htaccess"
 
-cp -a "$PHTA" "$PHTA.bak-E-$STAMP" && echo "backup: platform/public/.htaccess.bak-E-$STAMP"
+cp -a "$RHTA" "$RHTA.bak-F-$STAMP" && echo "backup: platform/.htaccess.bak-F-$STAMP"
+# Idempotence : retire un éventuel ancien bloc KLASYO handler
+sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
+# Ajoute le handler exécutant (lsphp83) au niveau RACINE
+cat >> "$RHTA" <<'HTA'
+# KLASYO-PHP-HANDLER
+<FilesMatch "\.(php|phtml)$">
+SetHandler application/x-lsphp83
+</FilesMatch>
+HTA
+echo "  lsphp83 posé sur platform/.htaccess (racine)."
 
-# Fichier diag qui, s'il EXÉCUTE, imprime un marqueur unique + la version PHP
-DIAG="$PUB/klasyo_exec.php"
-echo '<?php echo "LSPHPEXEC-".PHP_VERSION;' > "$DIAG"
-
-echo "== Handler actuel dans platform/public/.htaccess :"
-grep -niE 'sethandler|lsphp' "$PHTA" || echo "  (aucun)"
-
-WINNER=""
-for V in 83 82 81 80; do
-  # Remplace toute valeur x-lsphpNN existante par la version testée
-  if grep -qiE 'x-lsphp[0-9]+' "$PHTA"; then
-    sed -i -E "s#application/x-lsphp[0-9]+#application/x-lsphp${V}#g" "$PHTA"
-  else
-    # pas de SetHandler -> on en ajoute un (bloc KLASYO), nettoyé à chaque tour
-    sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$PHTA" 2>/dev/null || true
-    printf '# KLASYO-PHP-HANDLER\n<FilesMatch "\\.(php|phtml)$">\nSetHandler application/x-lsphp%s\n</FilesMatch>\n' "$V" >> "$PHTA"
-  fi
-  body=$(curl -sk -m 12 "https://klasyo.org/platform/public/klasyo_exec.php" 2>/dev/null | head -c 60)
-  if printf '%s' "$body" | grep -q "LSPHPEXEC-"; then
-    WINNER="$V"
-    echo "  lsphp${V} -> EXÉCUTE : ${body}"
-    break
-  else
-    echo "  lsphp${V} -> pas d'exécution (début: $(printf '%s' "$body" | head -c 25))"
-  fi
-done
-rm -f "$DIAG"
-
-if [ -z "$WINNER" ]; then
-  echo "  (!) Aucun handler n'exécute — restauration + il faudra fixer la version PHP dans DirectAdmin."
-  cp -a "$PHTA.bak-E-$STAMP" "$PHTA"
-else
-  echo "  ==> Handler lsphp${WINNER} appliqué à platform/public/.htaccess."
-fi
+# Nettoyage d'éventuels fichiers diag laissés
+rm -f "$P"/public/klasyo_exec.php "$P"/public/klasyo_*.php 2>/dev/null || true
 
 echo
 echo "== Purge caches =="
@@ -54,7 +32,7 @@ echo "== Purge caches =="
 (cd "$P" && php artisan view:clear   2>&1 | tail -1)
 
 echo
-echo "== VALIDATION FINALE — le corps doit être du HTML, jamais du source PHP =="
+echo "== VALIDATION FINALE (corps HTML, jamais du source) =="
 check() {
   local url="$1"
   local body; body=$(curl -skL -m 15 "$url" 2>/dev/null)
@@ -62,9 +40,10 @@ check() {
   if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|Taylor Otwell|require_once __DIR__'; then
     echo "  $url -> [$code] !!! SOURCE PHP"
   elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
-    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
+    local t; t=$(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)
+    echo "  $url -> [$code] OK HTML | $t"
   else
-    echo "  $url -> [$code] ? ($(printf '%s' "$body" | head -c 30 | tr -d '\n\r'))"
+    echo "  $url -> [$code] ? début: $(printf '%s' "$body" | head -c 40 | tr -d '\n\r')"
   fi
 }
 check "https://klasyo.org/platform/"
@@ -72,15 +51,17 @@ check "https://klasyo.org/platform/login"
 check "https://klasyo.org/platform/register"
 
 echo
-echo "== 'KLASYO' présent dans la page login ? =="
-curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE 'KLASYO' | head -1 && echo "  -> présent" || echo "  -> absent"
+echo "== Rebrand : 'KLASYO' visible dans la page login ? =="
+curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | head -3
 
 echo
-echo "== École (non-régression) + reste public/ propre =="
-for u in "https://klasyo.org/school/login" "https://klasyo.org/"; do
+echo "== Non-régression école + landing =="
+for u in "https://klasyo.org/" "https://klasyo.org/school/" "https://klasyo.org/school/login"; do
   echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
 done
-find "$PUB" -maxdepth 1 -name 'klasyo_*' 2>/dev/null && echo "  (fichiers diag restants ci-dessus)" || echo "  public/ propre (aucun diag)"
+echo "  -- sécurité : plus aucun .php servi en source ? test index.php :"
+b=$(curl -skL -m 12 "https://klasyo.org/platform/index.php" 2>/dev/null)
+printf '%s' "$b" | grep -qiE '<\?php|Illuminate\\Contracts' && echo "  !!! index.php encore en source" || echo "  OK index.php ne divulgue pas de source"
 
 echo
-echo "== FIN étape E =="
+echo "== FIN étape F =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,40 +1,73 @@
 #!/usr/bin/env bash
-# KLASYO — Étape M : annuler le hack register=>true (mauvais mécanisme : LMSZAI n'a pas de
-# vue auth.register -> 500). LMSZAI a sa propre inscription native, qui fonctionnera une fois
-# l'app servie à la racine (sous-domaine). On restaure register=>false (état propre, pas de 500).
+# KLASYO — Étape N : URLs propres pour /platform. La cause du 404 : router vers
+# public/index.php donne SCRIPT_NAME=/platform/public/index.php -> Laravel croit que sa base
+# est /platform/public -> /platform/login ne matche pas. En routant vers server.php (à la
+# RACINE de l'app), SCRIPT_NAME=/platform/server.php -> base=/platform -> /login matche.
+# (server.php échouait avant à cause du handler lsphp cassé, désormais corrigé en lsphp83.)
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-WEB="$P/routes/web.php"
+RHTA="$P/.htaccess"
 
-echo "== Ligne actuelle :"
-grep -n "Auth::routes" "$WEB"
-if grep -q "Auth::routes(\['register' => true\])" "$WEB"; then
-  cp -a "$WEB" "$WEB.bak-M-$STAMP"
-  sed -i "s/Auth::routes(\['register' => true\])/Auth::routes(['register' => false])/" "$WEB"
-  echo "  -> restauré register=>false (plus de 500 sur /register)."
-else
-  echo "  (déjà register=>false ou motif absent)"
-fi
-grep -n "Auth::routes" "$WEB"
+[ -f "$P/server.php" ] && echo "server.php présent (OK)" || { echo "(!) server.php absent — abandon"; exit 0; }
+cp -a "$RHTA" "$RHTA.bak-N-$STAMP" && echo "backup: platform/.htaccess.bak-N-$STAMP"
+
+cat > "$RHTA" <<'HTA'
+# KLASYO-ROOT-FRONTCTRL — /platform servi via server.php (racine app) pour que
+# Laravel calcule la bonne base (/platform) et matche les routes propres.
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews -Indexes
+    </IfModule>
+
+    RewriteEngine On
+
+    # Déjà sous public/ : ne pas réécrire
+    RewriteRule ^public/ - [L]
+
+    # Asset statique présent dans public/ -> le servir
+    RewriteCond %{DOCUMENT_ROOT}/platform/public/$1 -f
+    RewriteRule ^(.*)$ public/$1 [L]
+
+    # Tout le reste -> front controller RACINE (server.php) : donne SCRIPT_NAME=/platform/server.php
+    RewriteRule ^ server.php [L]
+
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+</IfModule>
+AddHandler application/x-lsphp83 .php .phtml
+HTA
+echo "  .htaccess racine réécrit (route -> server.php)."
+
 (cd "$P" && php artisan route:clear 2>&1 | tail -1)
 (cd "$P" && php artisan config:clear 2>&1 | tail -1)
+(cd "$P" && php artisan view:clear 2>&1 | tail -1)
 
 echo
-echo "== Chercher le flux d'inscription NATIF de LMSZAI (routes signup/register) =="
-grep -rniE "register|sign.?up|signup|enroll" "$P/routes/web.php" 2>/dev/null | grep -viE 'Auth::routes|verification|version' | head -12 || echo "  (aucune route register native évidente dans web.php)"
-echo "  --- vues d'inscription présentes ?"
-find "$P/resources/views" -iname '*register*' -o -iname '*signup*' 2>/dev/null | grep -v vendor | head -10 || echo "  (aucune vue register/signup)"
-echo "  --- lien d'inscription dans la page login (frontend) :"
-grep -rniE "href=.*(register|signup|sign-up)" "$P/resources/views/frontend" 2>/dev/null | head -5 || echo "  (aucun lien évident)"
+echo "== VALIDATION (corps ; 2 essais espacés pour contourner un éventuel throttling firewall) =="
+check() {
+  local url="$1" body code
+  for try in 1 2; do
+    body=$(curl -sk -m 20 "$url" 2>/dev/null)
+    code=$(curl -sk -o /dev/null -m 20 -w "%{http_code}" "$url" 2>/dev/null)
+    [ "$code" != "000" ] && break
+    sleep 4
+  done
+  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|require_once __DIR__'; then
+    echo "  $url -> [$code] SOURCE PHP"
+  elif printf '%s' "$body" | grep -qiE 'not found|404|error page' && ! printf '%s' "$body" | grep -qiE '<title>KLASYO'; then
+    echo "  $url -> [$code] 404/erreur | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
+  elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
+    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
+  else
+    echo "  $url -> [$code] ? $(printf '%s' "$body" | head -c 50 | tr -d '\n\r')"
+  fi
+}
+check "https://klasyo.org/platform/"
+check "https://klasyo.org/platform/login"
+check "https://klasyo.org/platform/courses"
 
 echo
-echo "== État final (un seul appel HTTP, pour éviter le throttling firewall) =="
-sleep 2
-code=$(curl -sk -o /dev/null -m 20 -w '%{http_code}' "https://klasyo.org/platform/public/login" 2>/dev/null)
-echo "  /platform/public/login -> [$code]"
-
-echo
-echo "== FIN étape M =="
+echo "== FIN étape N =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,86 +1,42 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 1, passe 5 : RÉPARER /school.
-# Cause identifiée : school/public/.htaccess n'a AUCUN handler PHP LiteSpeed,
-# alors que platform/public en a un (SetHandler application/x-lsphp80) et fonctionne.
-# → On détecte le handler lsphp qui répond (83>82>81>80, school=Laravel10 veut PHP 8.1+),
-#   puis on l'écrit dans school/public/.htaccess ET school/.htaccess. Backups + idempotent.
+# KLASYO — Phase 1 / Semaine 1, passe 6 : nettoyage final + confirmation.
+# Supprime tout fichier de diagnostic laissé dans les public/, purge caches Laravel,
+# et confirme l'état HTTP final des deux apps.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 S="$ROOT/school"
-STAMP="$(date +%Y%m%d-%H%M%S)"
+P="$ROOT/platform"
 
-DIAG="$S/public/klasyo_h.php"
-echo '<?php echo "OKHANDLER-".PHP_VERSION;' > "$DIAG"
-HTA="$S/public/.htaccess"
-cp -a "$HTA" "$HTA.bak-$STAMP" && echo "backup: public/.htaccess.bak-$STAMP"
-
-# Retire tout ancien bloc handler KLASYO déjà posé (idempotence)
-sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$HTA" 2>/dev/null || true
-
-WINNER=""
-for V in 83 82 81 80; do
-  # Injecte le bloc handler pour cette version
-  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$HTA" 2>/dev/null || true
-  cat >> "$HTA" <<EOF
-# KLASYO-PHP-HANDLER
-<FilesMatch "\.(php|phtml)\$">
-SetHandler application/x-lsphp${V}
-</FilesMatch>
-EOF
-  out=$(curl -sk -m 12 -w "%{http_code}" "https://klasyo.org/school/public/klasyo_h.php" 2>&1)
-  body=$(echo "$out" | head -c 60)
-  code=$(echo "$out" | tail -c 4)
-  echo "  lsphp${V} -> ${body}"
-  if echo "$out" | grep -q "OKHANDLER-"; then
-    WINNER="$V"
-    echo "  ==> lsphp${V} FONCTIONNE (PHP $(echo "$out" | grep -oE 'OKHANDLER-[0-9.]+' | cut -d- -f2))"
-    break
-  fi
+echo "== 1. Suppression des fichiers de diagnostic éventuels =="
+for f in "$S"/public/klasyo_h.php "$S"/public/klasyo_diag*.php "$P"/public/klasyo_diag*.php; do
+  if [ -e "$f" ]; then rm -f "$f" && echo "  supprimé : $(basename "$f")"; fi
 done
-rm -f "$DIAG"
-
-if [ -z "$WINNER" ]; then
-  echo "  (!) Aucun handler lsphp ne répond via .htaccess — restauration du backup."
-  cp -a "$HTA.bak-$STAMP" "$HTA"
-  echo "  Il faudra régler la version PHP de /school dans DirectAdmin (MultiPHP/PHP Selector)."
-else
-  # Le bloc gagnant est déjà en place dans public/.htaccess.
-  echo
-  echo "== Handler lsphp${WINNER} appliqué à school/public/.htaccess =="
-  # Poser aussi le handler dans school/.htaccess (racine du sous-dossier) par cohérence
-  RHTA="$S/.htaccess"
-  cp -a "$RHTA" "$RHTA.bak-$STAMP" 2>/dev/null
-  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
-  cat >> "$RHTA" <<EOF
-# KLASYO-PHP-HANDLER
-<FilesMatch "\.(php|phtml)\$">
-SetHandler application/x-lsphp${WINNER}
-</FilesMatch>
-EOF
-  echo "  Handler aussi posé sur school/.htaccess."
-fi
+echo "  Restes klasyo_* dans les public/ :"
+find "$S/public" "$P/public" -maxdepth 1 -name 'klasyo_*' 2>/dev/null || true
+echo "  (liste vide = propre)"
 
 echo
-echo "== Vérification finale HTTP =="
-for u in "https://klasyo.org/school/" \
-         "https://klasyo.org/school/login" \
-         "https://klasyo.org/school/public/index.php" \
+echo "== 2. Purge caches Laravel (school) après changement de handler =="
+(cd "$S" && php artisan config:clear 2>&1 | tail -1)
+(cd "$S" && php artisan cache:clear  2>&1 | tail -1) || true
+(cd "$S" && php artisan view:clear   2>&1 | tail -1)
+
+echo
+echo "== 3. Confirmation HTTP finale =="
+for u in "https://klasyo.org/" \
          "https://klasyo.org/platform/index.php" \
-         "https://klasyo.org/" ; do
-  out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (redirs=%{num_redirects}, %{time_total}s)" "$u" 2>&1)
+         "https://klasyo.org/school/" \
+         "https://klasyo.org/school/login" ; do
+  out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (%{time_total}s)" "$u" 2>&1)
   echo "  $u -> $out"
 done
 echo "  -- sécurité (403/404 attendus) :"
-for u in "https://klasyo.org/school/.env" "https://klasyo.org/school/public/klasyo_h.php"; do
+for u in "https://klasyo.org/school/.env" "https://klasyo.org/platform/.env" \
+         "https://klasyo.org/school/public/klasyo_h.php" ; do
   code=$(curl -sk -o /dev/null -m 10 -w "%{http_code}" "$u")
   echo "  $u -> $code"
 done
 
 echo
-echo "== Nouvelles erreurs Laravel school aujourd'hui (tronquées) =="
-L=$(ls -t "$S"/storage/logs/*.log 2>/dev/null | head -1)
-[ -n "$L" ] && grep -oE "^\[$(date +%Y-%m-%d)[0-9 :]*\] \w+\.\w+: [^{]{0,110}" "$L" | tail -4 || echo "  (aucune)"
-
-echo
-echo "== FIN passe 5 =="
+echo "== FIN passe 6 — Phase 1 / Semaine 1 (P0) terminée =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,63 +1,62 @@
 #!/usr/bin/env bash
-# KLASYO — Diagnostic B : pourquoi /platform/login et /platform/register hangent (15s)
-# alors que la page d'accueil (même front controller server.php) répond en 200.
-# Hypothèse : appel réseau sortant (license check / captcha serveur) sur ces routes.
-# Logs publics : aucun secret.
+# KLASYO — Étape C : réparer le hang des routes platform (server.php sans handler PHP).
+# CLI prouve que Laravel/login rendent bien (2s). Le hang est au niveau du handler PHP
+# du .htaccess RACINE de platform (server.php n'a pas de SetHandler lsphp).
+# On pose le handler et on valide contre les VRAIES routes /login /register. Backup + idempotent.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+RHTA="$P/.htaccess"
 
-echo "== B1. Timing HTTP fin : accueil vs login vs register =="
-for u in "https://klasyo.org/platform/" \
-         "https://klasyo.org/platform/index.php" \
+cp -a "$RHTA" "$RHTA.bak-$STAMP" && echo "backup: platform/.htaccess.bak-$STAMP"
+# Retire un éventuel ancien bloc KLASYO (idempotence)
+sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
+
+echo "== .htaccess racine platform AVANT (handlers) :"
+grep -niE 'sethandler|lsphp|server.php' "$RHTA" || echo "  (aucun handler)"
+
+WINNER=""
+for V in 80 81 82 83; do
+  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
+  cat >> "$RHTA" <<EOF
+# KLASYO-PHP-HANDLER
+<FilesMatch "\.(php|phtml)\$">
+SetHandler application/x-lsphp${V}
+</FilesMatch>
+EOF
+  # Valider contre la vraie route /login (celle qui hangait)
+  code=$(curl -sk -o /dev/null -m 12 -w "%{http_code}" "https://klasyo.org/platform/login" 2>&1)
+  echo "  lsphp${V} -> /platform/login = $code"
+  if [ "$code" != "000" ] && [ "$code" != "" ]; then
+    WINNER="$V"; echo "  ==> lsphp${V} débloque les routes platform."
+    break
+  fi
+done
+
+if [ -z "$WINNER" ]; then
+  echo "  (!) Aucun handler ne débloque via .htaccess racine — restauration."
+  cp -a "$RHTA.bak-$STAMP" "$RHTA"
+else
+  echo "  Handler lsphp${WINNER} appliqué à platform/.htaccess (racine)."
+fi
+
+echo
+echo "== Purge caches + vérification finale des routes platform =="
+(cd "$P" && php artisan config:clear 2>&1 | tail -1)
+(cd "$P" && php artisan view:clear   2>&1 | tail -1)
+for u in "https://klasyo.org/" \
+         "https://klasyo.org/platform/" \
          "https://klasyo.org/platform/login" \
-         "https://klasyo.org/platform/register" ; do
-  out=$(curl -sk -o /dev/null -m 20 -w "%{http_code} time=%{time_total}s" "$u" 2>&1)
+         "https://klasyo.org/platform/register" \
+         "https://klasyo.org/school/" \
+         "https://klasyo.org/school/login" ; do
+  out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (%{time_total}s)" "$u" 2>&1)
   echo "  $u -> $out"
 done
+echo "  --- <title> page login platform (doit mentionner KLASYO après rebrand) :"
+curl -skL -m 12 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE '<title>[^<]*</title>' | head -1
 
 echo
-echo "== B2. Exécution CLI de la route /login (localise le hang, timeout 25s) =="
-cd "$P"
-START=$(date +%s)
-timeout 25 php -d display_errors=1 -r '
-  $_SERVER["REQUEST_URI"]="/login";
-  $_SERVER["REQUEST_METHOD"]="GET";
-  $_SERVER["HTTP_HOST"]="klasyo.org";
-  $_SERVER["SCRIPT_NAME"]="/platform/index.php";
-  $_SERVER["SCRIPT_FILENAME"]=__DIR__."/server.php";
-  require "server.php";
-' > /tmp/kl_login.html 2>&1
-RC=$?; END=$(date +%s)
-echo "  exit=$RC durée=$((END-START))s taille=$(wc -c < /tmp/kl_login.html)o"
-if [ $RC -eq 124 ]; then echo "  => TIMEOUT en CLI aussi : le hang est DANS le code PHP (pas le web-server)."; fi
-echo "  --- 200 premiers caractères :"; head -c 200 /tmp/kl_login.html | tr -d '\r'
-echo
-echo "  --- erreurs/traces :"; grep -oiE '(fatal|exception|error|curl|guzzle|timed? ?out|curl_exec|file_get_contents|stream_socket|verify|license|licen[cs]e|activation)[^<]{0,80}' /tmp/kl_login.html | head -8 || echo "  (aucune)"
-rm -f /tmp/kl_login.html
-
-echo
-echo "== B3. Recherche d'appels réseau sortants sur les routes auth (code LMSZAI) =="
-echo "  --- LoginController / RegisterController :"
-for f in "$P"/app/Http/Controllers/Auth/LoginController.php "$P"/app/Http/Controllers/Auth/RegisterController.php; do
-  [ -f "$f" ] && { echo "  [$f]"; grep -niE 'curl|guzzle|http::|file_get_contents|Client\(|verify|licen[cs]e|activation|gethostby|fsockopen|checkPurchase|envato' "$f" | head -8 || echo "    (rien)"; }
-done
-echo "  --- middlewares globaux appelant l'extérieur :"
-grep -rniE 'curl_exec|file_get_contents\(.?http|Http::(get|post)|new Client|checkPurchase|envato|verify.*license|license.*verify' \
-  "$P"/app/Http/Middleware "$P"/app/Providers 2>/dev/null | head -12 || echo "  (rien)"
-
-echo
-echo "== B4. Sortie internet du serveur (un timeout ici expliquerait le hang) =="
-for host in "api.envato.com" "google.com" "codecanyon.net"; do
-  t=$(curl -s -o /dev/null -m 8 -w "%{http_code} %{time_total}s" "https://$host" 2>&1 || echo "FAIL")
-  echo "  https://$host -> $t"
-done
-
-echo
-echo "== B5. version.update middleware (LMSZAI enveloppe les routes dedans) =="
-grep -rniE 'version.update|VersionUpdate|process-update' "$P"/app/Http/Kernel.php "$P"/app/Http/Middleware 2>/dev/null | head -8 || echo "  (rien)"
-ls "$P"/app/Http/Middleware 2>/dev/null | head -30
-
-echo
-echo "== FIN diagnostic B =="
+echo "== FIN étape C =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# KLASYO — Phase 1 / Semaine 1 : correctifs P0 sécurité + réparation de /school.
+# Exécuté sur le VPS via GitHub Actions (klasyo-ops.yml : ssh ... bash -s < ce script).
+#
+# SÉCURITÉ (les logs Actions sont PUBLICS) :
+# - ne jamais afficher le contenu de .env, de clés ni de credentials
+# - toute modification est précédée d'un backup ; rien n'est supprimé (déplacé vers ~/backups_klasyo)
+# - idempotent : ré-exécutable sans danger
+set -uo pipefail
+
+ROOT="$HOME/domains/klasyo.org/public_html"
+P="$ROOT/platform"
+S="$ROOT/school"
+BK="$HOME/backups_klasyo"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$BK"
+
+echo "########################################"
+echo "== ÉTAPE 1 : zips de code source hors du web =="
+echo "########################################"
+move_out() {
+  local f="$1"
+  if [ -e "$f" ]; then
+    mv "$f" "$BK/" && echo "  DÉPLACÉ -> backups_klasyo/ : $(basename "$f")"
+  else
+    echo "  (déjà absent) $(basename "$f")"
+  fi
+}
+move_out "$P/klasyo.zip"
+move_out "$S/school.zip"
+move_out "$S/source_code.zip"
+move_out "$S/New_Installation_V1.9.3.zip"
+move_out "$S/Update 1.9.2-to-1.9.3.zip"
+move_out "$S/eSchool Sass student web v-1.9.3.zip"
+move_out "$S/eSchool-Saas-V1.9.3"
+# Fichiers parasites / fuite d'identité du script
+move_out "$P/index.html"          # ancien index statique "webetud.com" (parasite)
+move_out "$ROOT/documentation.txt"
+move_out "$ROOT/update_note.json"
+move_out "$P/documentation.txt"
+move_out "$P/update_note.json"
+echo "  Contenu de backups_klasyo (noms seulement) :"
+ls "$BK" | head -20
+
+echo
+echo "########################################"
+echo "== ÉTAPE 2 : correction des .env (backup préalable) =="
+echo "########################################"
+fix_env() {
+  local envfile="$1"; shift
+  [ -f "$envfile" ] || { echo "  (!) introuvable : $envfile"; return; }
+  cp -a "$envfile" "$envfile.bak-$STAMP"
+  echo "  backup : $(basename "$envfile").bak-$STAMP"
+  while [ $# -gt 0 ]; do
+    local key="${1%%=*}"
+    if grep -q "^${key}=" "$envfile"; then
+      sed -i "s|^${key}=.*|${1}|" "$envfile"
+    else
+      printf '%s\n' "$1" >> "$envfile"
+    fi
+    shift
+  done
+}
+fix_env "$P/.env" "APP_ENV=production" "APP_DEBUG=false" "APP_URL=https://klasyo.org/platform"
+fix_env "$S/.env" "APP_ENV=production" "APP_DEBUG=false" "APP_URL=https://klasyo.org/school"
+
+echo "  Vérification (clés non sensibles uniquement) :"
+echo "  --- platform :"; grep -E '^(APP_ENV|APP_DEBUG|APP_URL)=' "$P/.env"
+echo "  --- school   :"; grep -E '^(APP_ENV|APP_DEBUG|APP_URL)=' "$S/.env"
+
+echo
+echo "########################################"
+echo "== ÉTAPE 3 : APP_KEY de school =="
+echo "########################################"
+if grep -q '^APP_KEY=base64:.\+' "$S/.env"; then
+  echo "  APP_KEY déjà présente (non affichée)."
+else
+  echo "  APP_KEY absente -> génération…"
+  (cd "$S" && php artisan key:generate --force 2>&1 | grep -iv 'base64') || echo "  (!) échec key:generate"
+  grep -q '^APP_KEY=base64:.\+' "$S/.env" && echo "  APP_KEY générée avec succès (non affichée)."
+fi
+# Platform : contrôle seulement
+grep -q '^APP_KEY=base64:.\+' "$P/.env" && echo "  APP_KEY platform : présente." || echo "  (!) APP_KEY platform ABSENTE"
+
+echo
+echo "########################################"
+echo "== ÉTAPE 4 : purge des caches Laravel =="
+echo "########################################"
+for APPDIR in "$P" "$S"; do
+  echo "  --- $(basename "$APPDIR") :"
+  (cd "$APPDIR" && php artisan config:clear 2>&1 | tail -1)
+  (cd "$APPDIR" && php artisan route:clear  2>&1 | tail -1)
+  (cd "$APPDIR" && php artisan view:clear   2>&1 | tail -1)
+  (cd "$APPDIR" && php artisan cache:clear  2>&1 | tail -1) || true
+done
+echo "  Version PHP CLI : $(php -r 'echo PHP_VERSION;')"
+
+echo
+echo "########################################"
+echo "== ÉTAPE 5 : vérification HTTP (codes seulement) =="
+echo "########################################"
+for u in "https://klasyo.org/" \
+         "https://klasyo.org/platform/index.php" \
+         "https://klasyo.org/platform/public/" \
+         "https://klasyo.org/school" \
+         "https://klasyo.org/school/public/index.php" ; do
+  code=$(curl -skL -o /dev/null -m 12 -w "%{http_code}" "$u")
+  echo "  $u -> $code"
+done
+echo "  -- exposition (on veut 403/404 partout) :"
+for u in "https://klasyo.org/platform/.env" "https://klasyo.org/school/.env" \
+         "https://klasyo.org/platform/klasyo.zip" "https://klasyo.org/school/school.zip"; do
+  code=$(curl -sk -o /dev/null -m 10 -r 0-0 -w "%{http_code}" "$u")
+  echo "  $u -> $code"
+done
+
+echo
+echo "== Dernière erreur Laravel school (si encore en panne, message tronqué sans données) =="
+L=$(ls -t "$S"/storage/logs/*.log 2>/dev/null | head -1)
+[ -n "$L" ] && grep -oE '^\[[0-9 :-]+\] \w+\.\w+: [^{]{0,120}' "$L" | tail -3 || echo "(pas de log)"
+
+echo
+echo "== FIN Phase 1 / Semaine 1 (P0) =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
-# KLASYO — Étape C : réparer le hang des routes platform (server.php sans handler PHP).
-# CLI prouve que Laravel/login rendent bien (2s). Le hang est au niveau du handler PHP
-# du .htaccess RACINE de platform (server.php n'a pas de SetHandler lsphp).
-# On pose le handler et on valide contre les VRAIES routes /login /register. Backup + idempotent.
+# KLASYO — Étape D : CORRIGER platform — server.php était servi en SOURCE (pas exécuté).
+# Cause : le .htaccess racine rewrite vers server.php + un SetHandler mal appliqué -> code source
+# renvoyé en texte (bug fonctionnel + divulgation de code). Fix : router vers public/index.php
+# (patron "subdir-safe" identique à school, dont le public/.htaccess a déjà le handler lsphp80).
+# On VALIDE le CONTENU (HTML réel, pas du source PHP), pas seulement le code HTTP.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
@@ -10,53 +11,82 @@ P="$ROOT/platform"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 RHTA="$P/.htaccess"
 
-cp -a "$RHTA" "$RHTA.bak-$STAMP" && echo "backup: platform/.htaccess.bak-$STAMP"
-# Retire un éventuel ancien bloc KLASYO (idempotence)
-sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
+cp -a "$RHTA" "$RHTA.bak-D-$STAMP" && echo "backup: platform/.htaccess.bak-D-$STAMP"
 
-echo "== .htaccess racine platform AVANT (handlers) :"
-grep -niE 'sethandler|lsphp|server.php' "$RHTA" || echo "  (aucun handler)"
+echo "== .htaccess racine platform AVANT :"
+sed -n '1,60p' "$RHTA"
 
-WINNER=""
-for V in 80 81 82 83; do
-  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
-  cat >> "$RHTA" <<EOF
-# KLASYO-PHP-HANDLER
-<FilesMatch "\.(php|phtml)\$">
-SetHandler application/x-lsphp${V}
-</FilesMatch>
-EOF
-  # Valider contre la vraie route /login (celle qui hangait)
-  code=$(curl -sk -o /dev/null -m 12 -w "%{http_code}" "https://klasyo.org/platform/login" 2>&1)
-  echo "  lsphp${V} -> /platform/login = $code"
-  if [ "$code" != "000" ] && [ "$code" != "" ]; then
-    WINNER="$V"; echo "  ==> lsphp${V} débloque les routes platform."
-    break
-  fi
-done
+# Nouveau .htaccess racine : route tout vers public/ (front controller public/index.php),
+# PAS de SetHandler ici (c'est public/.htaccess qui porte le handler lsphp80).
+cat > "$RHTA" <<'HTA'
+# KLASYO-SUBDIR-SAFE — platform (LMSZAI) servi depuis /platform/, routé vers public/
+# (server.php était renvoyé en SOURCE ; on passe par public/index.php comme school)
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews -Indexes
+    </IfModule>
 
-if [ -z "$WINNER" ]; then
-  echo "  (!) Aucun handler ne débloque via .htaccess racine — restauration."
-  cp -a "$RHTA.bak-$STAMP" "$RHTA"
-else
-  echo "  Handler lsphp${WINNER} appliqué à platform/.htaccess (racine)."
-fi
+    RewriteEngine On
+
+    # Ne pas re-réécrire ce qui est déjà sous public/ (stoppe toute boucle)
+    RewriteRule ^public/ - [L]
+
+    # Fichier statique existant dans public/ -> le servir directement
+    RewriteCond %{DOCUMENT_ROOT}/platform/public/$1 -f
+    RewriteRule ^(.*)$ public/$1 [L]
+
+    # Tout le reste -> front controller Laravel (public/index.php porte le handler lsphp80)
+    RewriteRule ^ public/index.php [L]
+
+    # En-tête Authorization pour l'API
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+</IfModule>
+HTA
+echo "  Nouveau .htaccess racine écrit (route vers public/, sans SetHandler)."
 
 echo
-echo "== Purge caches + vérification finale des routes platform =="
+echo "== Purge caches =="
 (cd "$P" && php artisan config:clear 2>&1 | tail -1)
 (cd "$P" && php artisan view:clear   2>&1 | tail -1)
-for u in "https://klasyo.org/" \
-         "https://klasyo.org/platform/" \
-         "https://klasyo.org/platform/login" \
-         "https://klasyo.org/platform/register" \
-         "https://klasyo.org/school/" \
-         "https://klasyo.org/school/login" ; do
-  out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (%{time_total}s)" "$u" 2>&1)
-  echo "  $u -> $out"
-done
-echo "  --- <title> page login platform (doit mentionner KLASYO après rebrand) :"
-curl -skL -m 12 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE '<title>[^<]*</title>' | head -1
+(cd "$P" && php artisan route:clear  2>&1 | tail -1)
 
 echo
-echo "== FIN étape C =="
+echo "== VALIDATION DU CONTENU (pas seulement le code HTTP) =="
+check() {
+  local url="$1"
+  local body; body=$(curl -skL -m 15 "$url" 2>/dev/null)
+  local code; code=$(curl -skL -o /dev/null -m 15 -w "%{http_code}" "$url" 2>/dev/null)
+  local first; first=$(printf '%s' "$body" | head -c 40 | tr -d '\n\r')
+  local verdict="?"
+  if printf '%s' "$body" | grep -qiE 'Taylor Otwell|mod_rewrite|require_once __DIR__|A PHP Framework'; then
+    verdict="!!! SOURCE PHP EXPOSÉE"
+  elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
+    verdict="OK (HTML rendu)"
+  elif [ -z "$body" ]; then
+    verdict="(vide)"
+  else
+    verdict="autre"
+  fi
+  echo "  $url -> [$code] $verdict | début: ${first}"
+}
+check "https://klasyo.org/platform/"
+check "https://klasyo.org/platform/login"
+check "https://klasyo.org/platform/register"
+check "https://klasyo.org/platform/index.php"
+
+echo
+echo "== Titre + présence de 'KLASYO' dans la page login (rebrand) =="
+LOGIN=$(curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null)
+printf '%s' "$LOGIN" | grep -oiE '<title>[^<]*</title>' | head -1 || echo "  (pas de title)"
+printf '%s' "$LOGIN" | grep -oiE 'KLASYO' | head -1 && echo "  -> 'KLASYO' présent" || echo "  -> 'KLASYO' absent (vérifier logo/nom dans les vues)"
+
+echo
+echo "== Confirmation école (ne pas régresser) =="
+for u in "https://klasyo.org/school/" "https://klasyo.org/school/login" "https://klasyo.org/"; do
+  code=$(curl -skL -o /dev/null -m 12 -w "%{http_code}" "$u")
+  echo "  $u -> $code"
+done
+
+echo
+echo "== FIN étape D =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,42 +1,102 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 1, passe 6 : nettoyage final + confirmation.
-# Supprime tout fichier de diagnostic laissé dans les public/, purge caches Laravel,
-# et confirme l'état HTTP final des deux apps.
+# KLASYO — Phase 1 / Semaine 2, étape A : dé-brander LMSZAI -> KLASYO (app_name)
+# + réactiver l'inscription publique sur platform (routes/web.php: register=>false -> true).
+# Scripts achetés : modifications minimales, chirurgicales, sauvegardées, réversibles.
+# Logs publics : aucun secret (on n'affiche jamais .env ni credentials DB).
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
-S="$ROOT/school"
 P="$ROOT/platform"
+BK="$HOME/backups_klasyo"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$BK"
 
-echo "== 1. Suppression des fichiers de diagnostic éventuels =="
-for f in "$S"/public/klasyo_h.php "$S"/public/klasyo_diag*.php "$P"/public/klasyo_diag*.php; do
-  if [ -e "$f" ]; then rm -f "$f" && echo "  supprimé : $(basename "$f")"; fi
+# Petit assistant PHP : lit la config DB depuis platform/.env, exécute une requête,
+# n'affiche que ce qu'on lui demande (jamais de credentials).
+run_sql() { # $1 = requête SQL
+  php -r '
+    $dir=$argv[1]; $host="localhost";$db=null;$u=null;$p=null;
+    foreach(file("$dir/.env",FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $l){
+      if(preg_match("/^(DB_HOST|DB_DATABASE|DB_USERNAME|DB_PASSWORD)\s*=\s*(.*)$/",$l,$m)){
+        $v=trim($m[2]," \t\"'"'"'");
+        if($m[1]=="DB_HOST")$host=$v; if($m[1]=="DB_DATABASE")$db=$v;
+        if($m[1]=="DB_USERNAME")$u=$v; if($m[1]=="DB_PASSWORD")$p=$v;
+      }
+    }
+    mysqli_report(MYSQLI_REPORT_OFF);
+    $m=@mysqli_connect($host,$u,$p,$db); if(!$m){echo "DB-ERR\n";exit(1);}
+    $r=mysqli_query($m,$argv[2]);
+    if($r===true){echo "OK rows=".mysqli_affected_rows($m)."\n";}
+    elseif($r){while($row=mysqli_fetch_row($r))echo implode(" | ",$row)."\n";}
+    else echo "SQL-ERR: ".mysqli_error($m)."\n";
+  ' "$P" "$1"
+}
+
+echo "########################################"
+echo "== A1. Sauvegarde des réglages de marque (avant modification) =="
+echo "########################################"
+run_sql "SELECT option_key, option_value FROM settings WHERE option_key IN ('app_name','app_title','site_title','copyright','meta_title')" \
+  | tee "$BK/settings_brand.before-$STAMP.txt"
+
+echo
+echo "########################################"
+echo "== A2. app_name : LMSZAI -> KLASYO (DB) =="
+echo "########################################"
+run_sql "UPDATE settings SET option_value='KLASYO' WHERE option_key='app_name'"
+# Certaines vues LMSZAI utilisent d'autres clés de titre : on les aligne si elles existent
+for K in app_title site_title meta_title; do
+  run_sql "UPDATE settings SET option_value='KLASYO' WHERE option_key='$K' AND option_value LIKE '%LMSzai%'"
 done
-echo "  Restes klasyo_* dans les public/ :"
-find "$S/public" "$P/public" -maxdepth 1 -name 'klasyo_*' 2>/dev/null || true
-echo "  (liste vide = propre)"
+echo "  --- après :"
+run_sql "SELECT option_key, option_value FROM settings WHERE option_key IN ('app_name','app_title','site_title','meta_title')"
 
 echo
-echo "== 2. Purge caches Laravel (school) après changement de handler =="
-(cd "$S" && php artisan config:clear 2>&1 | tail -1)
-(cd "$S" && php artisan cache:clear  2>&1 | tail -1) || true
-(cd "$S" && php artisan view:clear   2>&1 | tail -1)
+echo "########################################"
+echo "== A3. APP_NAME dans platform/.env =="
+echo "########################################"
+cp -a "$P/.env" "$P/.env.bak-name-$STAMP"
+if grep -q '^APP_NAME=' "$P/.env"; then
+  sed -i 's|^APP_NAME=.*|APP_NAME=KLASYO|' "$P/.env"
+else
+  printf 'APP_NAME=KLASYO\n' >> "$P/.env"
+fi
+grep '^APP_NAME=' "$P/.env"
 
 echo
-echo "== 3. Confirmation HTTP finale =="
-for u in "https://klasyo.org/" \
-         "https://klasyo.org/platform/index.php" \
-         "https://klasyo.org/school/" \
-         "https://klasyo.org/school/login" ; do
+echo "########################################"
+echo "== A4. Réactivation de l'inscription publique (routes/web.php) =="
+echo "########################################"
+WEB="$P/routes/web.php"
+echo "  Ligne actuelle Auth::routes :"
+grep -n "Auth::routes" "$WEB" || echo "  (introuvable)"
+if grep -q "Auth::routes(\['register' => false\])" "$WEB"; then
+  cp -a "$WEB" "$BK/web.php.bak-$STAMP"
+  echo "  backup: web.php.bak-$STAMP"
+  sed -i "s/Auth::routes(\['register' => false\])/Auth::routes(['register' => true])/" "$WEB"
+  echo "  -> inscription RÉACTIVÉE. Nouvelle ligne :"
+  grep -n "Auth::routes" "$WEB"
+elif grep -q "Auth::routes(\['register' => true\])" "$WEB"; then
+  echo "  Déjà réactivée (register => true)."
+else
+  echo "  (!) Motif register=>false non trouvé — inspection manuelle nécessaire :"
+  grep -n "Auth::routes" "$WEB"
+fi
+
+echo
+echo "########################################"
+echo "== A5. Purge caches + vérification HTTP =="
+echo "########################################"
+(cd "$P" && php artisan config:clear 2>&1 | tail -1)
+(cd "$P" && php artisan route:clear  2>&1 | tail -1)
+(cd "$P" && php artisan view:clear   2>&1 | tail -1)
+for u in "https://klasyo.org/platform/index.php" \
+         "https://klasyo.org/platform/register" \
+         "https://klasyo.org/platform/login" ; do
   out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (%{time_total}s)" "$u" 2>&1)
   echo "  $u -> $out"
 done
-echo "  -- sécurité (403/404 attendus) :"
-for u in "https://klasyo.org/school/.env" "https://klasyo.org/platform/.env" \
-         "https://klasyo.org/school/public/klasyo_h.php" ; do
-  code=$(curl -sk -o /dev/null -m 10 -w "%{http_code}" "$u")
-  echo "  $u -> $code"
-done
+echo "  --- <title> de la page d'accueil platform (doit refléter KLASYO) :"
+curl -skL -m 12 "https://klasyo.org/platform/index.php" 2>/dev/null | grep -oiE '<title>[^<]*</title>' | head -1
 
 echo
-echo "== FIN passe 6 — Phase 1 / Semaine 1 (P0) terminée =="
+echo "== FIN étape A (rebrand + inscription) =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,38 +1,39 @@
 #!/usr/bin/env bash
-# KLASYO — Étape F : la pièce manquante. lsphp83 exécute bien un .php DIRECT dans
-# platform/public, mais /platform/ (rewrite root -> public/index.php) sert du SOURCE
-# car le .htaccess RACINE n'a pas de handler (LiteSpeed applique le handler du contexte
-# où la règle de rewrite se déclenche). School marche car son .htaccess racine a lsphp83.
-# -> On pose lsphp83 dans platform/.htaccess (racine) et on VALIDE le HTML rendu.
+# KLASYO — Étape G : LA vraie cause. <FilesMatch "\.php$">SetHandler ne s'applique qu'aux
+# URLs finissant par .php. Les URLs propres (/platform/login) réécrites en interne vers
+# index.php n'exécutent pas -> PHP servi en SOURCE. Fix : AddHandler (clé sur l'extension
+# du FICHIER servi, pas l'URL). On corrige platform ET school, et on VALIDE le corps HTML.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
-P="$ROOT/platform"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-RHTA="$P/.htaccess"
 
-cp -a "$RHTA" "$RHTA.bak-F-$STAMP" && echo "backup: platform/.htaccess.bak-F-$STAMP"
-# Idempotence : retire un éventuel ancien bloc KLASYO handler
-sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
-# Ajoute le handler exécutant (lsphp83) au niveau RACINE
-cat >> "$RHTA" <<'HTA'
-# KLASYO-PHP-HANDLER
-<FilesMatch "\.(php|phtml)$">
-SetHandler application/x-lsphp83
-</FilesMatch>
-HTA
-echo "  lsphp83 posé sur platform/.htaccess (racine)."
+apply_addhandler() { # $1 = fichier .htaccess ; $2 = version lsphp
+  local f="$1" v="$2"
+  [ -f "$f" ] || { echo "  (absent) $f"; return; }
+  cp -a "$f" "$f.bak-G-$STAMP"
+  # Retire l'ancien bloc KLASYO handler (FilesMatch/SetHandler) posé précédemment
+  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$f" 2>/dev/null || true
+  # Retire d'éventuelles lignes AddHandler/SetHandler lsphp existantes pour repartir propre
+  sed -i -E '/AddHandler +application\/x-lsphp[0-9]+/d' "$f" 2>/dev/null || true
+  # Ajoute AddHandler (s'applique au fichier résolu, y compris index.php après rewrite)
+  cat >> "$f" <<EOF
+# KLASYO-PHP-HANDLER-ADD
+AddHandler application/x-lsphp${v} .php .phtml
+EOF
+  echo "  AddHandler lsphp${v} -> $(basename "$(dirname "$f")")/.htaccess"
+}
 
-# Nettoyage d'éventuels fichiers diag laissés
-rm -f "$P"/public/klasyo_exec.php "$P"/public/klasyo_*.php 2>/dev/null || true
+# platform (Laravel 9) et school (Laravel 10) : PHP 8.3 est le seul handler qui exécute ici
+for APP in platform school; do
+  apply_addhandler "$ROOT/$APP/.htaccess" 83
+  apply_addhandler "$ROOT/$APP/public/.htaccess" 83
+  (cd "$ROOT/$APP" && php artisan config:clear 2>&1 | tail -1)
+  (cd "$ROOT/$APP" && php artisan view:clear 2>&1 | tail -1)
+done
 
 echo
-echo "== Purge caches =="
-(cd "$P" && php artisan config:clear 2>&1 | tail -1)
-(cd "$P" && php artisan view:clear   2>&1 | tail -1)
-
-echo
-echo "== VALIDATION FINALE (corps HTML, jamais du source) =="
+echo "== VALIDATION — le CORPS doit être du HTML, jamais du source PHP =="
 check() {
   local url="$1"
   local body; body=$(curl -skL -m 15 "$url" 2>/dev/null)
@@ -40,28 +41,24 @@ check() {
   if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|Taylor Otwell|require_once __DIR__'; then
     echo "  $url -> [$code] !!! SOURCE PHP"
   elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
-    local t; t=$(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)
-    echo "  $url -> [$code] OK HTML | $t"
+    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
   else
-    echo "  $url -> [$code] ? début: $(printf '%s' "$body" | head -c 40 | tr -d '\n\r')"
+    echo "  $url -> [$code] ? $(printf '%s' "$body" | head -c 45 | tr -d '\n\r')"
   fi
 }
+echo "--- PLATFORM :"
 check "https://klasyo.org/platform/"
 check "https://klasyo.org/platform/login"
 check "https://klasyo.org/platform/register"
+echo "--- SCHOOL :"
+check "https://klasyo.org/school/"
+check "https://klasyo.org/school/login"
+echo "--- LANDING :"
+check "https://klasyo.org/"
 
 echo
-echo "== Rebrand : 'KLASYO' visible dans la page login ? =="
-curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | head -3
+echo "== Rebrand KLASYO visible ? (page login platform) =="
+curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | sort -u | head -3 || echo "  (ni KLASYO ni LMSzai trouvés)"
 
 echo
-echo "== Non-régression école + landing =="
-for u in "https://klasyo.org/" "https://klasyo.org/school/" "https://klasyo.org/school/login"; do
-  echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
-done
-echo "  -- sécurité : plus aucun .php servi en source ? test index.php :"
-b=$(curl -skL -m 12 "https://klasyo.org/platform/index.php" 2>/dev/null)
-printf '%s' "$b" | grep -qiE '<\?php|Illuminate\\Contracts' && echo "  !!! index.php encore en source" || echo "  OK index.php ne divulgue pas de source"
-
-echo
-echo "== FIN étape F =="
+echo "== FIN étape G =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,102 +1,63 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 2, étape A : dé-brander LMSZAI -> KLASYO (app_name)
-# + réactiver l'inscription publique sur platform (routes/web.php: register=>false -> true).
-# Scripts achetés : modifications minimales, chirurgicales, sauvegardées, réversibles.
-# Logs publics : aucun secret (on n'affiche jamais .env ni credentials DB).
+# KLASYO — Diagnostic B : pourquoi /platform/login et /platform/register hangent (15s)
+# alors que la page d'accueil (même front controller server.php) répond en 200.
+# Hypothèse : appel réseau sortant (license check / captcha serveur) sur ces routes.
+# Logs publics : aucun secret.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
-BK="$HOME/backups_klasyo"
-STAMP="$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$BK"
 
-# Petit assistant PHP : lit la config DB depuis platform/.env, exécute une requête,
-# n'affiche que ce qu'on lui demande (jamais de credentials).
-run_sql() { # $1 = requête SQL
-  php -r '
-    $dir=$argv[1]; $host="localhost";$db=null;$u=null;$p=null;
-    foreach(file("$dir/.env",FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES) as $l){
-      if(preg_match("/^(DB_HOST|DB_DATABASE|DB_USERNAME|DB_PASSWORD)\s*=\s*(.*)$/",$l,$m)){
-        $v=trim($m[2]," \t\"'"'"'");
-        if($m[1]=="DB_HOST")$host=$v; if($m[1]=="DB_DATABASE")$db=$v;
-        if($m[1]=="DB_USERNAME")$u=$v; if($m[1]=="DB_PASSWORD")$p=$v;
-      }
-    }
-    mysqli_report(MYSQLI_REPORT_OFF);
-    $m=@mysqli_connect($host,$u,$p,$db); if(!$m){echo "DB-ERR\n";exit(1);}
-    $r=mysqli_query($m,$argv[2]);
-    if($r===true){echo "OK rows=".mysqli_affected_rows($m)."\n";}
-    elseif($r){while($row=mysqli_fetch_row($r))echo implode(" | ",$row)."\n";}
-    else echo "SQL-ERR: ".mysqli_error($m)."\n";
-  ' "$P" "$1"
-}
-
-echo "########################################"
-echo "== A1. Sauvegarde des réglages de marque (avant modification) =="
-echo "########################################"
-run_sql "SELECT option_key, option_value FROM settings WHERE option_key IN ('app_name','app_title','site_title','copyright','meta_title')" \
-  | tee "$BK/settings_brand.before-$STAMP.txt"
-
-echo
-echo "########################################"
-echo "== A2. app_name : LMSZAI -> KLASYO (DB) =="
-echo "########################################"
-run_sql "UPDATE settings SET option_value='KLASYO' WHERE option_key='app_name'"
-# Certaines vues LMSZAI utilisent d'autres clés de titre : on les aligne si elles existent
-for K in app_title site_title meta_title; do
-  run_sql "UPDATE settings SET option_value='KLASYO' WHERE option_key='$K' AND option_value LIKE '%LMSzai%'"
-done
-echo "  --- après :"
-run_sql "SELECT option_key, option_value FROM settings WHERE option_key IN ('app_name','app_title','site_title','meta_title')"
-
-echo
-echo "########################################"
-echo "== A3. APP_NAME dans platform/.env =="
-echo "########################################"
-cp -a "$P/.env" "$P/.env.bak-name-$STAMP"
-if grep -q '^APP_NAME=' "$P/.env"; then
-  sed -i 's|^APP_NAME=.*|APP_NAME=KLASYO|' "$P/.env"
-else
-  printf 'APP_NAME=KLASYO\n' >> "$P/.env"
-fi
-grep '^APP_NAME=' "$P/.env"
-
-echo
-echo "########################################"
-echo "== A4. Réactivation de l'inscription publique (routes/web.php) =="
-echo "########################################"
-WEB="$P/routes/web.php"
-echo "  Ligne actuelle Auth::routes :"
-grep -n "Auth::routes" "$WEB" || echo "  (introuvable)"
-if grep -q "Auth::routes(\['register' => false\])" "$WEB"; then
-  cp -a "$WEB" "$BK/web.php.bak-$STAMP"
-  echo "  backup: web.php.bak-$STAMP"
-  sed -i "s/Auth::routes(\['register' => false\])/Auth::routes(['register' => true])/" "$WEB"
-  echo "  -> inscription RÉACTIVÉE. Nouvelle ligne :"
-  grep -n "Auth::routes" "$WEB"
-elif grep -q "Auth::routes(\['register' => true\])" "$WEB"; then
-  echo "  Déjà réactivée (register => true)."
-else
-  echo "  (!) Motif register=>false non trouvé — inspection manuelle nécessaire :"
-  grep -n "Auth::routes" "$WEB"
-fi
-
-echo
-echo "########################################"
-echo "== A5. Purge caches + vérification HTTP =="
-echo "########################################"
-(cd "$P" && php artisan config:clear 2>&1 | tail -1)
-(cd "$P" && php artisan route:clear  2>&1 | tail -1)
-(cd "$P" && php artisan view:clear   2>&1 | tail -1)
-for u in "https://klasyo.org/platform/index.php" \
-         "https://klasyo.org/platform/register" \
-         "https://klasyo.org/platform/login" ; do
-  out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (%{time_total}s)" "$u" 2>&1)
+echo "== B1. Timing HTTP fin : accueil vs login vs register =="
+for u in "https://klasyo.org/platform/" \
+         "https://klasyo.org/platform/index.php" \
+         "https://klasyo.org/platform/login" \
+         "https://klasyo.org/platform/register" ; do
+  out=$(curl -sk -o /dev/null -m 20 -w "%{http_code} time=%{time_total}s" "$u" 2>&1)
   echo "  $u -> $out"
 done
-echo "  --- <title> de la page d'accueil platform (doit refléter KLASYO) :"
-curl -skL -m 12 "https://klasyo.org/platform/index.php" 2>/dev/null | grep -oiE '<title>[^<]*</title>' | head -1
 
 echo
-echo "== FIN étape A (rebrand + inscription) =="
+echo "== B2. Exécution CLI de la route /login (localise le hang, timeout 25s) =="
+cd "$P"
+START=$(date +%s)
+timeout 25 php -d display_errors=1 -r '
+  $_SERVER["REQUEST_URI"]="/login";
+  $_SERVER["REQUEST_METHOD"]="GET";
+  $_SERVER["HTTP_HOST"]="klasyo.org";
+  $_SERVER["SCRIPT_NAME"]="/platform/index.php";
+  $_SERVER["SCRIPT_FILENAME"]=__DIR__."/server.php";
+  require "server.php";
+' > /tmp/kl_login.html 2>&1
+RC=$?; END=$(date +%s)
+echo "  exit=$RC durée=$((END-START))s taille=$(wc -c < /tmp/kl_login.html)o"
+if [ $RC -eq 124 ]; then echo "  => TIMEOUT en CLI aussi : le hang est DANS le code PHP (pas le web-server)."; fi
+echo "  --- 200 premiers caractères :"; head -c 200 /tmp/kl_login.html | tr -d '\r'
+echo
+echo "  --- erreurs/traces :"; grep -oiE '(fatal|exception|error|curl|guzzle|timed? ?out|curl_exec|file_get_contents|stream_socket|verify|license|licen[cs]e|activation)[^<]{0,80}' /tmp/kl_login.html | head -8 || echo "  (aucune)"
+rm -f /tmp/kl_login.html
+
+echo
+echo "== B3. Recherche d'appels réseau sortants sur les routes auth (code LMSZAI) =="
+echo "  --- LoginController / RegisterController :"
+for f in "$P"/app/Http/Controllers/Auth/LoginController.php "$P"/app/Http/Controllers/Auth/RegisterController.php; do
+  [ -f "$f" ] && { echo "  [$f]"; grep -niE 'curl|guzzle|http::|file_get_contents|Client\(|verify|licen[cs]e|activation|gethostby|fsockopen|checkPurchase|envato' "$f" | head -8 || echo "    (rien)"; }
+done
+echo "  --- middlewares globaux appelant l'extérieur :"
+grep -rniE 'curl_exec|file_get_contents\(.?http|Http::(get|post)|new Client|checkPurchase|envato|verify.*license|license.*verify' \
+  "$P"/app/Http/Middleware "$P"/app/Providers 2>/dev/null | head -12 || echo "  (rien)"
+
+echo
+echo "== B4. Sortie internet du serveur (un timeout ici expliquerait le hang) =="
+for host in "api.envato.com" "google.com" "codecanyon.net"; do
+  t=$(curl -s -o /dev/null -m 8 -w "%{http_code} %{time_total}s" "https://$host" 2>&1 || echo "FAIL")
+  echo "  https://$host -> $t"
+done
+
+echo
+echo "== B5. version.update middleware (LMSZAI enveloppe les routes dedans) =="
+grep -rniE 'version.update|VersionUpdate|process-update' "$P"/app/Http/Kernel.php "$P"/app/Http/Middleware 2>/dev/null | head -8 || echo "  (rien)"
+ls "$P"/app/Http/Middleware 2>/dev/null | head -30
+
+echo
+echo "== FIN diagnostic B =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,44 +1,46 @@
 #!/usr/bin/env bash
-# KLASYO — Diagnostic K : confirmer que les apps FONCTIONNENT via /public/ (le 404 est
-# purement un souci de sous-dossier vs racine), et évaluer l'option sous-domaines.
+# KLASYO — Diagnostic L : (1) trouver la cause du 500 sur /register,
+# (2) chercher un outil de capture d'écran sur le VPS, (3) reconfirmer le login OK.
+# Logs publics : aucun secret.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
+P="$ROOT/platform"
 
-echo "== K1. Les apps rendent-elles la VRAIE page via /public/ ? =="
-check() {
-  local url="$1"
-  local body; body=$(curl -sk -m 15 "$url" 2>/dev/null)
-  local code; code=$(curl -sk -o /dev/null -m 15 -w "%{http_code}" "$url" 2>/dev/null)
-  local title; title=$(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)
-  local hasform; printf '%s' "$body" | grep -qiE '<form|password|login|connexion|sign in' && hasform="[formulaire présent]" || hasform=""
-  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts'; then
-    echo "  $url -> [$code] SOURCE"
-  else
-    echo "  $url -> [$code] $title $hasform"
-  fi
-}
-check "https://klasyo.org/platform/public/"
-check "https://klasyo.org/platform/public/login"
-check "https://klasyo.org/platform/public/register"
-check "https://klasyo.org/school/public/"
-check "https://klasyo.org/school/public/login"
-
-echo
-echo "== K2. Sous-domaines déjà présents ? (domains/ du compte) =="
-ls -d /home/*/domains/*/ 2>/dev/null | sed 's#.*/domains/##' | head -40
+echo "== L1. Cause du 500 sur /register (exécution CLI, erreurs affichées) =="
+cd "$P/public"
+timeout 30 php -d display_errors=1 -d error_reporting=E_ALL -r '
+  $_SERVER["REQUEST_URI"]="/register";
+  $_SERVER["REQUEST_METHOD"]="GET";
+  $_SERVER["HTTP_HOST"]="klasyo.org";
+  $_SERVER["SCRIPT_NAME"]="/platform/public/index.php";
+  $_SERVER["SCRIPT_FILENAME"]=__DIR__."/index.php";
+  require "index.php";
+' > /tmp/kl_reg.html 2>&1
+echo "  taille réponse: $(wc -c < /tmp/kl_reg.html)o"
+echo "  --- erreurs/exception détectées :"
+grep -oiE '(Fatal error|ParseError|Exception|Error:|Undefined|Call to|View \[[^]]*\] not found|Class .* not found|SQLSTATE|does not exist|Trait|Target class)[^<]{0,120}' /tmp/kl_reg.html | head -8 || echo "  (aucune ligne d'erreur évidente)"
+echo "  --- titre rendu :"
+grep -oiE '<title>[^<]*</title>' /tmp/kl_reg.html | head -1
+echo "  --- dernières lignes du log Laravel platform (messages) :"
+L=$(ls -t "$P"/storage/logs/*.log 2>/dev/null | head -1)
+[ -n "$L" ] && grep -oE '^\[[0-9 :-]+\] \w+\.\w+: [^{]{0,140}' "$L" | tail -4 || echo "  (pas de log)"
+rm -f /tmp/kl_reg.html
 
 echo
-echo "== K3. Outil DirectAdmin CLI dispo pour créer un sous-domaine ? =="
-for b in /usr/local/directadmin/directadmin /usr/local/bin/da; do
-  [ -x "$b" ] && echo "  trouvé: $b" || echo "  absent: $b"
+echo "== L2. Outils de capture d'écran disponibles sur le VPS ? =="
+for t in chromium chromium-browser google-chrome google-chrome-stable wkhtmltoimage cutycapt; do
+  p=$(command -v "$t" 2>/dev/null) && echo "  TROUVÉ: $t -> $p" || echo "  absent: $t"
 done
-echo "  --- structure d'un sous-domaine existant (sub-dir sous public_html ?) :"
-ls -la "$ROOT" 2>/dev/null | grep -iE 'sub|platform|school|store|studio|app' | head -10
+echo "  (node/npx pour puppeteer ?) : $(command -v node 2>/dev/null || echo 'node absent') / $(command -v npx 2>/dev/null || echo 'npx absent')"
 
 echo
-echo "== K4. APP_URL actuels (indice de config racine attendue) =="
-grep -h '^APP_URL=' "$ROOT/platform/.env" "$ROOT/school/.env" 2>/dev/null
+echo "== L3. Reconfirmation login (doit rester OK) =="
+for u in "https://klasyo.org/platform/public/login" "https://klasyo.org/school/public/login"; do
+  code=$(curl -sk -o /dev/null -m 12 -w '%{http_code}' "$u")
+  title=$(curl -sk -m 12 "$u" 2>/dev/null | grep -oiE '<title>[^<]*</title>' | head -1)
+  echo "  $u -> [$code] $title"
+done
 
 echo
-echo "== FIN diagnostic K =="
+echo "== FIN diagnostic L =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,46 +1,40 @@
 #!/usr/bin/env bash
-# KLASYO — Diagnostic L : (1) trouver la cause du 500 sur /register,
-# (2) chercher un outil de capture d'écran sur le VPS, (3) reconfirmer le login OK.
-# Logs publics : aucun secret.
+# KLASYO — Étape M : annuler le hack register=>true (mauvais mécanisme : LMSZAI n'a pas de
+# vue auth.register -> 500). LMSZAI a sa propre inscription native, qui fonctionnera une fois
+# l'app servie à la racine (sous-domaine). On restaure register=>false (état propre, pas de 500).
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
+STAMP="$(date +%Y%m%d-%H%M%S)"
+WEB="$P/routes/web.php"
 
-echo "== L1. Cause du 500 sur /register (exécution CLI, erreurs affichées) =="
-cd "$P/public"
-timeout 30 php -d display_errors=1 -d error_reporting=E_ALL -r '
-  $_SERVER["REQUEST_URI"]="/register";
-  $_SERVER["REQUEST_METHOD"]="GET";
-  $_SERVER["HTTP_HOST"]="klasyo.org";
-  $_SERVER["SCRIPT_NAME"]="/platform/public/index.php";
-  $_SERVER["SCRIPT_FILENAME"]=__DIR__."/index.php";
-  require "index.php";
-' > /tmp/kl_reg.html 2>&1
-echo "  taille réponse: $(wc -c < /tmp/kl_reg.html)o"
-echo "  --- erreurs/exception détectées :"
-grep -oiE '(Fatal error|ParseError|Exception|Error:|Undefined|Call to|View \[[^]]*\] not found|Class .* not found|SQLSTATE|does not exist|Trait|Target class)[^<]{0,120}' /tmp/kl_reg.html | head -8 || echo "  (aucune ligne d'erreur évidente)"
-echo "  --- titre rendu :"
-grep -oiE '<title>[^<]*</title>' /tmp/kl_reg.html | head -1
-echo "  --- dernières lignes du log Laravel platform (messages) :"
-L=$(ls -t "$P"/storage/logs/*.log 2>/dev/null | head -1)
-[ -n "$L" ] && grep -oE '^\[[0-9 :-]+\] \w+\.\w+: [^{]{0,140}' "$L" | tail -4 || echo "  (pas de log)"
-rm -f /tmp/kl_reg.html
+echo "== Ligne actuelle :"
+grep -n "Auth::routes" "$WEB"
+if grep -q "Auth::routes(\['register' => true\])" "$WEB"; then
+  cp -a "$WEB" "$WEB.bak-M-$STAMP"
+  sed -i "s/Auth::routes(\['register' => true\])/Auth::routes(['register' => false])/" "$WEB"
+  echo "  -> restauré register=>false (plus de 500 sur /register)."
+else
+  echo "  (déjà register=>false ou motif absent)"
+fi
+grep -n "Auth::routes" "$WEB"
+(cd "$P" && php artisan route:clear 2>&1 | tail -1)
+(cd "$P" && php artisan config:clear 2>&1 | tail -1)
 
 echo
-echo "== L2. Outils de capture d'écran disponibles sur le VPS ? =="
-for t in chromium chromium-browser google-chrome google-chrome-stable wkhtmltoimage cutycapt; do
-  p=$(command -v "$t" 2>/dev/null) && echo "  TROUVÉ: $t -> $p" || echo "  absent: $t"
-done
-echo "  (node/npx pour puppeteer ?) : $(command -v node 2>/dev/null || echo 'node absent') / $(command -v npx 2>/dev/null || echo 'npx absent')"
+echo "== Chercher le flux d'inscription NATIF de LMSZAI (routes signup/register) =="
+grep -rniE "register|sign.?up|signup|enroll" "$P/routes/web.php" 2>/dev/null | grep -viE 'Auth::routes|verification|version' | head -12 || echo "  (aucune route register native évidente dans web.php)"
+echo "  --- vues d'inscription présentes ?"
+find "$P/resources/views" -iname '*register*' -o -iname '*signup*' 2>/dev/null | grep -v vendor | head -10 || echo "  (aucune vue register/signup)"
+echo "  --- lien d'inscription dans la page login (frontend) :"
+grep -rniE "href=.*(register|signup|sign-up)" "$P/resources/views/frontend" 2>/dev/null | head -5 || echo "  (aucun lien évident)"
 
 echo
-echo "== L3. Reconfirmation login (doit rester OK) =="
-for u in "https://klasyo.org/platform/public/login" "https://klasyo.org/school/public/login"; do
-  code=$(curl -sk -o /dev/null -m 12 -w '%{http_code}' "$u")
-  title=$(curl -sk -m 12 "$u" 2>/dev/null | grep -oiE '<title>[^<]*</title>' | head -1)
-  echo "  $u -> [$code] $title"
-done
+echo "== État final (un seul appel HTTP, pour éviter le throttling firewall) =="
+sleep 2
+code=$(curl -sk -o /dev/null -m 20 -w '%{http_code}' "https://klasyo.org/platform/public/login" 2>/dev/null)
+echo "  /platform/public/login -> [$code]"
 
 echo
-echo "== FIN diagnostic L =="
+echo "== FIN étape M =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,92 +1,86 @@
 #!/usr/bin/env bash
-# KLASYO — Étape D : CORRIGER platform — server.php était servi en SOURCE (pas exécuté).
-# Cause : le .htaccess racine rewrite vers server.php + un SetHandler mal appliqué -> code source
-# renvoyé en texte (bug fonctionnel + divulgation de code). Fix : router vers public/index.php
-# (patron "subdir-safe" identique à school, dont le public/.htaccess a déjà le handler lsphp80).
-# On VALIDE le CONTENU (HTML réel, pas du source PHP), pas seulement le code HTTP.
+# KLASYO — Étape E : platform sert le PHP en SOURCE car son handler lsphp80 n'exécute pas
+# (PHP 8.0 non enregistré sur ce LiteSpeed). School marche avec lsphp83.
+# On DÉTECTE le handler qui EXÉCUTE réellement (on valide le CORPS, pas le code HTTP),
+# on l'applique à platform/public/.htaccess, puis on valide que les pages rendent du HTML.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
+PUB="$P/public"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-RHTA="$P/.htaccess"
+PHTA="$PUB/.htaccess"
 
-cp -a "$RHTA" "$RHTA.bak-D-$STAMP" && echo "backup: platform/.htaccess.bak-D-$STAMP"
+cp -a "$PHTA" "$PHTA.bak-E-$STAMP" && echo "backup: platform/public/.htaccess.bak-E-$STAMP"
 
-echo "== .htaccess racine platform AVANT :"
-sed -n '1,60p' "$RHTA"
+# Fichier diag qui, s'il EXÉCUTE, imprime un marqueur unique + la version PHP
+DIAG="$PUB/klasyo_exec.php"
+echo '<?php echo "LSPHPEXEC-".PHP_VERSION;' > "$DIAG"
 
-# Nouveau .htaccess racine : route tout vers public/ (front controller public/index.php),
-# PAS de SetHandler ici (c'est public/.htaccess qui porte le handler lsphp80).
-cat > "$RHTA" <<'HTA'
-# KLASYO-SUBDIR-SAFE — platform (LMSZAI) servi depuis /platform/, routé vers public/
-# (server.php était renvoyé en SOURCE ; on passe par public/index.php comme school)
-<IfModule mod_rewrite.c>
-    <IfModule mod_negotiation.c>
-        Options -MultiViews -Indexes
-    </IfModule>
+echo "== Handler actuel dans platform/public/.htaccess :"
+grep -niE 'sethandler|lsphp' "$PHTA" || echo "  (aucun)"
 
-    RewriteEngine On
+WINNER=""
+for V in 83 82 81 80; do
+  # Remplace toute valeur x-lsphpNN existante par la version testée
+  if grep -qiE 'x-lsphp[0-9]+' "$PHTA"; then
+    sed -i -E "s#application/x-lsphp[0-9]+#application/x-lsphp${V}#g" "$PHTA"
+  else
+    # pas de SetHandler -> on en ajoute un (bloc KLASYO), nettoyé à chaque tour
+    sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$PHTA" 2>/dev/null || true
+    printf '# KLASYO-PHP-HANDLER\n<FilesMatch "\\.(php|phtml)$">\nSetHandler application/x-lsphp%s\n</FilesMatch>\n' "$V" >> "$PHTA"
+  fi
+  body=$(curl -sk -m 12 "https://klasyo.org/platform/public/klasyo_exec.php" 2>/dev/null | head -c 60)
+  if printf '%s' "$body" | grep -q "LSPHPEXEC-"; then
+    WINNER="$V"
+    echo "  lsphp${V} -> EXÉCUTE : ${body}"
+    break
+  else
+    echo "  lsphp${V} -> pas d'exécution (début: $(printf '%s' "$body" | head -c 25))"
+  fi
+done
+rm -f "$DIAG"
 
-    # Ne pas re-réécrire ce qui est déjà sous public/ (stoppe toute boucle)
-    RewriteRule ^public/ - [L]
-
-    # Fichier statique existant dans public/ -> le servir directement
-    RewriteCond %{DOCUMENT_ROOT}/platform/public/$1 -f
-    RewriteRule ^(.*)$ public/$1 [L]
-
-    # Tout le reste -> front controller Laravel (public/index.php porte le handler lsphp80)
-    RewriteRule ^ public/index.php [L]
-
-    # En-tête Authorization pour l'API
-    RewriteCond %{HTTP:Authorization} .
-    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
-</IfModule>
-HTA
-echo "  Nouveau .htaccess racine écrit (route vers public/, sans SetHandler)."
+if [ -z "$WINNER" ]; then
+  echo "  (!) Aucun handler n'exécute — restauration + il faudra fixer la version PHP dans DirectAdmin."
+  cp -a "$PHTA.bak-E-$STAMP" "$PHTA"
+else
+  echo "  ==> Handler lsphp${WINNER} appliqué à platform/public/.htaccess."
+fi
 
 echo
 echo "== Purge caches =="
 (cd "$P" && php artisan config:clear 2>&1 | tail -1)
 (cd "$P" && php artisan view:clear   2>&1 | tail -1)
-(cd "$P" && php artisan route:clear  2>&1 | tail -1)
 
 echo
-echo "== VALIDATION DU CONTENU (pas seulement le code HTTP) =="
+echo "== VALIDATION FINALE — le corps doit être du HTML, jamais du source PHP =="
 check() {
   local url="$1"
   local body; body=$(curl -skL -m 15 "$url" 2>/dev/null)
   local code; code=$(curl -skL -o /dev/null -m 15 -w "%{http_code}" "$url" 2>/dev/null)
-  local first; first=$(printf '%s' "$body" | head -c 40 | tr -d '\n\r')
-  local verdict="?"
-  if printf '%s' "$body" | grep -qiE 'Taylor Otwell|mod_rewrite|require_once __DIR__|A PHP Framework'; then
-    verdict="!!! SOURCE PHP EXPOSÉE"
+  if printf '%s' "$body" | grep -qiE '<\?php|Illuminate\\Contracts|Taylor Otwell|require_once __DIR__'; then
+    echo "  $url -> [$code] !!! SOURCE PHP"
   elif printf '%s' "$body" | grep -qiE '<!doctype html|<html'; then
-    verdict="OK (HTML rendu)"
-  elif [ -z "$body" ]; then
-    verdict="(vide)"
+    echo "  $url -> [$code] OK HTML | $(printf '%s' "$body" | grep -oiE '<title>[^<]*</title>' | head -1)"
   else
-    verdict="autre"
+    echo "  $url -> [$code] ? ($(printf '%s' "$body" | head -c 30 | tr -d '\n\r'))"
   fi
-  echo "  $url -> [$code] $verdict | début: ${first}"
 }
 check "https://klasyo.org/platform/"
 check "https://klasyo.org/platform/login"
 check "https://klasyo.org/platform/register"
-check "https://klasyo.org/platform/index.php"
 
 echo
-echo "== Titre + présence de 'KLASYO' dans la page login (rebrand) =="
-LOGIN=$(curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null)
-printf '%s' "$LOGIN" | grep -oiE '<title>[^<]*</title>' | head -1 || echo "  (pas de title)"
-printf '%s' "$LOGIN" | grep -oiE 'KLASYO' | head -1 && echo "  -> 'KLASYO' présent" || echo "  -> 'KLASYO' absent (vérifier logo/nom dans les vues)"
+echo "== 'KLASYO' présent dans la page login ? =="
+curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE 'KLASYO' | head -1 && echo "  -> présent" || echo "  -> absent"
 
 echo
-echo "== Confirmation école (ne pas régresser) =="
-for u in "https://klasyo.org/school/" "https://klasyo.org/school/login" "https://klasyo.org/"; do
-  code=$(curl -skL -o /dev/null -m 12 -w "%{http_code}" "$u")
-  echo "  $u -> $code"
+echo "== École (non-régression) + reste public/ propre =="
+for u in "https://klasyo.org/school/login" "https://klasyo.org/"; do
+  echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
 done
+find "$PUB" -maxdepth 1 -name 'klasyo_*' 2>/dev/null && echo "  (fichiers diag restants ci-dessus)" || echo "  public/ propre (aucun diag)"
 
 echo
-echo "== FIN étape D =="
+echo "== FIN étape E =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,55 +1,86 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 1, passe 4 : isoler la cause du hang PHP dans /school.
-# Le PHP direct dans school/public timeout (000/15s) alors que platform/public répond.
-# On teste : (a) contenu du .htaccess de school/public vs platform/public,
-# (b) réponse PHP quand on met school/public/.htaccess de côté.
-# Logs publics : aucun secret (ces .htaccess ne contiennent pas de secrets).
+# KLASYO — Phase 1 / Semaine 1, passe 5 : RÉPARER /school.
+# Cause identifiée : school/public/.htaccess n'a AUCUN handler PHP LiteSpeed,
+# alors que platform/public en a un (SetHandler application/x-lsphp80) et fonctionne.
+# → On détecte le handler lsphp qui répond (83>82>81>80, school=Laravel10 veut PHP 8.1+),
+#   puis on l'écrit dans school/public/.htaccess ET school/.htaccess. Backups + idempotent.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 S="$ROOT/school"
-P="$ROOT/platform"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 
-echo "== A. school/public/.htaccess (intégral) =="
-cat "$S/public/.htaccess" 2>/dev/null || echo "(absent)"
-echo
-echo "== B. platform/public/.htaccess (intégral, référence qui marche) =="
-cat "$P/public/.htaccess" 2>/dev/null || echo "(absent)"
+DIAG="$S/public/klasyo_h.php"
+echo '<?php echo "OKHANDLER-".PHP_VERSION;' > "$DIAG"
+HTA="$S/public/.htaccess"
+cp -a "$HTA" "$HTA.bak-$STAMP" && echo "backup: public/.htaccess.bak-$STAMP"
 
-echo
-echo "== C. Test décisif : PHP direct SANS le .htaccess de school/public =="
-DIAG="$S/public/klasyo_diag2.php"
-echo '<?php echo "OK-NOHTA-".PHP_VERSION;' > "$DIAG"
-if [ -f "$S/public/.htaccess" ]; then
-  mv "$S/public/.htaccess" "$S/public/.htaccess.OFF-$STAMP"
-  echo "  .htaccess mis de côté (.htaccess.OFF-$STAMP)"
-fi
-out=$(curl -sk -m 15 -w " [%{http_code} time=%{time_total}s]" "https://klasyo.org/school/public/klasyo_diag2.php" 2>&1 | head -c 100)
-echo "  résultat SANS .htaccess -> $out"
-# Restaurer immédiatement
-if [ -f "$S/public/.htaccess.OFF-$STAMP" ]; then
-  mv "$S/public/.htaccess.OFF-$STAMP" "$S/public/.htaccess"
-  echo "  .htaccess restauré."
-fi
+# Retire tout ancien bloc handler KLASYO déjà posé (idempotence)
+sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$HTA" 2>/dev/null || true
+
+WINNER=""
+for V in 83 82 81 80; do
+  # Injecte le bloc handler pour cette version
+  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$HTA" 2>/dev/null || true
+  cat >> "$HTA" <<EOF
+# KLASYO-PHP-HANDLER
+<FilesMatch "\.(php|phtml)\$">
+SetHandler application/x-lsphp${V}
+</FilesMatch>
+EOF
+  out=$(curl -sk -m 12 -w "%{http_code}" "https://klasyo.org/school/public/klasyo_h.php" 2>&1)
+  body=$(echo "$out" | head -c 60)
+  code=$(echo "$out" | tail -c 4)
+  echo "  lsphp${V} -> ${body}"
+  if echo "$out" | grep -q "OKHANDLER-"; then
+    WINNER="$V"
+    echo "  ==> lsphp${V} FONCTIONNE (PHP $(echo "$out" | grep -oE 'OKHANDLER-[0-9.]+' | cut -d- -f2))"
+    break
+  fi
+done
 rm -f "$DIAG"
 
-echo
-echo "== D. Comparaison des handlers PHP (school vs platform) au niveau du domaine =="
-echo "  --- lignes PHP/handler dans TOUS les .htaccess de school :"
-grep -rniE 'php|handler|fcgi|lsapi|application/x-httpd' "$S"/.htaccess "$S"/public/.htaccess 2>/dev/null | head -15 || echo "  (rien)"
-echo "  --- idem platform (référence) :"
-grep -rniE 'php|handler|fcgi|lsapi|application/x-httpd' "$P"/.htaccess "$P"/public/.htaccess 2>/dev/null | head -15 || echo "  (rien)"
+if [ -z "$WINNER" ]; then
+  echo "  (!) Aucun handler lsphp ne répond via .htaccess — restauration du backup."
+  cp -a "$HTA.bak-$STAMP" "$HTA"
+  echo "  Il faudra régler la version PHP de /school dans DirectAdmin (MultiPHP/PHP Selector)."
+else
+  # Le bloc gagnant est déjà en place dans public/.htaccess.
+  echo
+  echo "== Handler lsphp${WINNER} appliqué à school/public/.htaccess =="
+  # Poser aussi le handler dans school/.htaccess (racine du sous-dossier) par cohérence
+  RHTA="$S/.htaccess"
+  cp -a "$RHTA" "$RHTA.bak-$STAMP" 2>/dev/null
+  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$RHTA" 2>/dev/null || true
+  cat >> "$RHTA" <<EOF
+# KLASYO-PHP-HANDLER
+<FilesMatch "\.(php|phtml)\$">
+SetHandler application/x-lsphp${WINNER}
+</FilesMatch>
+EOF
+  echo "  Handler aussi posé sur school/.htaccess."
+fi
 
 echo
-echo "== E. Différence de permissions / propriété entre les deux public/ =="
-stat -c '%A %U:%G %n' "$S/public" "$S/public/index.php" "$P/public" "$P/public/index.php" 2>/dev/null
-
-echo
-echo "== F. .htaccess éventuels plus haut dans l'arborescence (hériteraient sur school) =="
-for d in "$ROOT" "$HOME"; do
-  [ -f "$d/.htaccess" ] && { echo "  --- $d/.htaccess :"; grep -niE 'php|handler|rewrite|deny|require' "$d/.htaccess" | head -10; } || echo "  (pas de .htaccess dans $d)"
+echo "== Vérification finale HTTP =="
+for u in "https://klasyo.org/school/" \
+         "https://klasyo.org/school/login" \
+         "https://klasyo.org/school/public/index.php" \
+         "https://klasyo.org/platform/index.php" \
+         "https://klasyo.org/" ; do
+  out=$(curl -skL -o /dev/null -m 15 -w "%{http_code} (redirs=%{num_redirects}, %{time_total}s)" "$u" 2>&1)
+  echo "  $u -> $out"
+done
+echo "  -- sécurité (403/404 attendus) :"
+for u in "https://klasyo.org/school/.env" "https://klasyo.org/school/public/klasyo_h.php"; do
+  code=$(curl -sk -o /dev/null -m 10 -w "%{http_code}" "$u")
+  echo "  $u -> $code"
 done
 
 echo
-echo "== FIN passe 4 =="
+echo "== Nouvelles erreurs Laravel school aujourd'hui (tronquées) =="
+L=$(ls -t "$S"/storage/logs/*.log 2>/dev/null | head -1)
+[ -n "$L" ] && grep -oE "^\[$(date +%Y-%m-%d)[0-9 :]*\] \w+\.\w+: [^{]{0,110}" "$L" | tail -4 || echo "  (aucune)"
+
+echo
+echo "== FIN passe 5 =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,123 +1,104 @@
 #!/usr/bin/env bash
-# KLASYO — Phase 1 / Semaine 1 : correctifs P0 sécurité + réparation de /school.
-# Exécuté sur le VPS via GitHub Actions (klasyo-ops.yml : ssh ... bash -s < ce script).
-#
-# SÉCURITÉ (les logs Actions sont PUBLICS) :
-# - ne jamais afficher le contenu de .env, de clés ni de credentials
-# - toute modification est précédée d'un backup ; rien n'est supprimé (déplacé vers ~/backups_klasyo)
-# - idempotent : ré-exécutable sans danger
+# KLASYO — Phase 1 / Semaine 1, passe 2 : réparer le routing de /school (.htaccess)
+# + vérifier le format APP_KEY de platform.
+# Exécuté sur le VPS via GitHub Actions (klasyo-ops.yml). Logs publics : aucun secret.
+# Idempotent ; backups avant toute écriture.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
 P="$ROOT/platform"
 S="$ROOT/school"
-BK="$HOME/backups_klasyo"
 STAMP="$(date +%Y%m%d-%H%M%S)"
-mkdir -p "$BK"
 
 echo "########################################"
-echo "== ÉTAPE 1 : zips de code source hors du web =="
+echo "== ÉTAPE 1 : .htaccess de /school (boucle de réécriture en sous-dossier) =="
 echo "########################################"
-move_out() {
-  local f="$1"
-  if [ -e "$f" ]; then
-    mv "$f" "$BK/" && echo "  DÉPLACÉ -> backups_klasyo/ : $(basename "$f")"
-  else
-    echo "  (déjà absent) $(basename "$f")"
-  fi
-}
-move_out "$P/klasyo.zip"
-move_out "$S/school.zip"
-move_out "$S/source_code.zip"
-move_out "$S/New_Installation_V1.9.3.zip"
-move_out "$S/Update 1.9.2-to-1.9.3.zip"
-move_out "$S/eSchool Sass student web v-1.9.3.zip"
-move_out "$S/eSchool-Saas-V1.9.3"
-# Fichiers parasites / fuite d'identité du script
-move_out "$P/index.html"          # ancien index statique "webetud.com" (parasite)
-move_out "$ROOT/documentation.txt"
-move_out "$ROOT/update_note.json"
-move_out "$P/documentation.txt"
-move_out "$P/update_note.json"
-echo "  Contenu de backups_klasyo (noms seulement) :"
-ls "$BK" | head -20
-
-echo
-echo "########################################"
-echo "== ÉTAPE 2 : correction des .env (backup préalable) =="
-echo "########################################"
-fix_env() {
-  local envfile="$1"; shift
-  [ -f "$envfile" ] || { echo "  (!) introuvable : $envfile"; return; }
-  cp -a "$envfile" "$envfile.bak-$STAMP"
-  echo "  backup : $(basename "$envfile").bak-$STAMP"
-  while [ $# -gt 0 ]; do
-    local key="${1%%=*}"
-    if grep -q "^${key}=" "$envfile"; then
-      sed -i "s|^${key}=.*|${1}|" "$envfile"
-    else
-      printf '%s\n' "$1" >> "$envfile"
-    fi
-    shift
-  done
-}
-fix_env "$P/.env" "APP_ENV=production" "APP_DEBUG=false" "APP_URL=https://klasyo.org/platform"
-fix_env "$S/.env" "APP_ENV=production" "APP_DEBUG=false" "APP_URL=https://klasyo.org/school"
-
-echo "  Vérification (clés non sensibles uniquement) :"
-echo "  --- platform :"; grep -E '^(APP_ENV|APP_DEBUG|APP_URL)=' "$P/.env"
-echo "  --- school   :"; grep -E '^(APP_ENV|APP_DEBUG|APP_URL)=' "$S/.env"
-
-echo
-echo "########################################"
-echo "== ÉTAPE 3 : APP_KEY de school =="
-echo "########################################"
-if grep -q '^APP_KEY=base64:.\+' "$S/.env"; then
-  echo "  APP_KEY déjà présente (non affichée)."
+if grep -q 'KLASYO-SUBDIR-SAFE' "$S/.htaccess" 2>/dev/null; then
+  echo "  Déjà remplacé (marqueur présent) — rien à faire."
 else
-  echo "  APP_KEY absente -> génération…"
-  (cd "$S" && php artisan key:generate --force 2>&1 | grep -iv 'base64') || echo "  (!) échec key:generate"
-  grep -q '^APP_KEY=base64:.\+' "$S/.env" && echo "  APP_KEY générée avec succès (non affichée)."
+  cp -a "$S/.htaccess" "$S/.htaccess.bak-$STAMP" 2>/dev/null && echo "  backup : .htaccess.bak-$STAMP"
+  cat > "$S/.htaccess" <<'HTA'
+# KLASYO-SUBDIR-SAFE — Laravel servi depuis le sous-dossier /school/
+# (l'original, prévu pour une racine de domaine, bouclait sur public/public/…)
+<IfModule mod_rewrite.c>
+    <IfModule mod_negotiation.c>
+        Options -MultiViews -Indexes
+    </IfModule>
+
+    RewriteEngine On
+
+    # 1) Ce qui est déjà sous public/ n'est PAS réécrit (stoppe la boucle)
+    RewriteRule ^public/ - [L]
+
+    # 2) Fichier statique existant dans public/ -> le servir
+    RewriteCond %{DOCUMENT_ROOT}/school/public/$1 -f
+    RewriteRule ^(.*)$ public/$1 [L]
+
+    # 3) Tout le reste -> front controller Laravel
+    RewriteRule ^ public/index.php [L]
+
+    # En-tête Authorization pour l'API
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    # En-tête school-code (multi-écoles eSchool)
+    RewriteCond %{HTTP:school-code} ^(.*)
+    RewriteRule .* - [E=HTTP_SCHOOL_CODE:%1]
+</IfModule>
+HTA
+  echo "  Nouveau .htaccess écrit."
 fi
-# Platform : contrôle seulement
-grep -q '^APP_KEY=base64:.\+' "$P/.env" && echo "  APP_KEY platform : présente." || echo "  (!) APP_KEY platform ABSENTE"
+echo "  --- public/.htaccess de school présent ? "
+[ -f "$S/public/.htaccess" ] && echo "  oui ($(wc -c < "$S/public/.htaccess") octets)" || echo "  (!) NON — front controller sans réécriture interne"
 
 echo
 echo "########################################"
-echo "== ÉTAPE 4 : purge des caches Laravel =="
+echo "== ÉTAPE 2 : APP_KEY de platform (contrôle de format, valeur jamais affichée) =="
 echo "########################################"
-for APPDIR in "$P" "$S"; do
-  echo "  --- $(basename "$APPDIR") :"
-  (cd "$APPDIR" && php artisan config:clear 2>&1 | tail -1)
-  (cd "$APPDIR" && php artisan route:clear  2>&1 | tail -1)
-  (cd "$APPDIR" && php artisan view:clear   2>&1 | tail -1)
-  (cd "$APPDIR" && php artisan cache:clear  2>&1 | tail -1) || true
-done
-echo "  Version PHP CLI : $(php -r 'echo PHP_VERSION;')"
+if grep -q '^APP_KEY=.\+' "$P/.env"; then
+  KEYLEN=$(grep '^APP_KEY=' "$P/.env" | head -1 | cut -d= -f2- | tr -d '"' | wc -c)
+  if grep -q '^APP_KEY=base64:' "$P/.env"; then
+    echo "  APP_KEY présente au format base64 (longueur $KEYLEN)."
+  else
+    echo "  APP_KEY présente au format LEGACY (longueur $KEYLEN) — fonctionnelle, ne pas régénérer."
+  fi
+else
+  echo "  (!) APP_KEY réellement vide — génération…"
+  cp -a "$P/.env" "$P/.env.bak-key-$STAMP"
+  (cd "$P" && php artisan key:generate --force 2>&1 | grep -iv 'base64')
+fi
 
 echo
 echo "########################################"
-echo "== ÉTAPE 5 : vérification HTTP (codes seulement) =="
+echo "== ÉTAPE 3 : santé de school côté CLI (sans secrets) =="
 echo "########################################"
-for u in "https://klasyo.org/" \
+(cd "$S" && php artisan about 2>/dev/null | grep -E 'Environment|Debug Mode|Cache|Laravel Version' | head -6) \
+  || echo "  (artisan about indisponible)"
+
+echo
+echo "########################################"
+echo "== ÉTAPE 4 : vérification HTTP (codes + redirections) =="
+echo "########################################"
+for u in "https://klasyo.org/school" \
+         "https://klasyo.org/school/" \
+         "https://klasyo.org/school/public/index.php" \
+         "https://klasyo.org/school/login" \
          "https://klasyo.org/platform/index.php" \
-         "https://klasyo.org/platform/public/" \
-         "https://klasyo.org/school" \
-         "https://klasyo.org/school/public/index.php" ; do
-  code=$(curl -skL -o /dev/null -m 12 -w "%{http_code}" "$u")
-  echo "  $u -> $code"
+         "https://klasyo.org/" ; do
+  out=$(curl -sk -o /dev/null -m 12 -w "%{http_code} redir=%{redirect_url}" "$u" 2>&1)
+  echo "  $u -> $out"
 done
-echo "  -- exposition (on veut 403/404 partout) :"
-for u in "https://klasyo.org/platform/.env" "https://klasyo.org/school/.env" \
-         "https://klasyo.org/platform/klasyo.zip" "https://klasyo.org/school/school.zip"; do
-  code=$(curl -sk -o /dev/null -m 10 -r 0-0 -w "%{http_code}" "$u")
-  echo "  $u -> $code"
-done
+echo "  -- avec suivi de redirections :"
+out=$(curl -skL -o /dev/null -m 15 -w "final=%{http_code} url=%{url_effective} redirs=%{num_redirects}" "https://klasyo.org/school/" 2>&1)
+echo "  /school/ -> $out"
 
 echo
-echo "== Dernière erreur Laravel school (si encore en panne, message tronqué sans données) =="
+echo "== ÉTAPE 5 : nouvelles erreurs Laravel school depuis aujourd'hui (messages tronqués) =="
 L=$(ls -t "$S"/storage/logs/*.log 2>/dev/null | head -1)
-[ -n "$L" ] && grep -oE '^\[[0-9 :-]+\] \w+\.\w+: [^{]{0,120}' "$L" | tail -3 || echo "(pas de log)"
+if [ -n "$L" ]; then
+  grep -oE "^\[$(date +%Y-%m-%d)[0-9 :]*\] \w+\.\w+: [^{]{0,120}" "$L" | tail -5 || echo "  (aucune erreur aujourd'hui)"
+else
+  echo "  (pas de log)"
+fi
 
 echo
-echo "== FIN Phase 1 / Semaine 1 (P0) =="
+echo "== FIN passe 2 =="

--- a/.github/scripts/klasyo-run.sh
+++ b/.github/scripts/klasyo-run.sh
@@ -1,39 +1,35 @@
 #!/usr/bin/env bash
-# KLASYO — Étape G : LA vraie cause. <FilesMatch "\.php$">SetHandler ne s'applique qu'aux
-# URLs finissant par .php. Les URLs propres (/platform/login) réécrites en interne vers
-# index.php n'exécutent pas -> PHP servi en SOURCE. Fix : AddHandler (clé sur l'extension
-# du FICHIER servi, pas l'URL). On corrige platform ET school, et on VALIDE le corps HTML.
+# KLASYO — Étape H : platform/public/.htaccess garde le bloc LMSZAI d'origine
+# <FilesMatch ...>SetHandler application/x-lsphp80</FilesMatch> (PHP 8.0 = inactif ici),
+# qui prime sur mon AddHandler lsphp83 -> source. On convertit TOUTE référence lsphpNN
+# en lsphp83 dans les .htaccess de platform. Validation du corps HTML.
 set -uo pipefail
 
 ROOT="$HOME/domains/klasyo.org/public_html"
+P="$ROOT/platform"
 STAMP="$(date +%Y%m%d-%H%M%S)"
 
-apply_addhandler() { # $1 = fichier .htaccess ; $2 = version lsphp
-  local f="$1" v="$2"
-  [ -f "$f" ] || { echo "  (absent) $f"; return; }
-  cp -a "$f" "$f.bak-G-$STAMP"
-  # Retire l'ancien bloc KLASYO handler (FilesMatch/SetHandler) posé précédemment
-  sed -i '/# KLASYO-PHP-HANDLER/,/<\/FilesMatch>/d' "$f" 2>/dev/null || true
-  # Retire d'éventuelles lignes AddHandler/SetHandler lsphp existantes pour repartir propre
-  sed -i -E '/AddHandler +application\/x-lsphp[0-9]+/d' "$f" 2>/dev/null || true
-  # Ajoute AddHandler (s'applique au fichier résolu, y compris index.php après rewrite)
-  cat >> "$f" <<EOF
-# KLASYO-PHP-HANDLER-ADD
-AddHandler application/x-lsphp${v} .php .phtml
-EOF
-  echo "  AddHandler lsphp${v} -> $(basename "$(dirname "$f")")/.htaccess"
-}
+echo "== Références lsphp AVANT (platform) =="
+grep -rniE 'lsphp[0-9]+' "$P/.htaccess" "$P/public/.htaccess" 2>/dev/null || echo "  (aucune)"
 
-# platform (Laravel 9) et school (Laravel 10) : PHP 8.3 est le seul handler qui exécute ici
-for APP in platform school; do
-  apply_addhandler "$ROOT/$APP/.htaccess" 83
-  apply_addhandler "$ROOT/$APP/public/.htaccess" 83
-  (cd "$ROOT/$APP" && php artisan config:clear 2>&1 | tail -1)
-  (cd "$ROOT/$APP" && php artisan view:clear 2>&1 | tail -1)
+for f in "$P/.htaccess" "$P/public/.htaccess"; do
+  [ -f "$f" ] || continue
+  cp -a "$f" "$f.bak-H-$STAMP"
+  # Toute version lsphpNN -> lsphp83 (corrige le bloc FilesMatch LMSZAI d'origine)
+  sed -i -E 's#(application/x-lsphp)[0-9]+#\183#g' "$f"
+  echo "  corrigé : $(basename "$(dirname "$f")")/.htaccess"
 done
 
+echo "== Références lsphp APRÈS (platform, doivent toutes être 83) =="
+grep -rniE 'lsphp[0-9]+' "$P/.htaccess" "$P/public/.htaccess" 2>/dev/null
+
 echo
-echo "== VALIDATION — le CORPS doit être du HTML, jamais du source PHP =="
+echo "== Purge caches platform =="
+(cd "$P" && php artisan config:clear 2>&1 | tail -1)
+(cd "$P" && php artisan view:clear   2>&1 | tail -1)
+
+echo
+echo "== VALIDATION (corps HTML, jamais du source) =="
 check() {
   local url="$1"
   local body; body=$(curl -skL -m 15 "$url" 2>/dev/null)
@@ -46,19 +42,19 @@ check() {
     echo "  $url -> [$code] ? $(printf '%s' "$body" | head -c 45 | tr -d '\n\r')"
   fi
 }
-echo "--- PLATFORM :"
 check "https://klasyo.org/platform/"
 check "https://klasyo.org/platform/login"
 check "https://klasyo.org/platform/register"
-echo "--- SCHOOL :"
-check "https://klasyo.org/school/"
-check "https://klasyo.org/school/login"
-echo "--- LANDING :"
-check "https://klasyo.org/"
 
 echo
-echo "== Rebrand KLASYO visible ? (page login platform) =="
-curl -skL -m 15 "https://klasyo.org/platform/login" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | sort -u | head -3 || echo "  (ni KLASYO ni LMSzai trouvés)"
+echo "== Rebrand : KLASYO / LMSzai dans la page d'accueil platform =="
+curl -skL -m 15 "https://klasyo.org/platform/" 2>/dev/null | grep -oiE 'KLASYO|LMSzai' | sort -u | head -3 || echo "  (aucun des deux)"
 
 echo
-echo "== FIN étape G =="
+echo "== Non-régression =="
+for u in "https://klasyo.org/" "https://klasyo.org/school/login"; do
+  echo "  $u -> $(curl -skL -o /dev/null -m 12 -w '%{http_code}' "$u")"
+done
+
+echo
+echo "== FIN étape H =="

--- a/.github/workflows/klasyo-ops.yml
+++ b/.github/workflows/klasyo-ops.yml
@@ -10,15 +10,15 @@ on:
     branches: ["claude/klasyo-org-vps-connection-n4zjyg"]
     paths:
       - ".github/workflows/klasyo-ops.yml"
-      - ".github/scripts/klasyo-inspect.sh"
+      - ".github/scripts/klasyo-run.sh"
 
 concurrency:
   group: klasyo-ops
   cancel-in-progress: false
 
 jobs:
-  inspect:
-    name: Inspect klasyo.org on VPS (read-only)
+  run:
+    name: Run klasyo.org operation on VPS
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,9 +31,9 @@ jobs:
           PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
           ssh-keyscan -p "$PORT" "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
 
-      - name: Run read-only inspection
+      - name: Run operation script
         run: |
           PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
           ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=accept-new \
             "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
-            'bash -s' < .github/scripts/klasyo-inspect.sh
+            'bash -s' < .github/scripts/klasyo-run.sh

--- a/.github/workflows/klasyo-ops.yml
+++ b/.github/workflows/klasyo-ops.yml
@@ -1,0 +1,39 @@
+name: Klasyo.org VPS ops
+
+# Connexion au VPS (mêmes secrets que le deploy TAGTOA) pour inspecter/gérer
+# le domaine klasyo.org, hébergé sur le même serveur que tagtoa.com.
+# - Déclenché sur push de la branche de travail (itération rapide sans merge)
+# - Ou manuellement (workflow_dispatch) une fois sur main
+on:
+  workflow_dispatch:
+  push:
+    branches: ["claude/klasyo-org-vps-connection-n4zjyg"]
+    paths:
+      - ".github/workflows/klasyo-ops.yml"
+      - ".github/scripts/klasyo-inspect.sh"
+
+concurrency:
+  group: klasyo-ops
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    name: Inspect klasyo.org on VPS (read-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
+          ssh-keyscan -p "$PORT" "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      - name: Run read-only inspection
+        run: |
+          PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
+          ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=accept-new \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
+            'bash -s' < .github/scripts/klasyo-inspect.sh


### PR DESCRIPTION
## Objectif

Permettre de se connecter au VPS (le même serveur que tagtoa.com — klasyo.org résout vers la même IP 67.217.56.29) pour inspecter et, ensuite, modifier le domaine **klasyo.org**, sans nouvel accès SSH : on réutilise les secrets GitHub existants du deploy TAGTOA (`VPS_SSH_KEY`, `VPS_HOST`, `VPS_USER`, `VPS_PORT`).

## Changements

- `.github/workflows/klasyo-ops.yml` — workflow « Klasyo.org VPS ops » :
  - déclenché sur push de cette branche (itération rapide) et par `workflow_dispatch` (une fois sur `main`) ;
  - se connecte en SSH au VPS et exécute le script d'inspection.
- `.github/scripts/klasyo-inspect.sh` — inspection **lecture seule** : utilisateur SSH, liste des domaines, arborescence de `domains/klasyo.org` (2 niveaux, `.env` masqué), contenu de `public_html`, config web visible. Ne modifie rien et n'affiche aucun secret.

## Contexte

`https://klasyo.org` répond actuellement **403 Forbidden** (domaine configuré sur le serveur mais rien de servi). Ce workflow sert de canal pour diagnostiquer puis appliquer les modifications demandées sur ce domaine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AXuin4gRaP79RedE7nouAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01AXuin4gRaP79RedE7nouAk)_