### PR TITLE
EVENT: vente staff — moyen de paiement (TAGTOA Pay) + lecture NFC à la vente

### DIFF
--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000092_add_payment_method_to_tagtoa_ev_tickets_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000092_add_payment_method_to_tagtoa_ev_tickets_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA EVENT — moyen de paiement d'un billet vendu au terminal staff.
+ *   Le vendeur choisit le moyen (issu de TAGTOA Pay : MonCash, NatCash, Espèces…).
+ * Colonne nullable, conforme à la règle « jamais casser l'existant ».
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('tagtoa_ev_tickets', 'payment_method')) {
+            Schema::table('tagtoa_ev_tickets', function (Blueprint $table) {
+                $table->string('payment_method')->nullable()->after('holder_phone');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('tagtoa_ev_tickets', 'payment_method')) {
+            Schema::table('tagtoa_ev_tickets', function (Blueprint $table) {
+                $table->dropColumn('payment_method');
+            });
+        }
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Event/StaffTerminalController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/StaffTerminalController.php
@@ -41,11 +41,16 @@ class StaffTerminalController extends Controller
 
         $ticketTypes = $event->ticketTypes()->where('is_active', true)->get();
 
+        // Moyens de paiement issus de TAGTOA Pay (page de paiement liée à l'événement).
+        $payMethods = $event->payPage
+            ? $event->payPage->activeMethods()->orderBy('sort')->get(['id', 'label', 'type'])
+            : collect();
+
         $pendingConflicts = $staff && $staff->role === 'admin'
             ? SyncConflict::where('event_id', $event->id)->where('resolved', false)->count()
             : 0;
 
-        return view('tagtoa::event.staff-terminal', compact('event', 'staff', 'roster', 'ticketTypes', 'pendingConflicts'));
+        return view('tagtoa::event.staff-terminal', compact('event', 'staff', 'roster', 'ticketTypes', 'payMethods', 'pendingConflicts'));
     }
 
     /* ---------------- Session PIN ---------------- */
@@ -189,12 +194,24 @@ class StaffTerminalController extends Controller
             'uid'            => ['nullable', 'string', 'max:120'],
             'ticket_type_id' => ['nullable', 'integer'],
             'credit'         => ['nullable', 'numeric', 'min:0', 'max:1000000'], // crédit initial du wallet
+            'payment_method' => ['nullable', 'string', 'max:60'],               // moyen de paiement (TAGTOA Pay)
         ]);
 
         if (! empty($data['ticket_type_id'])) {
             $okType = $event->ticketTypes()->whereKey($data['ticket_type_id'])->exists();
             if (! $okType) {
                 $data['ticket_type_id'] = null;
+            }
+        }
+
+        // Le moyen de paiement doit provenir de TAGTOA Pay (page liée) ou être « Espèces ».
+        $method = trim((string) ($data['payment_method'] ?? ''));
+        if ($method !== '' && $method !== 'Espèces') {
+            $allowed = $event->payPage
+                ? $event->payPage->activeMethods()->pluck('label')->all()
+                : [];
+            if (! in_array($method, $allowed, true)) {
+                $method = ''; // valeur inconnue ignorée (anti-spoof)
             }
         }
 
@@ -228,6 +245,16 @@ class StaffTerminalController extends Controller
             }
         } catch (\Throwable $e) {
             return response()->json(['ok' => false, 'message' => __('Réessayez.')], 422);
+        }
+
+        // Enregistre le moyen de paiement + le revenu (billetterie) dans TAGTOA.
+        $ticket->update(['payment_method' => $method !== '' ? $method : null]);
+        if (! empty($data['ticket_type_id'])) {
+            $tt = $event->ticketTypes()->whereKey($data['ticket_type_id'])->first();
+            if ($tt && (float) $tt->price > 0) {
+                app(\Modules\Tagtoa\App\Services\Billing\RevenueService::class)
+                    ->record('event_ticket', $ticket->id, 'event', (float) $tt->price, $event->tenant_id, $event->currency);
+            }
         }
 
         return response()->json(['ok' => true, 'code' => $ticket->code, 'name' => $ticket->holder_name]);

--- a/Modules/Tagtoa/app/Models/Event/Ticket.php
+++ b/Modules/Tagtoa/app/Models/Event/Ticket.php
@@ -17,7 +17,7 @@ class Ticket extends Model
     protected $table = 'tagtoa_ev_tickets';
 
     protected $fillable = [
-        'event_id', 'order_id', 'ticket_type_id', 'code', 'holder_name', 'holder_phone',
+        'event_id', 'order_id', 'ticket_type_id', 'code', 'holder_name', 'holder_phone', 'payment_method',
         'status', 'checked_in', 'checked_in_at',
     ];
 

