### PR TITLE
BILLING : paiement automatique des forfaits (Phase 3)

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Billing/PlanController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Billing/PlanController.php
@@ -42,14 +42,27 @@ class PlanController extends Controller
         $data = $request->validate([
             'plan' => ['required', Rule::in(array_keys((array) config('tagtoa.plans', [])))],
         ]);
+        $plan = $data['plan'];
+        $price = (float) (config('tagtoa.plans.'.$plan.'.price') ?? 0);
 
-        // Self-service pour l'instant (le paiement du forfait viendra avec PAY auto).
+        // Forfait PAYANT + passerelle active → paiement avant activation.
+        if ($price > 0) {
+            $url = app(\Modules\Tagtoa\App\Services\Pay\CheckoutService::class)
+                ->startSubscription(Tenant::id(), $plan);
+            if ($url) {
+                return redirect()->away($url); // le forfait s'active au retour de paiement (confirm)
+            }
+            // Pas de passerelle configurée : on n'accorde pas un forfait payant gratuitement.
+            return back()->with('error', __('Le paiement en ligne n\'est pas encore activé. Contactez-nous pour souscrire.'));
+        }
+
+        // Forfait gratuit → self-service immédiat.
         Subscription::updateOrCreate(
             ['tenant_id' => Tenant::id()],
-            ['plan' => $data['plan'], 'status' => 'active', 'started_at' => now()]
+            ['plan' => $plan, 'status' => 'active', 'started_at' => now(), 'expires_at' => null]
         );
 
-        app(\Modules\Tagtoa\App\Services\Audit\AuditService::class)->log('plan.changed', null, $data['plan']);
+        app(\Modules\Tagtoa\App\Services\Audit\AuditService::class)->log('plan.changed', null, $plan);
 
         return back()->with('success', __('Forfait mis à jour.'));
     }

--- a/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
+++ b/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
@@ -89,7 +89,7 @@ class CheckoutService
         $status = $driver->verify($txn);
         if ($status === 'paid') {
             $txn->update(['status' => PayTransaction::STATUS_PAID, 'paid_at' => now()]);
-            $this->markOrderPaid($txn->order_type, (int) $txn->order_id);
+            $this->applyPaid($txn);
 
             return true;
         }
@@ -100,6 +100,36 @@ class CheckoutService
         return false;
     }
 
+    /**
+     * Démarre le paiement d'un ABONNEMENT (forfait). Retourne l'URL de
+     * redirection, ou null si le forfait est gratuit / passerelle indisponible.
+     */
+    public function startSubscription(?string $tenantId, string $plan, string $gateway = 'moncash'): ?string
+    {
+        $price = (float) (config('tagtoa.plans.'.$plan.'.price') ?? 0);
+        if ($price <= 0 || ! GatewayManager::enabled($gateway)) {
+            return null;
+        }
+        $driver = $this->driver($gateway);
+        if (! $driver) {
+            return null;
+        }
+
+        $txn = PayTransaction::create([
+            'tenant_id'  => $tenantId,
+            'gateway'    => $gateway,
+            'reference'  => PayTransaction::generateReference(),
+            'order_type' => 'subscription',
+            'order_id'   => 0,
+            'amount'     => $price,
+            'currency'   => 'HTG',
+            'status'     => PayTransaction::STATUS_PENDING,
+            'meta'       => ['plan' => $plan, 'tenant_id' => $tenantId],
+        ]);
+
+        return $driver->createPayment($txn);
+    }
+
     /** Charge la commande (amount/currency/tenant/isPaid) selon le type. */
     protected function loadOrder(string $type, int $id): ?object
     {
@@ -108,15 +138,28 @@ class CheckoutService
         return $model ? $model::find($id) : null;
     }
 
