### PR TITLE
TAGTOA deploy : étape diagnostic structure serveur (situer docroot)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,22 @@ jobs:
         id: apppath
         run: |
           PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
+          # Diagnostic : structure réelle du domaine (aide à situer docroot vs app).
+          echo "::group::Structure serveur (diagnostic)"
+          ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=accept-new \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" '
+              D=$(ls -d /home/*/domains/tagtoa.com 2>/dev/null | head -1)
+              echo "domaine: $D"
+              echo "--- $D ---";                ls -la "$D" 2>/dev/null
+              echo "--- $D/public_html ---";    ls -la "$D/public_html" 2>/dev/null
+              echo "--- $D/public_html/laravel (head) ---"; ls -la "$D/public_html/laravel" 2>/dev/null | head -20
+              echo "--- $D/public_html/laravel/public ---"; ls -la "$D/public_html/laravel/public" 2>/dev/null
+              echo "--- $D/laravel (head) ---"; ls -la "$D/laravel" 2>/dev/null | head -20
+              echo "--- DocumentRoot déclaré ---"
+              grep -rhi "documentroot" /usr/local/directadmin/data/users/*/httpd.conf 2>/dev/null | grep -i tagtoa || \
+              grep -rhi "documentroot.*tagtoa" /etc/httpd/conf* /etc/apache2 2>/dev/null | head
+            ' || true
+          echo "::endgroup::"
           RESOLVED=$(ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=accept-new \
             "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" '
               # 1) le secret, s il est bon, gagne


### PR DESCRIPTION
403 persistant sur `tagtoa.com` = le docroot ne contient pas d'`index.php`. Cette étape de diagnostic (au début du déploiement) affiche dans le log la vraie arborescence du serveur : contenu de `~/domains/tagtoa.com/`, `public_html/`, `public_html/laravel/`, `public_html/laravel/public/`, et le DocumentRoot déclaré. Objectif : voir enfin la structure exacte pour donner l'instruction précise au lieu de deviner. Listings de répertoires uniquement, aucune donnée sensible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_