### PR TITLE
EVENT: page publique — date de fin (multi-jour) + bouton Partager

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -118,6 +118,15 @@ jobs:
           ls -la "$L/bootstrap/cache/" 2>&1 || true
           echo "::endgroup::"
 
+          echo "::group::Menu sadmin (pour insérer un lien TAGTOA)"
+          MENUF=$(grep -rilE 'Sell NFC Cards|WhatsApp Stores' "$L/resources/views" 2>/dev/null | head -1)
+          echo "fichier menu: ${MENUF:-introuvable}"
+          if [ -n "$MENUF" ]; then
+            echo "-- extrait (lignes autour de 'Dashboard' / 'vCards') --"
+            grep -nE "Dashboard|vCards|Sell NFC|route\(|href=|menu-item|<li|nav-link" "$MENUF" | head -40
+          fi
+          echo "::endgroup::"
+
           echo "::group::Vues login / marque (rebranding TAGTOA)"
           echo "== fichiers de vues login/auth =="
           find "$L/resources/views" -maxdepth 3 -iregex '.*\(login\|auth\).*\.blade\.php' 2>/dev/null | head -20

--- a/Modules/Tagtoa/resources/views/event/show.blade.php
+++ b/Modules/Tagtoa/resources/views/event/show.blade.php
@@ -35,10 +35,19 @@
     <div class="body">
         <h1>{{ $event->title }}</h1>
         <div class="meta">
-            @if($event->starts_at)<div><i class="fa-regular fa-calendar"></i> {{ $event->starts_at->format('d M Y · H:i') }}</div>@endif
+            @if($event->starts_at)
+                @php $sameDay = $event->ends_at && $event->ends_at->isSameDay($event->starts_at); @endphp
+                <div><i class="fa-regular fa-calendar"></i> {{ $event->starts_at->format('d M Y · H:i') }}@if($event->ends_at && ! $sameDay) → {{ $event->ends_at->format('d M Y') }}@elseif($event->ends_at && $sameDay) – {{ $event->ends_at->format('H:i') }}@endif</div>
+            @endif
             @if($event->venue)<div><i class="fa-solid fa-location-dot"></i> {{ $event->venue }}{{ $event->address ? ', '.$event->address : '' }}</div>@endif
             <div><i class="fa-solid fa-tag"></i> {{ $event->is_free ? __('Gratuit') : __('Billets payants') }}</div>
         </div>
+        <button type="button" onclick="tagShare()" style="background:none;border:1px solid rgba(0,0,0,.15);border-radius:10px;padding:8px 12px;font:600 13px var(--fh,sans-serif);cursor:pointer;margin-top:4px"><i class="fa-solid fa-share-nodes"></i> {{ __('Partager') }}</button>
+        <script>
+        function tagShare(){var u=window.location.href,t=@json($event->title);
+            if(navigator.share){navigator.share({title:t,url:u}).catch(function(){});}
+            else{var w='https://wa.me/?text='+encodeURIComponent(t+' — '+u);window.open(w,'_blank');}}
+        </script>
         @if($event->description)<p class="desc">{{ $event->description }}</p>@endif
         @if($errors->any())<div class="err">{{ $errors->first() }}</div>@endif
 


### PR DESCRIPTION
## Contexte

« Plus Event » : améliorations de la page publique de l'événement.

## Changements

- **Date de fin** affichée quand elle existe : `→ jour suivant` pour un festival multi-jour, ou `– HH:mm` le même jour.
- **Bouton « Partager »** : `navigator.share` natif si disponible, sinon partage **WhatsApp** pré-rempli (titre + lien). Facilite la diffusion.

## Note — lien TAGTOA dans le menu sadmin

Le diagnostic montre que le menu de l'admin Biztap n'est **pas** un simple fichier éditable (piloté par clés de traduction / Livewire) : le modifier à l'aveugle serait fragile, non versionné et écrasé aux mises à jour Biztap. **Alternative déjà en place** : `LandingController` redirige tout utilisateur connecté vers `/tagtoa/home` — visiter `tagtoa.com/` (connecté) mène directement au hub TAGTOA. L'entrée de menu native est à prévoir pour le TAGTOA v2 autonome.

## Validation

- Suite Unit : **93 tests, 477 assertions — OK** (`ViewCompileTest`).

Aucune migration, aucun changement cassant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_