### PR TITLE
EVENT: création enrichie (types, mode billet, prix + réduction) + outil diagnostic VPS

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -118,9 +118,14 @@ jobs:
           ls -la "$L/bootstrap/cache/" 2>&1 || true
           echo "::endgroup::"
 
-          echo "::group::laravel.log — 40 dernières lignes (secrets redactés)"
-          if [ -f "$L/storage/logs/laravel.log" ]; then
-            tail -40 "$L/storage/logs/laravel.log" \
+          echo "::group::laravel.log — messages d'ERREUR (secrets redactés)"
+          LOG="$L/storage/logs/laravel.log"
+          if [ -f "$LOG" ]; then
+            echo "--- 8 derniers messages ERROR/CRITICAL (classe + message + fichier:ligne) ---"
+            grep -aE '\.(ERROR|CRITICAL|EMERGENCY):' "$LOG" | tail -8 | cut -c1-500 \
+              | sed -E 's/(password|pwd|secret|token|DB_PASSWORD)([=" :]+)[^ "]+/\1\2[REDACTED]/gi'
+            echo "--- 12 dernières lignes brutes ---"
+            tail -12 "$LOG" | cut -c1-400 \
               | sed -E 's/(password|pwd|secret|token|DB_PASSWORD)([=" :]+)[^ "]+/\1\2[REDACTED]/gi'
           else
             echo "pas de laravel.log"

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -118,6 +118,15 @@ jobs:
           ls -la "$L/bootstrap/cache/" 2>&1 || true
           echo "::endgroup::"
 
+          echo "::group::Vues login / marque (rebranding TAGTOA)"
+          echo "== fichiers de vues login/auth =="
+          find "$L/resources/views" -maxdepth 3 -iregex '.*\(login\|auth\).*\.blade\.php' 2>/dev/null | head -20
+          echo "== vues contenant l'ancienne marque (biztap) =="
+          grep -rilo 'biztap' "$L/resources/views" 2>/dev/null | head -30
+          echo "== layouts/auth.blade.php (60 premières lignes) =="
+          sed -n '1,60p' "$L/resources/views/layouts/auth.blade.php" 2>/dev/null || echo "absent"
+          echo "::endgroup::"
+
           echo "::group::laravel.log — messages d'ERREUR (secrets redactés)"
           LOG="$L/storage/logs/laravel.log"
           if [ -f "$LOG" ]; then
@@ -163,6 +172,12 @@ jobs:
             rm -f "$L/storage/framework/views/"*.php 2>/dev/null && echo "vues compilées supprimées" || true
             ( cd "$L" && php artisan optimize:clear 2>&1 ) || true
             chmod -R ug+rwX "$L/storage" "$L/bootstrap/cache" 2>/dev/null && echo "permissions storage/bootstrap corrigées" || true
+            # Accélération prod : met le config + vues en cache (évite de relire
+            # ~30 fichiers config + .env à CHAQUE requête → dashboard plus rapide).
+            # (pas de route:cache : Biztap peut avoir des routes en closure.)
+            echo "-- optimisation (config + vues en cache) --"
+            ( cd "$L" && php artisan config:cache 2>&1 ) || true
+            ( cd "$L" && php artisan view:cache 2>&1 ) || true
             echo "::endgroup::"
             echo "→ Rechargez https://tagtoa.com/login"
           fi

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -46,28 +46,36 @@ jobs:
           echo "--- /home ---"; ls -la /home 2>&1 | head -40
           echo "::endgroup::"
 
-          # 1) EXPLORER : trouver où l'app Laravel vit RÉELLEMENT sur ce serveur.
-          echo "::group::Recherche large de l'app (artisan / tagtoa.com / public_html)"
-          echo "== dossiers tagtoa.com =="
-          find /home -maxdepth 6 -type d -name 'tagtoa.com' 2>/dev/null | head
-          echo "== fichiers artisan (app Laravel) =="
-          ART=$(find /home -maxdepth 7 -type f -name artisan 2>/dev/null | head -20); echo "${ART:-aucun}"
-          echo "== dossiers public_html =="
-          find /home -maxdepth 5 -type d -name public_html 2>/dev/null | head
-          echo "== fichiers .env =="
-          find /home -maxdepth 7 -type f -name '.env' 2>/dev/null | grep -iE 'tagtoa|laravel|public_html' | head
+          # 1) EXPLORER sous $HOME (/home global n'est pas lisible : le glob
+          #    /home/*/domains échoue → c'est LA cause de « INTROUVABLE »).
+          echo "::group::Domaines du compte ($HOME/domains)"
+          ls -la "$HOME/domains" 2>&1 | head -40
           echo "::endgroup::"
 
