### PR TITLE
TAGTOA deploy : restructuration docroot automatique (répare 403 + protège .env)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ name: Deploy TAGTOA to VPS
 # - ou push sur main touchant le module
 on:
   workflow_dispatch:
+    inputs:
+      restructure:
+        description: "Restructurer le docroot (déplacer laravel hors de public_html) — une seule fois"
+        type: boolean
+        default: false
   push:
     branches: ["main"]
     paths: ["Modules/Tagtoa/**"]
@@ -27,6 +32,63 @@ jobs:
           chmod 600 ~/.ssh/id_deploy
           PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
           ssh-keyscan -p "$PORT" "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null || true
+
+      # Restructuration docroot (une seule fois, sur demande via workflow_dispatch).
+      # Déplace l'app Laravel HORS de public_html (sécurité .env) et place le
+      # contenu de public/ dans le docroot. Idempotent + non destructif :
+      #  - ne clobbere jamais un fichier/dossier existant (biztap/menu/profil saufs) ;
+      #  - se saute tout seul si déjà restructuré ;
+      #  - abandonne proprement si l'app n'est pas là où on l'attend.
+      - name: Restructure docroot (on demand)
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.restructure }}
+        run: |
+          PORT="${{ secrets.VPS_PORT }}"; PORT="${PORT:-22}"
+          ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=accept-new \
+            "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" 'bash -s' <<'EOSSH'
+          set -uo pipefail
+          D=$(ls -d /home/*/domains/tagtoa.com 2>/dev/null | head -1)
+          [ -n "$D" ] || { echo "domaine introuvable"; exit 1; }
+          PUB="$D/public_html"; SIB="$D/laravel"; APPIN="$PUB/laravel"
+          echo "D=$D"
+
+          # Déjà restructuré ?
+          if [ -f "$PUB/index.php" ] && grep -q "laravel/vendor" "$PUB/index.php" 2>/dev/null && [ -d "$SIB" ]; then
+            echo "Déjà restructuré — rien à faire."; ls -la "$PUB" | head; exit 0
+          fi
+
+          # L'app doit être à public_html/laravel
+          [ -f "$APPIN/artisan" ] || { echo "App introuvable à $APPIN — abandon."; exit 1; }
+
+          # 1) déplacer l'app hors du docroot (vers le sibling)
+          if [ ! -e "$SIB" ]; then mv "$APPIN" "$SIB" && echo "→ app déplacée vers $SIB"; fi
+
+          # 2) déplacer le CONTENU de public/ dans public_html (sans clobber)
+          if [ -d "$SIB/public" ]; then
+            shopt -s dotglob nullglob
+            for f in "$SIB/public/"*; do
+              b=$(basename "$f")
+              [ "$b" = "." ] || [ "$b" = ".." ] && continue
+              if [ ! -e "$PUB/$b" ]; then mv "$f" "$PUB/"; else echo "  (garde existant: $b)"; fi
+            done
+            shopt -u dotglob nullglob
+            echo "→ contenu public/ placé dans le docroot"
+          fi
+
+          # 3) index.php : booter depuis ../laravel (idempotent)
+          if [ -f "$PUB/index.php" ] && ! grep -q "laravel/vendor" "$PUB/index.php"; then
+            sed -i "s#/\.\./vendor/autoload#/../laravel/vendor/autoload#; s#/\.\./bootstrap/app#/../laravel/bootstrap/app#; s#/\.\./storage/framework/maintenance#/../laravel/storage/framework/maintenance#" "$PUB/index.php"
+            echo "→ index.php pointé vers ../laravel"
+          fi
+
+          # 4) écarter un index.html résiduel qui masquerait index.php
+          [ -f "$PUB/index.html" ] && mv "$PUB/index.html" "$PUB/index.html.bak" && echo "→ index.html mis de côté" || true
+
+          # 5) re-lier le stockage public
+          ( cd "$SIB" && php artisan storage:link >/dev/null 2>&1 ) || true
+
+          echo "=== public_html après restructuration ==="; ls -la "$PUB" | head -25
+          echo "Restructuration OK."
+          EOSSH
 
       # Le VPS a été restructuré (public_html/tapbiz → laravel/ ou public_html).
       # On résout le chemin RÉEL de l'app (présence d'artisan) au lieu de faire


### PR DESCRIPTION
## Objectif

Réparer définitivement le 403 (docroot `public_html` sans `index.php`) **et** l'exposition de `.env` (l'app `laravel/` est actuellement DANS `public_html`, donc `tagtoa.com/laravel/.env` est servi). Le changement de Document Root DirectAdmin n'étant pas accessible par SSH, on **restructure les fichiers** — l'utilisateur SSH possède les dossiers.

## Étape `restructure` (workflow_dispatch, une seule fois)

1. déplace `public_html/laravel` → **sibling `../laravel`** (hors docroot → `.env` protégé)
2. déplace le **contenu** de `laravel/public/` dans `public_html` — **sans clobber** (biztap/menu/profil intacts)
3. corrige `index.php` pour booter depuis `../laravel` (idempotent)
4. écarte un `index.html` résiduel qui masquerait `index.php`, re-link storage

**Sûreté** : idempotent (se saute si déjà restructuré), non destructif (ne remplace jamais un fichier existant), abandonne proprement si l'app n'est pas à l'emplacement attendu. Ne s'exécute QUE sur déclenchement manuel avec la case cochée.

Après restructuration, l'auto-détection de chemin (déjà en place) trouve l'app au sibling `~/domains/tagtoa.com/laravel` et le déploiement normal continue.

YAML validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_