### PR TITLE
TESTS: intégrité statique des routes (Roadmap Phase 4)

### DIFF
--- a/Modules/Tagtoa/app/Support/Dev/RouteNames.php
+++ b/Modules/Tagtoa/app/Support/Dev/RouteNames.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Dev;
+
+/**
+ * TAGTOA DEV — analyse statique PURE des noms de routes (sans Laravel).
+ *
+ * Sert au test d'intégrité : un `route('nom')` utilisé dans une vue ou un
+ * contrôleur mais NON défini dans routes/web.php provoque un 500 en prod
+ * (RouteNotFoundException). La CI ne bootant pas Laravel (cœur Biztap absent),
+ * on vérifie la cohérence par lecture de texte.
+ */
+class RouteNames
+{
+    /**
+     * Noms de routes PLEINEMENT qualifiés définis dans le source de routes.
+     * Gère les préfixes de nom de groupe : ->name('a.b.')->group(fn () { ->name('c') } ) => a.b.c.
+     *
+     * @return string[]  PUR
+     */
+    public static function defined(string $src): array
+    {
+        $names = [];
+        $stack = [];   // [ [prefix, openDepth], ... ]
+        $depth = 0;
+
+        foreach (explode("\n", $src) as $line) {
+            $opensGroup = strpos($line, '->group(') !== false;
+            preg_match_all("/->name\((['\"])([^'\"]*)\\1\)/", $line, $m);
+            $found = $m[2] ?? [];
+
+            if ($opensGroup) {
+                // Le nom présent sur la ligne du groupe est un PRÉFIXE.
+                $prefix = $found ? (string) end($found) : '';
+                $stack[] = [$prefix, $depth];
+            } elseif ($found) {
+                // Route feuille : nom complet = concat des préfixes + feuille.
+                $prefix = '';
+                foreach ($stack as $e) {
+                    $prefix .= $e[0];
+                }
+                foreach ($found as $n) {
+                    $names[] = $prefix.$n;
+                }
+            }
+
+            $depth += substr_count($line, '{') - substr_count($line, '}');
+
+            // Referme les groupes dont la profondeur d'ouverture est atteinte.
+            while ($stack && $depth <= $stack[count($stack) - 1][1]) {
+                array_pop($stack);
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
+     * Noms de routes UTILISÉS via route('nom'...) dans un ensemble de sources.
+     *
+     * @param  string[]  $sources  contenus de fichiers (vues, contrôleurs)
+     * @return string[]  PUR
+     */
+    public static function used(array $sources): array
+    {
+        $used = [];
+        foreach ($sources as $src) {
+            if (preg_match_all("/route\((['\"])([^'\"]+)\\1/", $src, $m)) {
+                foreach ($m[2] as $n) {
+                    $used[] = $n;
+                }
+            }
+        }
+
+        return array_values(array_unique($used));
+    }
+}

--- a/Modules/Tagtoa/tests/Unit/RouteIntegrityTest.php
+++ b/Modules/Tagtoa/tests/Unit/RouteIntegrityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Support\Dev\RouteNames;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Intégrité des routes : chaque `route('tagtoa.xxx')` utilisé dans une vue ou
+ * un contrôleur DOIT correspondre à une route définie dans routes/web.php.
+ *
+ * Pourquoi : un nom de route erroné (faute de frappe, route renommée/supprimée)
+ * lève RouteNotFoundException → 500 en prod. La CI ne boot pas Laravel (cœur
+ * Biztap absent), donc on ne détecterait jamais ce crash sans vérification
+ * statique. Même classe de bug que le crash Blade @json du PR #41 : invisible
+ * en logique pure, fatal en prod.
+ *
+ * On ne vérifie QUE les noms préfixés `tagtoa.` : les routes du cœur Biztap
+ * (home, logout, mail…) sont définies ailleurs et légitimement hors périmètre.
+ */
+class RouteIntegrityTest extends TestCase
+{
+    public function test_every_used_tagtoa_route_is_defined(): void
+    {
+        $moduleRoot = __DIR__.'/../..';
+        $routesFile = $moduleRoot.'/routes/web.php';
+
+        $defined = RouteNames::defined((string) file_get_contents($routesFile));
+        $this->assertNotEmpty($defined, 'Aucune route analysée — routes/web.php introuvable ou parseur cassé ?');
+
+        // Sources qui utilisent route() : vues Blade + contrôleurs.
+        $sources = [];
+        foreach ([$moduleRoot.'/resources/views', $moduleRoot.'/app/Http/Controllers'] as $dir) {
+            if (! is_dir($dir)) {
+                continue;
+            }
+            $files = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir));
+            foreach ($files as $file) {
+                if ($file->isFile() && str_ends_with($file->getFilename(), '.php')) {
+                    $sources[] = (string) file_get_contents($file->getPathname());
+                }
+            }
+        }
+
+        $used = array_filter(
+            RouteNames::used($sources),
+            fn (string $name) => str_starts_with($name, 'tagtoa.')
+        );
+        $this->assertNotEmpty($used, 'Aucune utilisation de route tagtoa.* trouvée — chemins de scan cassés ?');
+
+        $definedSet = array_flip($defined);
+        $missing = array_values(array_filter(
+            $used,
+            fn (string $name) => ! isset($definedSet[$name])
+        ));
+        sort($missing);
+
+        $this->assertSame([], $missing,
+            "Routes tagtoa.* utilisées mais NON définies dans routes/web.php (500 en prod) :\n"
+            .implode("\n", array_map(fn ($m) => "  - $m", $missing)));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,3 +25,4 @@ require_once $base.'/Support/Store/Cart.php';
 require_once $base.'/Support/Gateways/MonCash.php';
 require_once $base.'/Support/Event/Ledger.php';
 require_once $base.'/Support/Money.php';
+require_once $base.'/Support/Dev/RouteNames.php';


### PR DESCRIPTION
## Contexte — Roadmap Phase 4 (Tests)

La CI ne boot pas Laravel (le cœur Biztap est absent du dépôt), donc deux classes de crash **fatals en prod** restent invisibles en test :

1. **Crash de compilation Blade** — déjà couvert par `ViewCompileTest` (leçon du PR #41, `@json(fn…)`).
2. **Route introuvable** — un `route('tagtoa.xxx')` erroné (typo, route renommée/supprimée) lève `RouteNotFoundException` → **500**. C'est ce que ce PR couvre.

## Changements

- **`Support/Dev/RouteNames`** (analyse statique pure, sans Laravel) :
  - `defined($src)` lit `routes/web.php` en suivant la pile de préfixes de nom de groupe + la profondeur d'accolades (`->name('a.b.')->group(fn(){ ->name('c') })` ⇒ `a.b.c`).
  - `used($sources)` extrait les appels `route('…')` / `route("…")` (guillemets simples **et** doubles).
- **`RouteIntegrityTest`** : assert que chaque `route('tagtoa.*')` utilisé dans une vue ou un contrôleur est bien défini. Ne contrôle que le préfixe `tagtoa.` — les routes du cœur Biztap (`home`, `logout`, `mail`) sont légitimement hors périmètre.
- Enregistre `RouteNames.php` dans `tests/bootstrap.php`.

## Validation

- Sur les fichiers réels : **153 routes définies, 132 utilisées, 0 manquante**.
- Vérification négative : une route erronée est détectée dans les deux styles de guillemets.
- Suite Unit complète : **70 tests, 443 assertions — OK**.

Aucune modification de schéma de base de données, aucun changement de comportement runtime : ajout de tests uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_