-          # 2) Choisir l'app : 1er artisan trouvé (priorité aux chemins tagtoa).
-          D=$(ls -d /home/*/domains/tagtoa.com 2>/dev/null | head -1)
-          echo "Domaine attendu : ${D:-INTROUVABLE}"
+          echo "::group::Structure de tagtoa.com"
+          T="$HOME/domains/tagtoa.com"
+          echo "== $T =="; ls -la "$T" 2>&1 | head -50
+          echo "== $T/public_html =="; ls -la "$T/public_html" 2>&1 | head -60
+          echo "== $T/laravel (si existe) =="; ls -la "$T/laravel" 2>&1 | head -50
+          echo "== $T/public_html/laravel (si existe) =="; ls -la "$T/public_html/laravel" 2>&1 | head -50
+          echo "::endgroup::"
+
+          echo "::group::Recherche des fichiers ESSENTIELS sous tagtoa.com"
+          echo "== artisan =="; ART=$(find "$T" -maxdepth 4 -type f -name artisan 2>/dev/null | head -10); echo "${ART:-aucun}"
+          echo "== .env =="; find "$T" -maxdepth 4 -type f -name '.env' 2>/dev/null | head
+          echo "== dossiers storage / bootstrap / vendor / Modules / public =="
+          for dir in storage bootstrap vendor Modules public; do
+            r=$(find "$T" -maxdepth 4 -type d -name "$dir" 2>/dev/null | head); echo "$dir: ${r:-ABSENT}"
+          done
+          echo "== index.php (docroot) =="; find "$T" -maxdepth 3 -name index.php 2>/dev/null | head
+          echo "::endgroup::"
+
+          # 2) Choisir l'app : artisan sous tagtoa.com en priorité.
+          D="$T"
           L=""
           for c in "$D/laravel" "$D/public_html/laravel" "$D/public_html"; do
             [ -f "$c/artisan" ] && { L="$c"; break; }
           done
-          if [ -z "$L" ]; then
-            L=$(printf '%s\n' "$ART" | grep -iE 'tagtoa' | head -1 | xargs -r dirname)
-          fi
           if [ -z "$L" ]; then
             L=$(printf '%s\n' "$ART" | head -1 | xargs -r dirname)
           fi

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -39,16 +39,40 @@ jobs:
             "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "CLEAR='$CLEAR' bash -s" <<'EOSSH'
           set -uo pipefail
 
-          # 1) Localiser l'app Laravel (artisan) sous le domaine.
           D=$(ls -d /home/*/domains/tagtoa.com 2>/dev/null | head -1)
+          echo "Domaine : ${D:-INTROUVABLE}"
+
+          # 0) STRUCTURE réelle du serveur (pour repérer ce qui manque/où est l'app).
+          echo "::group::Arborescence du domaine (2 niveaux)"
+          [ -n "$D" ] && ls -la "$D" 2>&1 || echo "domaine introuvable"
+          echo "--- public_html/ ---"; ls -la "$D/public_html" 2>&1 | head -60 || true
+          echo "--- public_html/laravel/ (si existe) ---"; ls -la "$D/public_html/laravel" 2>&1 | head -40 || true
+          echo "--- laravel/ (si existe) ---"; ls -la "$D/laravel" 2>&1 | head -40 || true
+          echo "::endgroup::"
+
+          echo "::group::Où sont les fichiers ESSENTIELS ?"
+          for f in artisan .env composer.json; do
+            echo "== $f =="; find "$D" -maxdepth 4 -name "$f" 2>/dev/null || true
+          done
+          for dir in storage bootstrap vendor Modules public; do
+            echo "== dossier $dir =="; find "$D" -maxdepth 4 -type d -name "$dir" 2>/dev/null | head || true
+          done
+          echo "== index.php (docroot) =="; find "$D" -maxdepth 3 -name index.php 2>/dev/null | head || true
+          echo "::endgroup::"
+
+          # 1) Localiser l'app Laravel (artisan) sous le domaine.
           L=""
           for c in "$D/laravel" "$D/public_html/laravel" "$D/public_html"; do
             [ -f "$c/artisan" ] && { L="$c"; break; }
           done
           if [ -z "$L" ]; then
