### PR TITLE
EVENT: annuaire public /events + confirmation d'achat + mode de billet visible

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Event/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/PublicController.php
@@ -22,6 +22,21 @@ class PublicController extends Controller
     {
     }
 
+    /** Vitrine publique : TOUS les événements publiés (annuaire découverte). */
+    public function index(): View
+    {
+        $events = Event::where('is_published', true)
+            ->where(function ($q) {
+                // Masque les événements clairement terminés (fin < hier).
+                $q->whereNull('ends_at')->orWhere('ends_at', '>=', now()->subDay());
+            })
+            ->with('activeTicketTypes')
+            ->orderByRaw('CASE WHEN starts_at IS NULL THEN 1 ELSE 0 END, starts_at ASC')
+            ->paginate(24);
+
+        return view('tagtoa::event.directory', compact('events'));
+    }
+
     public function show(string $alias): View
     {
         $event = Event::where('alias', $alias)->where('is_published', true)
@@ -72,6 +87,8 @@ class PublicController extends Controller
             $this->revenue->record('event_order', $order->id, 'event', (float) $order->total, $event->tenant_id, $order->currency);
         }
 
+        $this->notifyBuyer($event, $order);
+
         return redirect()->route('tagtoa.event.order', $order->reference);
     }
 
@@ -87,5 +104,38 @@ class PublicController extends Controller
         $ticket = Ticket::where('code', $code)->with(['event', 'ticketType'])->firstOrFail();
 
         return view('tagtoa::event.ticket', ['ticket' => $ticket, 'event' => $ticket->event]);
+    }
+
+    /**
+     * Message de confirmation au participant après l'achat en ligne
+     * (WhatsApp + e-mail, opt-in/tolérant — ne bloque jamais la commande).
+     */
+    protected function notifyBuyer(Event $event, Order $order): void
+    {
+        try {
+            $svc = app(\Modules\Tagtoa\App\Services\Notifications\NotificationService::class);
+            $url = route('tagtoa.event.order', $order->reference);
+            $status = $order->isPaid()
+                ? __('Vos billets sont confirmés — présentez le QR à l\'entrée.')
+                : __('Finalisez le paiement pour valider vos billets.');
+            $body = __('Merci :name! Commande :ref pour :event. :status Vos billets : :url', [
+                'name'   => $order->buyer_name,
+                'ref'    => $order->reference,
+                'event'  => $event->title,
+                'status' => $status,
+                'url'    => $url,
+            ]);
+
+            if ($order->buyer_phone) {
+                $svc->push(['channels' => ['whatsapp'], 'phone' => $order->buyer_phone, 'subject' => $event->title, 'body' => $body]);
+            }
+            if ($order->buyer_email) {
+                $svc->push(['channels' => ['email'], 'email' => $order->buyer_email, 'subject' => __('Vos billets').' — '.$event->title, 'body' => $body]);
+            }
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
     }
 }

