### PR TITLE
EVENT: démo multi-jour (Jour 1/Jour 2) pour tester le check-in NFC

### DIFF
--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -87,13 +87,18 @@ class TagtoaDemoSeeder extends Seeder
             ]);
         }
 
-        // 4) EVENT — concert démo (gratuit) + 1 type de billet
+        // 4) EVENT — festival démo MULTI-JOUR (gratuit) + types de billets.
+        //    2 jours pour démontrer le check-in « une entrée par jour » (Jour 1/Jour 2).
         $event = Event::firstOrCreate(
             ['alias' => 'demo-concert'],
             ['title' => 'TAGTOA Live Demo', 'type' => 'concert', 'venue' => 'BANJ, Gonaïves',
-             'starts_at' => now()->addDays(7)->setTime(19, 0), 'currency' => 'HTG', 'is_free' => true, 'is_published' => true]
+             'currency' => 'HTG', 'is_free' => true, 'is_published' => true]
         );
+        // Dates roulantes (toujours à venir) + fin = lendemain → événement 2 jours.
+        $demoStart = now()->addDays(7)->setTime(19, 0);
+        $event->update(['starts_at' => $demoStart, 'ends_at' => $demoStart->copy()->addDay()->setTime(23, 0)]);
         $event->ticketTypes()->firstOrCreate(['name' => 'Standard'], ['price' => 0, 'quantity' => 200, 'is_active' => true]);
+        $event->ticketTypes()->firstOrCreate(['name' => 'Pass 2 jours'], ['price' => 0, 'quantity' => 200, 'is_active' => true]);
 
         // 4b) EVENT WALLET — démo testable avec un tag NFC (UID: TAGTOA-DEMO-TAG)
         app(\Modules\Tagtoa\App\Actions\Event\Wallet\OpenEventWalletAccounts::class)->handle($event);


### PR DESCRIPTION
## Contexte

Le fondateur a des tags **NTAG213/216** et `tagtoa.com` est en HTTPS → il peut tester le NFC. Ce PR rend l'événement démo **multi-jour** pour démontrer immédiatement le check-in « une entrée par jour » (livré dans #68).

## Changement

- `demo-concert` devient un **festival 2 jours** (`ends_at` = lendemain).
- Ajout du type de billet **« Pass 2 jours »**.
- Dates roulantes idempotentes (toujours à venir) à chaque seed de déploiement.

## Test attendu (tag NFC, Chrome Android, HTTPS)

1. Encoder une carte sur `/tagtoa/event/{id}/wallet` (tap tag → UID + crédit).
2. Check-in : tap → « Bienvenue! » ; re-tap le même jour → « Déjà entré aujourd'hui » ; le lendemain → entrée autorisée.
3. Rapport temps réel : bloc **Entrées Jour 1 / Jour 2** visible.

Aucune migration, aucun impact hors données de démo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_