-            L=$(find /home/*/domains/tagtoa.com -maxdepth 3 -name artisan 2>/dev/null | head -1 | xargs -r dirname)
+            L=$(find /home/*/domains/tagtoa.com -maxdepth 4 -name artisan 2>/dev/null | head -1 | xargs -r dirname)
           fi
-          [ -n "$L" ] && [ -f "$L/artisan" ] || { echo "::error::App Laravel introuvable sous /home/*/domains/tagtoa.com"; exit 1; }
+          if [ -z "$L" ] || [ ! -f "$L/artisan" ]; then
+            echo "::warning::artisan introuvable — l'app Laravel n'est pas déployée correctement. Voir l'arborescence ci-dessus."
+            echo "Diagnostic structurel terminé (pas d'app à inspecter plus loin)."
+            exit 0
+          fi
           echo "App Laravel : $L"
 
           echo "::group::Présence des clés .env (valeurs masquées)"

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -39,34 +39,42 @@ jobs:
             "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" "CLEAR='$CLEAR' bash -s" <<'EOSSH'
           set -uo pipefail
 
+          # 0) QUI/OÙ suis-je ? (le chemin domaine attendu était introuvable)
+          echo "::group::Contexte SSH"
+          echo "whoami : $(whoami)"; echo "HOME : $HOME"; echo "pwd : $(pwd)"
+          echo "--- \$HOME ---"; ls -la "$HOME" 2>&1 | head -40
+          echo "--- /home ---"; ls -la /home 2>&1 | head -40
+          echo "::endgroup::"
+
+          # 1) EXPLORER : trouver où l'app Laravel vit RÉELLEMENT sur ce serveur.
+          echo "::group::Recherche large de l'app (artisan / tagtoa.com / public_html)"
+          echo "== dossiers tagtoa.com =="
+          find /home -maxdepth 6 -type d -name 'tagtoa.com' 2>/dev/null | head
+          echo "== fichiers artisan (app Laravel) =="
+          ART=$(find /home -maxdepth 7 -type f -name artisan 2>/dev/null | head -20); echo "${ART:-aucun}"
+          echo "== dossiers public_html =="
+          find /home -maxdepth 5 -type d -name public_html 2>/dev/null | head
+          echo "== fichiers .env =="
+          find /home -maxdepth 7 -type f -name '.env' 2>/dev/null | grep -iE 'tagtoa|laravel|public_html' | head
+          echo "::endgroup::"
+
+          # 2) Choisir l'app : 1er artisan trouvé (priorité aux chemins tagtoa).
           D=$(ls -d /home/*/domains/tagtoa.com 2>/dev/null | head -1)
-          echo "Domaine : ${D:-INTROUVABLE}"
-
-          # 0) STRUCTURE réelle du serveur (pour repérer ce qui manque/où est l'app).
-          echo "::group::Arborescence du domaine (2 niveaux)"
-          [ -n "$D" ] && ls -la "$D" 2>&1 || echo "domaine introuvable"
-          echo "--- public_html/ ---"; ls -la "$D/public_html" 2>&1 | head -60 || true
-          echo "--- public_html/laravel/ (si existe) ---"; ls -la "$D/public_html/laravel" 2>&1 | head -40 || true
-          echo "--- laravel/ (si existe) ---"; ls -la "$D/laravel" 2>&1 | head -40 || true
-          echo "::endgroup::"
-
-          echo "::group::Où sont les fichiers ESSENTIELS ?"
-          for f in artisan .env composer.json; do
-            echo "== $f =="; find "$D" -maxdepth 4 -name "$f" 2>/dev/null || true
-          done
-          for dir in storage bootstrap vendor Modules public; do
-            echo "== dossier $dir =="; find "$D" -maxdepth 4 -type d -name "$dir" 2>/dev/null | head || true
-          done
-          echo "== index.php (docroot) =="; find "$D" -maxdepth 3 -name index.php 2>/dev/null | head || true
-          echo "::endgroup::"
-
-          # 1) Localiser l'app Laravel (artisan) sous le domaine.
+          echo "Domaine attendu : ${D:-INTROUVABLE}"
           L=""
           for c in "$D/laravel" "$D/public_html/laravel" "$D/public_html"; do
             [ -f "$c/artisan" ] && { L="$c"; break; }
           done
           if [ -z "$L" ]; then
-            L=$(find /home/*/domains/tagtoa.com -maxdepth 4 -name artisan 2>/dev/null | head -1 | xargs -r dirname)
+            L=$(printf '%s\n' "$ART" | grep -iE 'tagtoa' | head -1 | xargs -r dirname)
+          fi
+          if [ -z "$L" ]; then
+            L=$(printf '%s\n' "$ART" | head -1 | xargs -r dirname)
+          fi
+          if [ -n "$L" ] && [ -d "$L" ]; then
+            echo "::group::Arborescence de l'app trouvée : $L"
+            ls -la "$L" 2>&1 | head -50
+            echo "::endgroup::"
           fi
           if [ -z "$L" ] || [ ! -f "$L/artisan" ]; then
             echo "::warning::artisan introuvable — l'app Laravel n'est pas déployée correctement. Voir l'arborescence ci-dessus."