--- a/Modules/Tagtoa/resources/views/event/directory.blade.php
+++ b/Modules/Tagtoa/resources/views/event/directory.blade.php
@@ -1,0 +1,77 @@
+{{-- TAGTOA Event — annuaire public de TOUS les événements publiés. Variable : $events (paginator) --}}
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ __('Événements') }} — TAGTOA</title>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        :root{--blk:#0A0A0A;--green:#2cb809;--ink:#0d140c;--bg:#f5f9f2;--card:#fff;--bd:rgba(13,20,12,.10);--mut:#5d6b5a;--fh:'Space Grotesk',sans-serif;--fb:'Nunito',sans-serif}
+        *{box-sizing:border-box;margin:0;padding:0}body{font-family:var(--fb);background:var(--bg);color:var(--ink)}
+        .top{background:var(--ink);color:#fff;padding:26px 18px;text-align:center}
+        .top h1{font:400 30px 'Anton',sans-serif;letter-spacing:.02em}
+        .top p{opacity:.8;font-size:14px;margin-top:6px}
+        .wrap{max-width:1000px;margin:0 auto;padding:20px 16px 40px}
+        .grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:16px}
+        .card{background:var(--card);border:1px solid var(--bd);border-radius:16px;overflow:hidden;text-decoration:none;color:inherit;display:flex;flex-direction:column;transition:transform .12s,box-shadow .12s}
+        .card:hover{transform:translateY(-3px);box-shadow:0 10px 26px rgba(0,0,0,.10)}
+        .cover{height:150px;background:linear-gradient(135deg,#2cb809,#1D9E75);display:flex;align-items:center;justify-content:center;color:#fff;font-size:34px;position:relative}
+        .cover img{width:100%;height:100%;object-fit:cover}
+        .badge{position:absolute;top:10px;left:10px;background:rgba(0,0,0,.62);color:#fff;font:600 12px var(--fh);padding:5px 10px;border-radius:999px}
+        .body{padding:14px;flex:1;display:flex;flex-direction:column;gap:6px}
+        .body h2{font:600 16px var(--fh);line-height:1.25}
+        .meta{font-size:13px;color:var(--mut);display:flex;align-items:center;gap:6px}
+        .price{margin-top:auto;font:700 14px var(--fh);color:var(--green)}
+        .empty{text-align:center;padding:60px 20px;color:var(--mut)}
+        .pag{display:flex;justify-content:center;gap:8px;margin-top:24px}
+        .pag a,.pag span{padding:8px 13px;border-radius:10px;border:1px solid var(--bd);background:#fff;text-decoration:none;color:var(--ink);font:600 13px var(--fh)}
+        .pag .cur{background:var(--ink);color:#fff}
+        .foot{text-align:center;padding:24px;color:#9aa;font-size:12px}.foot b{font-family:var(--fh);color:var(--mut)}
+    </style>
+</head>
+<body>
+    <div class="top">
+        <h1>{{ __('Événements') }}</h1>
+        <p>{{ __('Découvrez et réservez vos billets') }}</p>
+    </div>
+    <div class="wrap">
+        @forelse($events as $e)
+            @php
+                $minPrice = $e->activeTicketTypes->min('price');
+                if ($e->is_free || $minPrice === null || (float) $minPrice <= 0) {
+                    $priceLabel = __('Gratuit');
+                } else {
+                    $priceLabel = __('À partir de').' '.number_format((float) $minPrice, 2).' '.$e->currency;
+                }
+                $dateLabel = optional($e->starts_at)->format('d/m/Y · H:i');
+            @endphp
+        @if($loop->first)<div class="grid">@endif
+            <a class="card" href="{{ route('tagtoa.event.show', $e->alias) }}">
+                <div class="cover">
+                    @if($e->cover_url)<img src="{{ $e->cover_url }}" alt="{{ $e->title }}">@else<i class="fa-solid fa-ticket"></i>@endif
+                    @if($e->type)<span class="badge">{{ ucfirst($e->type) }}</span>@endif
+                </div>
+                <div class="body">
+                    <h2>{{ $e->title }}</h2>
+                    @if($dateLabel)<div class="meta"><i class="fa-regular fa-calendar"></i> {{ $dateLabel }}</div>@endif
+                    @if($e->venue)<div class="meta"><i class="fa-solid fa-location-dot"></i> {{ $e->venue }}</div>@endif
+                    <div class="price">{{ $priceLabel }}</div>
+                </div>
+            </a>
+        @if($loop->last)</div>@endif
+        @empty
+            <div class="empty"><i class="fa-solid fa-calendar-xmark" style="font-size:40px;opacity:.4"></i><p style="margin-top:12px">{{ __('Aucun événement pour le moment.') }}</p></div>
+        @endforelse
+
+        @if($events->hasPages())
+            <div class="pag">
+                @if($events->onFirstPage())<span>‹</span>@else<a href="{{ $events->previousPageUrl() }}">‹</a>@endif
+                <span class="cur">{{ $events->currentPage() }} / {{ $events->lastPage() }}</span>
+                @if($events->hasMorePages())<a href="{{ $events->nextPageUrl() }}">›</a>@else<span>›</span>@endif
+            </div>
+        @endif
+    </div>
+    <div class="foot">{{ __('Propulsé par') }} <b>TAGTOA</b></div>
+</body>
+</html>

--- a/Modules/Tagtoa/resources/views/event/order.blade.php
+++ b/Modules/Tagtoa/resources/views/event/order.blade.php
@@ -35,6 +35,19 @@
     @foreach($order->tickets as $t)
         <a class="tkt" href="{{ route('tagtoa.event.ticket', $t->code) }}"><span class="ic"><i class="fa-solid fa-ticket"></i></span><span class="t"><b>{{ optional($t->ticketType)->name }}</b><span>{{ $t->code }}</span></span><i class="fa-solid fa-qrcode"></i></a>
     @endforeach
+    <div style="background:#eef9e8;border:1px solid var(--green);border-radius:14px;padding:14px;margin-top:14px;font-size:14px;line-height:1.5">
+        @if(($event->checkin_mode ?? 'qr') === 'nfc')
+            <b style="font-family:var(--fh)"><i class="fa-solid fa-id-card"></i> {{ __('Carte NFC') }}</b><br>
+            {{ __('Présentez cette référence à l\'entrée pour retirer votre carte/bracelet NFC.') }}
+        @else
+            <b style="font-family:var(--fh)"><i class="fa-solid fa-mobile-screen"></i> {{ __('Billet sur votre téléphone') }}</b><br>
+            {{ __('Gardez cette page. Présentez le QR code de chaque billet à l\'entrée pour être scanné et vérifié.') }}
+            @if(($event->checkin_mode ?? 'qr') === 'both')<br><span style="color:#666">{{ __('Une carte NFC physique peut aussi vous être remise à l\'entrée.') }}</span>@endif
+        @endif
+    </div>
+    @if($order->buyer_phone || $order->buyer_email)
+        <p style="text-align:center;color:#888;font-size:13px;margin-top:12px"><i class="fa-solid fa-paper-plane"></i> {{ __('Une confirmation vous a été envoyée.') }}</p>
+    @endif
     <div class="foot">{{ __('Propulsé par') }} <b>TAGTOA</b></div>
 </div>
 </body>

--- a/Modules/Tagtoa/resources/views/event/show.blade.php
+++ b/Modules/Tagtoa/resources/views/event/show.blade.php
@@ -43,6 +43,12 @@
         @if($errors->any())<div class="err">{{ $errors->first() }}</div>@endif
 
         <p class="sec">{{ __('Billets') }}</p>
+        @php $cm = $event->checkin_mode ?? 'qr'; @endphp
+        <div style="font-size:13px;color:#666;margin:-4px 0 12px">
+            @if($cm==='nfc')<i class="fa-solid fa-id-card"></i> {{ __('Accès par carte NFC remise à l\'entrée.') }}
+            @elseif($cm==='both')<i class="fa-solid fa-mobile-screen"></i> {{ __('Billet en ligne (QR) ou carte NFC physique à l\'entrée.') }}
+            @else<i class="fa-solid fa-mobile-screen"></i> {{ __('Billet en ligne — QR reçu sur votre téléphone.') }}@endif
+        </div>
         @forelse($event->activeTicketTypes as $tt)
             <div class="tt">
                 @php

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -47,6 +47,7 @@ Route::get('/links/go/{link}', [LinksPublic::class, 'go'])->name('tagtoa.links.g
 Route::get('/site/{alias}', [SitePublic::class, 'show'])->name('tagtoa.site.show');
 Route::get('/menu/{alias}', [MenuPublic::class, 'show'])->name('tagtoa.menu.show');
 Route::get('/store/{alias}', [\Modules\Tagtoa\App\Http\Controllers\Store\PublicController::class, 'show'])->name('tagtoa.store.show');
+Route::get('/events', [EventPublic::class, 'index'])->name('tagtoa.events.index');
 Route::get('/event/{alias}', [EventPublic::class, 'show'])->name('tagtoa.event.show');
 Route::get('/event/order/{reference}', [EventPublic::class, 'order'])->name('tagtoa.event.order');
 Route::get('/event/ticket/{code}', [EventPublic::class, 'ticket'])->name('tagtoa.event.ticket');


### PR DESCRIPTION
## Contexte

Compléter le parcours Événement demandé : annuaire public de tous les événements, achat en ligne avec billet sur téléphone + confirmation, et distinction billet en ligne / carte NFC.

## Changements

- **Annuaire public `/events`** (`tagtoa.events.index`) : tous les événements **publiés**, à venir en premier, en grille responsive (cover, type, date, lieu, prix « à partir de »). Chaque carte mène à la page de l'événement.
- **Confirmation d'achat en ligne** :
  - **Message au participant** (WhatsApp + e-mail, opt-in/tolérant) avec le lien de sa commande, à l'achat.
  - **Page commande enrichie** : « Billet sur votre téléphone — présentez le QR à l'entrée », ou retrait de la carte/bracelet NFC selon le mode.
- **Mode de billet visible côté public** (page événement + commande) selon `checkin_mode` : En ligne (QR) / Carte NFC / les deux.

Rappel du flux déjà en place : achat → commande → billets avec **QR scannables** (vérification au check-in).

## Validation

- Suite Unit : **93 tests, 477 assertions — OK** (toutes les vues Blade compilent — `ViewCompileTest` ; `RouteIntegrityTest` OK).
- `php -l` contrôleur OK.

Aucune migration, aucun changement cassant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_