-    /** Marque la commande sous-jacente payée + commission (idempotent). */
-    protected function markOrderPaid(string $type, int $orderId): void
+    /** Applique le paiement (commande OU abonnement) — idempotent. */
+    protected function applyPaid(PayTransaction $txn): void
     {
-        $order = $this->loadOrder($type, $orderId);
+        if ($txn->order_type === 'subscription') {
+            $plan = $txn->meta['plan'] ?? null;
+            $tenantId = $txn->meta['tenant_id'] ?? $txn->tenant_id;
+            if ($plan && array_key_exists($plan, (array) config('tagtoa.plans', []))) {
+                \Modules\Tagtoa\App\Models\Billing\Subscription::updateOrCreate(
+                    ['tenant_id' => $tenantId],
+                    ['plan' => $plan, 'status' => 'active', 'started_at' => now(), 'expires_at' => now()->addMonth()]
+                );
+            }
+
+            return;
+        }
+
+        $order = $this->loadOrder($txn->order_type, (int) $txn->order_id);
         if (! $order || $order->isPaid()) {
             return;
         }
 
-        switch ($type) {
+        switch ($txn->order_type) {
             case 'store':
                 app(\Modules\Tagtoa\App\Services\Store\StoreOrderService::class)->markPaid($order);
                 break;

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -365,6 +365,7 @@
     "Le menu arrive bientôt.": "The menu is coming soon.",
     "Le paiement automatique des forfaits arrive avec les passerelles. Pour l'instant, le changement est immédiat.": "Automatic plan billing is coming with the gateways. For now, switching is immediate.",
     "Le paiement en ligne arrive bientôt. Utilisez les informations ci-dessous.": "Online payment is coming soon. Use the details below.",
+    "Le paiement en ligne n'est pas encore activé. Contactez-nous pour souscrire.": "Online payment is not enabled yet. Contact us to subscribe.",
     "Les deux": "Both",
     "Libellé (ex: Mon MonCash)": "Label (e.g.: My MonCash)",
     "Lien copié": "Link copied",

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -365,6 +365,7 @@
     "Le menu arrive bientôt.": "El menú llegará pronto.",
     "Le paiement automatique des forfaits arrive avec les passerelles. Pour l'instant, le changement est immédiat.": "El pago automático de planes llegará con las pasarelas. Por ahora, el cambio es inmediato.",
     "Le paiement en ligne arrive bientôt. Utilisez les informations ci-dessous.": "El pago en línea llegará pronto. Usa los datos de abajo.",
+    "Le paiement en ligne n'est pas encore activé. Contactez-nous pour souscrire.": "El pago en línea aún no está activado. Contáctanos para suscribirte.",
     "Les deux": "Ambos",
     "Libellé (ex: Mon MonCash)": "Etiqueta (ej.: Mi MonCash)",
     "Lien copié": "Enlace copiado",

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -365,6 +365,7 @@
     "Le menu arrive bientôt.": "Meni an ap vini talè.",
     "Le paiement automatique des forfaits arrive avec les passerelles. Pour l'instant, le changement est immédiat.": "Peman otomatik fòfè yo ap vini ak pasrèl yo. Pou kounye a, chanjman an imedya.",
     "Le paiement en ligne arrive bientôt. Utilisez les informations ci-dessous.": "Peman an liy ap vini talè. Sèvi ak enfòmasyon anba yo.",
+    "Le paiement en ligne n'est pas encore activé. Contactez-nous pour souscrire.": "Peman an liy poko aktive. Kontakte nou pou abòne.",
     "Les deux": "Toulède",
     "Libellé (ex: Mon MonCash)": "Etikèt (egz: MonCash mwen)",
     "Lien copié": "Lyen kopye",


### PR DESCRIPTION
## Roadmap Phase 3 — Paiement automatique des forfaits

Bâtit sur le checkout MonCash (#63). Un forfait **payant** (Pro/Enterprise) passe désormais par le paiement **avant** activation ; le forfait **gratuit** reste en self-service immédiat.

- `CheckoutService::startSubscription(tenant, plan)` → transaction `subscription` (montant = prix du forfait, `meta.plan`) → URL de redirection MonCash.
- `confirm()` → `applyPaid()` gère désormais le type `subscription` : **active/étend l'abonnement** (`expires_at = +1 mois`) de façon idempotente — comme il marque une commande payée.
- `PlanController::subscribe` : `price > 0` **et** passerelle active → redirige vers le paiement (le forfait s'active au retour) ; sinon message clair (pas de forfait payant accordé gratuitement). Gratuit → activation immédiate (inchangé).

**Dormant** tant que MonCash n'a pas de credentials (comme Phase 2).

### Vérifications
`php -l` OK · suite Unit **69 tests / 440 assertions** OK · i18n en/ht/es.

### DB
Aucune migration (réutilise `tagtoa_subscriptions` + `tagtoa_pay_transactions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_