--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -133,7 +133,32 @@ jobs:
           echo "::endgroup::"
 
           if [ "${CLEAR:-false}" = "true" ]; then
-            echo "::group::Vidage cache + permissions (sûr, sans DB)"
+            echo "::group::Réparations (sûr, sans DB)"
+
+            # FIX 500 « Mix manifest not found » : mix() cherche le manifeste dans
+            # laravel/public/ mais les assets buildés sont dans public_html/ (docroot).
+            # On relie le manifeste ET les dossiers d'assets manquants vers public_html.
+            PH="$(dirname "$L")/public_html"
+            if [ -d "$PH" ]; then
+              [ -d "$L/public" ] || mkdir -p "$L/public"
+              if [ ! -e "$L/public/mix-manifest.json" ] && [ -f "$PH/mix-manifest.json" ]; then
+                ln -s "$PH/mix-manifest.json" "$L/public/mix-manifest.json" 2>/dev/null \
+                  && echo "mix-manifest.json relié → public_html" \
+                  || { cp "$PH/mix-manifest.json" "$L/public/" && echo "mix-manifest.json copié"; }
+              else
+                echo "mix-manifest.json : déjà présent ou source absente"
+              fi
+              # Relie les dossiers d'assets référencés par mix() (au cas où mix() vérifie le fichier).
+              for a in css js fonts img images assets build web front vendor; do
+                if [ -e "$PH/$a" ] && [ ! -e "$L/public/$a" ]; then
+                  ln -s "$PH/$a" "$L/public/$a" 2>/dev/null && echo "lien public/$a → public_html/$a" || true
+                fi
+              done
+            else
+              echo "public_html introuvable à $PH"
+            fi
+
+            echo "-- vidage cache --"
             rm -f "$L/bootstrap/cache/"*.php 2>/dev/null && echo "bootstrap/cache/*.php supprimés" || true
             rm -f "$L/storage/framework/views/"*.php 2>/dev/null && echo "vues compilées supprimées" || true
             ( cd "$L" && php artisan optimize:clear 2>&1 ) || true

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000091_add_compare_at_price_to_tagtoa_ev_ticket_types_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000091_add_compare_at_price_to_tagtoa_ev_ticket_types_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — prix barré (avant réduction) sur les types de billets.
+ *   compare_at_price = ancien prix affiché barré à côté du prix courant.
+ *   Une réduction est visible ⇔ compare_at_price > price.
+ * Colonne nullable, conforme à la règle « jamais casser l'existant ».
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('tagtoa_ev_ticket_types', 'compare_at_price')) {
+            Schema::table('tagtoa_ev_ticket_types', function (Blueprint $table) {
+                $table->decimal('compare_at_price', 12, 2)->nullable()->after('price');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('tagtoa_ev_ticket_types', 'compare_at_price')) {
+            Schema::table('tagtoa_ev_ticket_types', function (Blueprint $table) {
+                $table->dropColumn('compare_at_price');
+            });
+        }
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Event/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/DashboardController.php
@@ -48,6 +48,7 @@ $data = $this->validateEvent($request);
             $event->cover_path = $request->file('cover')->store('tagtoa/event-covers', 'public');
         }
         $event->save();
+        $this->syncTypes($event, $request); // capture les types de billets + prix dès la création
 
         return redirect()->route('tagtoa.event.dashboard.edit', $event->id)->with('success', __('Événement créé.'));
     }
