### PR TITLE
TAGTOA deploy : diagnostic étendu (HTTP local + logs) pour le timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,16 @@ jobs:
               echo "--- DocumentRoot déclaré ---"
               grep -rhi "documentroot" /usr/local/directadmin/data/users/*/httpd.conf 2>/dev/null | grep -i tagtoa || \
               grep -rhi "documentroot.*tagtoa" /etc/httpd/conf* /etc/apache2 2>/dev/null | head
+              echo "--- HTTP local (app en direct, sans DNS/CDN) ---"
+              for U in "http://127.0.0.1/" "https://127.0.0.1/"; do
+                curl -skS -m 12 -o /dev/null -w "  $U -> code=%{http_code} time=%{time_total}s\n" -H "Host: tagtoa.com" "$U" || echo "  $U -> curl échec/timeout"
+              done
+              echo "--- maintenance mode ? ---"
+              ls -la "$D/laravel/storage/framework/down" 2>/dev/null && echo "EN MAINTENANCE" || echo "pas en maintenance"
+              echo "--- .env (clés non sensibles) ---"
+              grep -E "^(APP_ENV|APP_DEBUG|APP_URL|SESSION_DRIVER|CACHE_DRIVER|QUEUE_CONNECTION|DB_HOST|REDIS_HOST|DEBUGBAR_ENABLED)=" "$D/laravel/.env" 2>/dev/null
+              echo "--- laravel.log (30 dernières lignes) ---"
+              tail -30 "$D/laravel/storage/logs/laravel.log" 2>/dev/null || echo "pas de log"
             ' || true
           echo "::endgroup::"
           RESOLVED=$(ssh -i ~/.ssh/id_deploy -p "$PORT" -o StrictHostKeyChecking=accept-new \


### PR DESCRIPTION
`tagtoa.com` renvoie ERR_TIMED_OUT après la restructuration (avant : 403). L'app boote désormais mais quelque chose bloque la requête. Ce diagnostic (exécuté au début du déploiement, depuis le serveur) ajoute : `curl` localhost http+https (code + temps de réponse, sans DNS/CDN), détection du mode maintenance, clés `.env` non sensibles (APP_ENV/DEBUG/URL/SESSION/CACHE/QUEUE/DB_HOST/REDIS), et les 30 dernières lignes de `laravel.log`. Objectif : voir la cause exacte (500 ? redirect loop ? driver session/redis qui pend ? maintenance restée active ?). Aucune valeur sensible affichée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_