--- a/Modules/Tagtoa/resources/views/event/staff-terminal.blade.php
+++ b/Modules/Tagtoa/resources/views/event/staff-terminal.blade.php
@@ -118,7 +118,15 @@
                 <label>{{ __('E-mail (optionnel)') }}</label><input class="inp" id="slEmail" type="email">
                 <label>{{ __('Type de billet') }}</label>
                 <select id="slType"><option value="">{{ __('— Aucun —') }}</option>@foreach($ticketTypes as $tt)<option value="{{ $tt->id }}">{{ $tt->name }}</option>@endforeach</select>
-                <label>{{ __('UID carte NFC (vide = e-billet QR)') }}</label><input class="inp" id="slUid" autocomplete="off" placeholder="04:A2:...">
+                <label>{{ __('Moyen de paiement') }}</label>
+                <select id="slPay">
+                    <option value="Espèces">{{ __('Espèces (cash)') }}</option>
+                    @foreach($payMethods as $pm)<option value="{{ $pm->label }}">{{ $pm->label }}</option>@endforeach
+                </select>
+                @if($payMethods->isEmpty())<div class="nfc" style="text-align:left">{{ __('Astuce : configurez vos moyens dans TAGTOA Pay et liez la page à l\'événement.') }}</div>@endif
+                <label>{{ __('UID carte NFC (vide = e-billet QR)') }}</label>
+                <div style="display:flex;gap:8px"><input class="inp" id="slUid" autocomplete="off" placeholder="04:A2:..." style="flex:1"><button class="btn btn-o" id="slNfcBtn" type="button" style="margin-top:0;flex:0;white-space:nowrap"><i class="fa-solid fa-wifi"></i> {{ __('Lire') }}</button></div>
+                <div class="nfc" id="slNfcHint" style="text-align:left"></div>
                 <label>{{ __('Crédit initial (wallet)') }}</label><input class="inp" id="slCredit" inputmode="decimal" placeholder="0">
                 <button class="btn btn-p" id="slBtn" type="button"><i class="fa-solid fa-cart-shopping"></i> {{ __('Activer la carte / émettre le billet') }}</button>
                 <div class="okc" id="slOk"><h2>{{ __('Billet émis') }}</h2><div class="code" id="slCode"></div><div style="color:var(--mut);font-size:13px" id="slWho"></div></div>
@@ -223,6 +231,13 @@
 
     /* ---------- Vente ---------- */
     @if($canSell)
+    // Lecture NFC de la carte à la vente (valide la carte AU MOMENT de l'émission).
+    el('slNfcBtn').addEventListener('click',function(){
+        if(!('NDEFReader' in window)){el('slNfcHint').textContent=T.nfcNo;return;}
+        try{var rd=new NDEFReader();el('slNfcHint').textContent=T.read;
+            rd.scan().then(function(){rd.onreading=function(e){var id=e.serialNumber||'';if(id){el('slUid').value=id;el('slNfcHint').textContent='✓ '+id;}};})
+            .catch(function(){el('slNfcHint').textContent=T.nfcNo;});
+        }catch(err){el('slNfcHint').textContent=T.nfcNo;}});
     el('slBtn').addEventListener('click',function(){
         var name=el('slName').value.trim(),phone=el('slPhone').value.trim();
         var errB=el('slErr');errB.style.display='none';
@@ -231,6 +246,7 @@
         post(URL_SELL,{name:name,phone:phone,email:el('slEmail').value.trim()||null,
             ticket_type_id:el('slType').value?Number(el('slType').value):null,
             uid:el('slUid').value.trim()||null,
+            payment_method:el('slPay')?el('slPay').value:null,
             credit:el('slCredit').value.trim()?Number(el('slCredit').value):null})
         .then(function(j){btn.disabled=false;
             if(!j.ok){errB.textContent=j.message||T.err;errB.style.display='block';return;}


### PR DESCRIPTION
## Contexte

Demandes du fondateur sur l'écran **Vente** du terminal staff (`/event/staff/{alias}`), aligné sur festival.tagtoa.com.

## Changements

- **Moyen de paiement (via TAGTOA Pay)** : nouveau sélecteur « Moyen de paiement » alimenté par les **moyens actifs de la page TAGTOA Pay liée à l'événement** (`event->payPage->activeMethods`) + « Espèces ». Le moyen est **validé côté serveur** (anti-spoof : doit provenir de la page Pay ou être « Espèces »), stocké sur le billet (`payment_method`, migration 000092, **nullable**), et le **revenu de la vente est enregistré** via `RevenueService` → il remonte dans la facturation/analytics TAGTOA.
- **Lecture NFC à la vente** : bouton **« Lire »** (Web NFC) sur le champ UID de l'écran Vente. La carte est **lue et validée au moment de l'émission** (comme Festival) — plus besoin de taper l'UID.

## Validation

- Suite Unit : **93 tests, 477 assertions — OK** (toutes les vues Blade compilent — `ViewCompileTest`).
- `php -l` contrôleur + migration OK.

Migration **nullable** uniquement (`payment_method` sur `tagtoa_ev_tickets`), conforme à la règle « jamais casser l'existant ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_