@@ -134,12 +135,16 @@ $data = $this->validateEvent($request);
             if (empty($row['name'])) {
                 continue;
             }
+            $compare = ($row['compare_at_price'] ?? '') === '' ? null : (float) $row['compare_at_price'];
+            $price = (float) ($row['price'] ?? 0);
             $attrs = [
-                'name'      => $row['name'],
-                'price'     => (float) ($row['price'] ?? 0),
-                'quantity'  => ($row['quantity'] ?? '') === '' ? null : (int) $row['quantity'],
-                'is_active' => ! empty($row['is_active']),
-                'sort'      => (int) ($row['sort'] ?? $i),
+                'name'             => $row['name'],
+                'price'            => $price,
+                // Prix barré valide seulement s'il est supérieur au prix courant (sinon pas de « fausse » réduction).
+                'compare_at_price' => ($compare !== null && $compare > $price) ? $compare : null,
+                'quantity'         => ($row['quantity'] ?? '') === '' ? null : (int) $row['quantity'],
+                'is_active'        => ! empty($row['is_active']),
+                'sort'             => (int) ($row['sort'] ?? $i),
             ];
             $t = ! empty($row['id']) ? $event->ticketTypes()->whereKey($row['id'])->first() : null;
             $t ? $t->update($attrs) : $t = $event->ticketTypes()->create($attrs);
@@ -158,6 +163,7 @@ $data = $this->validateEvent($request);
             'title'        => ['required', 'string', 'max:160'],
             'alias'        => ['nullable', 'string', 'max:120', 'alpha_dash', 'unique:tagtoa_ev_events,alias'.($ignoreId ? ','.$ignoreId : '')],
             'type'         => ['nullable', 'string', 'max:30'],
+            'checkin_mode' => ['nullable', Rule::in(['qr', 'nfc', 'both'])], // mode de billet : en ligne (QR) / carte NFC / les deux
             'description'  => ['nullable', 'string', 'max:2000'],
             'venue'        => ['nullable', 'string', 'max:160'],
             'address'      => ['nullable', 'string', 'max:255'],

--- a/Modules/Tagtoa/app/Models/Event/Event.php
+++ b/Modules/Tagtoa/app/Models/Event/Event.php
@@ -19,7 +19,7 @@ class Event extends Model
 
     protected $fillable = [
         'vcard_id', 'tenant_id', 'title', 'alias', 'type', 'description', 'venue', 'address',
-        'notify_email', 'starts_at', 'ends_at', 'currency', 'is_free', 'is_published', 'pay_page_id', 'cover_path', 'views',
+        'notify_email', 'checkin_mode', 'starts_at', 'ends_at', 'currency', 'is_free', 'is_published', 'pay_page_id', 'cover_path', 'views',
     ];
 
     protected $casts = [

--- a/Modules/Tagtoa/app/Models/Event/TicketType.php
+++ b/Modules/Tagtoa/app/Models/Event/TicketType.php
@@ -12,11 +12,27 @@ class TicketType extends Model
 {
     protected $table = 'tagtoa_ev_ticket_types';
 
-    protected $fillable = ['event_id', 'name', 'price', 'quantity', 'sold', 'is_active', 'sort'];
+    protected $fillable = ['event_id', 'name', 'price', 'compare_at_price', 'quantity', 'sold', 'is_active', 'sort'];
 
     protected $casts = [
-        'price' => 'decimal:2', 'quantity' => 'integer', 'sold' => 'integer', 'is_active' => 'boolean',
+        'price' => 'decimal:2', 'compare_at_price' => 'decimal:2', 'quantity' => 'integer', 'sold' => 'integer', 'is_active' => 'boolean',
     ];
+
+    /** Une réduction est active si un prix barré supérieur au prix courant est défini. */
+    public function hasDiscount(): bool
+    {
+        return $this->compare_at_price !== null && (float) $this->compare_at_price > (float) $this->price;
+    }
+
+    /** Pourcentage de réduction (0 si aucune). */
+    public function getDiscountPercentAttribute(): int
+    {
+        if (! $this->hasDiscount()) {
+            return 0;
+        }
+
+        return (int) round((1 - ((float) $this->price / (float) $this->compare_at_price)) * 100);
+    }
 
     public function event(): BelongsTo
     {

--- a/Modules/Tagtoa/deploy/remote-deploy.sh
+++ b/Modules/Tagtoa/deploy/remote-deploy.sh
@@ -66,8 +66,26 @@ if [ "${TAGTOA_SEED_DEMO:-1}" != "0" ]; then
     || echo "WARN: seed démo ignoré (non bloquant)"
 fi
 
-# 5) Caches + réouverture
+# 4.7) Assets « souverains » (auto-réparation). mix()/asset() cherchent le
+#      manifeste + les dossiers dans public/ (public_path), mais le docroot réel
+#      est public_html/. On relie (idempotent) pour éviter le 500 « Mix manifest
+#      not found » après un déplacement de l'app.
+PH="$(dirname "$APP")/public_html"
+if [ -d "$PH" ] && [ -d "$APP/public" ]; then
+  if [ ! -e "$APP/public/mix-manifest.json" ] && [ -f "$PH/mix-manifest.json" ]; then
+    ln -s "$PH/mix-manifest.json" "$APP/public/mix-manifest.json" 2>/dev/null && echo "mix-manifest relié" || true
+  fi
+  for a in css js fonts img images assets build web front vendor; do
+    if [ -e "$PH/$a" ] && [ ! -e "$APP/public/$a" ]; then ln -s "$PH/$a" "$APP/public/$a" 2>/dev/null || true; fi
+  done
+fi
+
+# 5) Caches + réouverture. On vide puis on RECACHE (prod plus rapide : évite de
+#    relire ~30 fichiers config + .env à chaque requête). Pas de route:cache
+#    (Biztap peut avoir des routes en closure).
 php artisan optimize:clear >/dev/null 2>&1 || true
+php artisan config:cache >/dev/null 2>&1 || true
+php artisan view:cache >/dev/null 2>&1 || true
 php artisan up
 
 # 6) Smoke test public (non bloquant). Activer : TAGTOA_SMOKE_BASE=https://tagtoa.com/tapbiz/public

--- a/Modules/Tagtoa/resources/views/event/form.blade.php
+++ b/Modules/Tagtoa/resources/views/event/form.blade.php
@@ -8,9 +8,27 @@
     @csrf @if($editing) @method('PUT') @endif
     <div class="card">
         <label class="lbl">{{ __('Titre') }} *</label><input class="inp" name="title" required value="{{ old('title',$event->title) }}">
+        @php
+            $eventTypes = [
+                'concert'   => 'Concert',    'festival' => 'Festival',   'bal'       => 'Bal',
+                'forum'     => 'Forum',      'programme'=> 'Programme',   'cinema'    => 'Cinéma',
+                'formation' => 'Formation',  'seminaire'=> 'Séminaire',   'conference'=> 'Conférence',
+                'expo'      => 'Exposition', 'mariage'  => 'Mariage',     'sport'     => 'Sport',
+                'soiree'    => 'Soirée',     'gala'     => 'Gala',        'autre'     => 'Autre',
+            ];
+            $cm = old('checkin_mode', $event->checkin_mode ?: 'both');
+        @endphp
         <div class="row">
-            <div><label class="lbl">{{ __('Type') }}</label><select class="sel" name="type">@foreach(['concert','expo','mariage','sport','conference','autre'] as $t)<option @selected(old('type',$event->type)===$t)>{{ ucfirst($t) }}</option>@endforeach</select></div>
+            <div><label class="lbl">{{ __('Type') }}</label><select class="sel" name="type">@foreach($eventTypes as $val => $label)<option value="{{ $val }}" @selected(old('type',$event->type)===$val)>{{ $label }}</option>@endforeach</select></div>
             <div><label class="lbl">{{ __('Devise') }}</label><select class="sel" name="currency">@foreach(['HTG','USD'] as $c)<option @selected(old('currency',$event->currency ?: 'HTG')===$c)>{{ $c }}</option>@endforeach</select></div>
+        </div>
+        <div class="row">
+            <div><label class="lbl">{{ __('Mode de billet') }}</label><select class="sel" name="checkin_mode">
+                <option value="both" @selected($cm==='both')>{{ __('En ligne (QR) + Carte NFC') }}</option>
+                <option value="qr" @selected($cm==='qr')>{{ __('En ligne (QR) seulement') }}</option>
+                <option value="nfc" @selected($cm==='nfc')>{{ __('Carte NFC seulement') }}</option>
+            </select></div>
+            <div></div>
         </div>
         <div class="row">
             <div><label class="lbl">{{ __('Début') }}</label><input class="inp" type="datetime-local" name="starts_at" value="{{ old('starts_at', optional($event->starts_at)->format('Y-m-d\TH:i')) }}"></div>
@@ -29,23 +47,20 @@
         </div>
     </div>
 
-    @if($editing)
     <div class="card">
         <div class="h-row"><h2>{{ __('Types de billets') }}</h2><button type="button" class="btn btn-d btn-sm" onclick="addTT()"><i class="fa-solid fa-plus"></i> {{ __('Ajouter') }}</button></div>
+        <p style="color:var(--muted);font-size:13px;margin:0 0 10px">{{ __('Nom · Prix · Prix barré (optionnel, pour afficher une réduction) · Quantité (vide = illimité).') }}</p>
         <div id="ttlist"></div>
     </div>
-    @else
-        <p style="color:var(--muted);font-size:14px;margin:10px 0">{{ __('Enregistrez, puis ajoutez les types de billets.') }}</p>
-    @endif
     <button class="btn btn-p"><i class="fa-solid fa-floppy-disk"></i> {{ __('Enregistrer') }}</button>
 </form>
 
-@if($editing)
 <template id="tttpl">
-    <div class="ttrow" style="display:flex;gap:8px;align-items:center;margin-bottom:8px">
-        <input name="ticket_types[IDX][name]" class="inp" placeholder="{{ __('Nom (VIP…)') }}" style="max-width:160px">
-        <input name="ticket_types[IDX][price]" type="number" step="0.01" class="inp" placeholder="{{ __('Prix') }}" style="max-width:110px">
-        <input name="ticket_types[IDX][quantity]" type="number" class="inp" placeholder="{{ __('Qté (∞)') }}" style="max-width:110px">
+    <div class="ttrow" style="display:flex;gap:8px;align-items:center;margin-bottom:8px;flex-wrap:wrap">
+        <input name="ticket_types[IDX][name]" class="inp" placeholder="{{ __('Nom (VIP…)') }}" style="max-width:150px">
+        <input name="ticket_types[IDX][price]" type="number" step="0.01" min="0" class="inp" placeholder="{{ __('Prix') }}" style="max-width:100px">
+        <input name="ticket_types[IDX][compare_at_price]" type="number" step="0.01" min="0" class="inp" placeholder="{{ __('Prix barré') }}" style="max-width:100px">
+        <input name="ticket_types[IDX][quantity]" type="number" class="inp" placeholder="{{ __('Qté (∞)') }}" style="max-width:90px">
         <label class="switch" style="flex:0"><input type="checkbox" name="ticket_types[IDX][is_active]" value="1" checked></label>
         <button type="button" class="btn btn-o btn-sm" style="flex:0;color:var(--red)" onclick="this.closest('.ttrow').remove()"><i class="fa-solid fa-trash"></i></button>
     </div>
@@ -54,16 +69,15 @@
 <script>
 var ttIdx=0;
 function addTT(d){var h=document.getElementById('tttpl').innerHTML.replace(/IDX/g,ttIdx),x=document.createElement('div');x.innerHTML=h;var r=x.firstElementChild;document.getElementById('ttlist').appendChild(r);
-    if(d){r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';r.querySelector('[name$="[quantity]"]').value=d.quantity==null?'':d.quantity;r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='ticket_types['+ttIdx+'][id]';i.value=d.id;r.appendChild(i);}
+    if(d){r.querySelector('[name$="[name]"]').value=d.name||'';r.querySelector('[name$="[price]"]').value=d.price||'';var cp=r.querySelector('[name$="[compare_at_price]"]');if(cp){cp.value=d.compare_at_price==null?'':d.compare_at_price;}r.querySelector('[name$="[quantity]"]').value=d.quantity==null?'':d.quantity;r.querySelector('[name$="[is_active]"]').checked=!!d.is_active;var i=document.createElement('input');i.type='hidden';i.name='ticket_types['+ttIdx+'][id]';i.value=d.id;r.appendChild(i);}
     ttIdx++;}
 @php
     $ttData = $event->relationLoaded('ticketTypes')
-        ? $event->ticketTypes->map(fn ($t) => ['id' => $t->id, 'name' => $t->name, 'price' => $t->price, 'quantity' => $t->quantity, 'is_active' => $t->is_active])->values()
+        ? $event->ticketTypes->map(fn ($t) => ['id' => $t->id, 'name' => $t->name, 'price' => $t->price, 'compare_at_price' => $t->compare_at_price, 'quantity' => $t->quantity, 'is_active' => $t->is_active])->values()
         : [];
 @endphp
 var ex=@json($ttData);
 if(ex.length){ex.forEach(addTT);}else{addTT();}
 </script>
 @endpush
-@endif
 @endsection

--- a/Modules/Tagtoa/resources/views/event/show.blade.php
+++ b/Modules/Tagtoa/resources/views/event/show.blade.php
@@ -45,7 +45,13 @@
         <p class="sec">{{ __('Billets') }}</p>
         @forelse($event->activeTicketTypes as $tt)
             <div class="tt">
-                <div class="info"><b>{{ $tt->name }}</b><span>{{ $tt->price > 0 ? number_format($tt->price,2).' '.$event->currency : __('Gratuit') }}@if($tt->remaining !== null) · {{ $tt->remaining }} {{ __('restants') }}@endif</span></div>
+                @php
+                    $priceLabel = $tt->price > 0 ? number_format($tt->price, 2).' '.$event->currency : __('Gratuit');
+                    $remainLabel = $tt->remaining !== null ? ' · '.$tt->remaining.' '.__('restants') : '';
+                @endphp
+                <div class="info"><b>{{ $tt->name }}</b><span>{{ $priceLabel }}{{ $remainLabel }}</span>
+                    @if($tt->hasDiscount())<span style="margin-left:6px"><s style="opacity:.55">{{ number_format($tt->compare_at_price,2) }}</s> <b style="color:#1D9E75">−{{ $tt->discount_percent }}%</b></span>@endif
+                </div>
                 @if($tt->isOnSale())
                     <div class="qty"><button type="button" onclick="ev(-1,{{ $tt->id }})">−</button><input type="number" name="qty[{{ $tt->id }}]" id="q{{ $tt->id }}" value="0" min="0" max="{{ $tt->remaining ?? 50 }}" data-price="{{ $tt->price }}" readonly><button type="button" onclick="ev(1,{{ $tt->id }})">+</button></div>
                 @else<span style="color:#E0473E;font-size:12px;font-weight:600">{{ __('Épuisé') }}</span>@endif


### PR DESCRIPTION
## Contexte

Réponses aux manques signalés par le fondateur sur la **création d'événement**, + le durcissement de l'outil de diagnostic VPS qui a permis de rétablir `tagtoa.com` (500 « Mix manifest not found »).

## Événement — formulaire de création

- **Types élargis** : Concert, Festival, Bal, Forum, Programme, Cinéma, Formation, Séminaire, Conférence, Exposition, Mariage, Sport, Soirée, Gala, Autre (valeur + libellé propres ; corrige l'ancien décalage valeur/texte).
- **Mode de billet** exposé (colonne `checkin_mode` déjà en base, jamais affichée) : **En ligne (QR)** / **Carte NFC** / **les deux** — choisi dès la création.
- **Prix visible dès la création** : la section « Types de billets » (Nom · Prix · Quantité) s'affiche maintenant à la création (plus besoin d'enregistrer d'abord). `store()` appelle `syncTypes()`.
- **Réduction** : nouveau champ **« Prix barré »** (`compare_at_price`, migration 000091, **nullable**) ; validé serveur (ignoré si ≤ prix) ; affiché **barré + %** sur la page publique. Helpers `TicketType::hasDiscount()` / `discount_percent`.

## Outil de diagnostic VPS (`.github/workflows/diagnose.yml`)

Bouton sûr (lecture + réparation, jamais de DB) qui a diagnostiqué et corrigé le 500 :
- Résout l'app via `$HOME/domains` (le glob `/home/*` échouait car `/home` non lisible).
- Répare le 500 **« Mix manifest not found »** : relie `mix-manifest.json` + assets `public_html` → `laravel/public` (mix() les cherchait au mauvais endroit).
- `config:cache` + `view:cache` (dashboard plus rapide), extraction des messages d'erreur, inspection des vues login.

## Validation

- Suite Unit : **93 tests, 477 assertions — OK** (toutes les vues Blade compilent — `ViewCompileTest`).
- `RouteIntegrityTest` OK. `php -l` sur contrôleur/modèles/migration OK.

Migration **nullable** uniquement (`compare_at_price` sur `tagtoa_ev_ticket_types`), conforme à la règle « jamais casser l'existant ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_