### PR TITLE
SUPER-ADMIN (Phase 8) + page de connexion TAGTOA (login override)

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -132,8 +132,10 @@ jobs:
           find "$L/resources/views" -maxdepth 3 -iregex '.*\(login\|auth\).*\.blade\.php' 2>/dev/null | head -20
           echo "== vues contenant l'ancienne marque (biztap) =="
           grep -rilo 'biztap' "$L/resources/views" 2>/dev/null | head -30
-          echo "== layouts/auth.blade.php (60 premières lignes) =="
-          sed -n '1,60p' "$L/resources/views/layouts/auth.blade.php" 2>/dev/null || echo "absent"
+          echo "== route(s) login (web.php) =="
+          grep -nE "login|Login" "$L/routes/web.php" 2>/dev/null | head -10
+          echo "== auth/login.blade.php (COMPLET) =="
+          cat "$L/resources/views/auth/login.blade.php" 2>/dev/null || echo "absent"
           echo "::endgroup::"
 
           echo "::group::laravel.log — messages d'ERREUR (secrets redactés)"

--- a/Modules/Tagtoa/app/Http/Controllers/Hub/HubController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Hub/HubController.php
@@ -28,7 +28,16 @@ class HubController extends Controller
             && $this->safeCount(\Modules\Tagtoa\App\Models\Links\LinkPage::class) === 0
             && $this->safeCount(\Modules\Tagtoa\App\Models\Site\Site::class) === 0;
 
-        return view('tagtoa::hub.index', compact('stats', 'isNew'));
+        // Le fondateur (super_admin) voit un accès au panneau plateforme.
+        $isSuperAdmin = false;
+        try {
+            $u = Tenant::user() ?: auth()->user();
+            $isSuperAdmin = $u && method_exists($u, 'hasRole') && $u->hasRole('super_admin');
+        } catch (\Throwable $e) {
+            // rôle indisponible → pas de lien (comportement sûr)
+        }
+
+        return view('tagtoa::hub.index', compact('stats', 'isNew', 'isSuperAdmin'));
     }
 
     private function safeCount(string $model, ?callable $scope = null): int

--- a/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/DashboardController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Services\Billing\SuperAdminService;
+
+/**
+ * TAGTOA SUPER-ADMIN — tableau de bord plateforme (fondateur, rôle super_admin).
+ *
+ * Vue CROSS-TENANT de tout TAGTOA : revenu global, commissions, abonnements,
+ * top marchands, revenu par module. Réservé au super_admin (garde route).
+ * Lecture seule — aucune action destructive ici.
+ */
+class DashboardController extends Controller
+{
+    public function __construct(protected SuperAdminService $svc)
+    {
+    }
+
+    public function index(): View
+    {
+        return view('tagtoa::superadmin.index', [
+            'totals'         => $this->svc->totals(),
+            'revenue'        => $this->svc->revenueByCurrency(),
+            'commission'     => $this->svc->commissionByStatus(),
+            'byModule'       => $this->svc->revenueByModule(),
+            'topMerchants'   => $this->svc->topMerchants(),
+            'plans'          => $this->svc->planCounts(),
+            'merchants'      => $this->svc->merchants(),
+        ]);
+    }
+}

--- a/Modules/Tagtoa/app/Providers/TagtoaServiceProvider.php
+++ b/Modules/Tagtoa/app/Providers/TagtoaServiceProvider.php
@@ -15,8 +15,27 @@ class TagtoaServiceProvider extends ServiceProvider
     {
         $this->registerConfig();
         $this->registerViews();
+        $this->overrideAuthViews();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/migrations'));
         $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'resources/lang'));
+    }
+
+    /**
+     * Remplace certaines vues du cœur (ex. auth/login) par les versions TAGTOA,
+     * de façon VERSIONNÉE et réversible : on prépend un chemin de vues, donc
+     * `view('auth.login')` résout d'abord `resources/views/overrides/auth/login`.
+     * Les vues non présentes dans overrides retombent sur le cœur (sûr).
+     */
+    protected function overrideAuthViews(): void
+    {
+        try {
+            $override = module_path($this->moduleName, 'resources/views/overrides');
+            if (is_dir($override)) {
+                view()->getFinder()->prependLocation($override);
+            }
+        } catch (\Throwable $e) {
+            // en cas d'échec, on garde la vue du cœur (login jamais cassé)
+        }
     }
 
     public function register(): void

--- a/Modules/Tagtoa/app/Services/Billing/SuperAdminService.php
+++ b/Modules/Tagtoa/app/Services/Billing/SuperAdminService.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Modules\Tagtoa\App\Services\Billing;
+
+use Modules\Tagtoa\App\Models\Billing\Commission;
+use Modules\Tagtoa\App\Models\Billing\Subscription;
+
+/**
+ * TAGTOA SUPER-ADMIN — agrégation CROSS-TENANT (vue plateforme du fondateur).
+ *
+ * Contrairement aux services marchands (scopés par Tenant::id()), celui-ci
+ * agrège TOUS les tenants : revenu global, commissions, abonnements, top
+ * marchands. Lecture seule. Réservé au rôle super_admin (garde au niveau route).
+ */
+class SuperAdminService
+{
+    /** Revenu brut + commission par devise (toutes commissions non annulées). */
+    public function revenueByCurrency(): array
+    {
+        return Commission::where('status', '!=', Commission::STATUS_VOID)
+            ->selectRaw('currency, SUM(gross_amount) AS gross, SUM(commission_amount) AS commission, COUNT(*) AS n')
+            ->groupBy('currency')->get()
+            ->map(fn ($r) => [
+                'currency'   => $r->currency,
+                'gross'      => (float) $r->gross,
+                'commission' => (float) $r->commission,
+                'count'      => (int) $r->n,
+            ])->all();
+    }
+
+    /** Commissions à régler vs réglées, par devise. */
+    public function commissionByStatus(): array
+    {
+        return Commission::selectRaw('currency, status, SUM(commission_amount) AS amount')
+            ->whereIn('status', [Commission::STATUS_ACCRUED, Commission::STATUS_SETTLED])
+            ->groupBy('currency', 'status')->get()
+            ->map(fn ($r) => [
+                'currency' => $r->currency,
+                'status'   => (int) $r->status,
+                'label'    => $r->status === Commission::STATUS_SETTLED ? 'Réglé' : 'À régler',
+                'amount'   => (float) $r->amount,
+            ])->all();
+    }
+
+    /** Revenu brut par module (menu, store, event, booking…). */
+    public function revenueByModule(): array
+    {
+        return Commission::where('status', '!=', Commission::STATUS_VOID)
+            ->selectRaw('module, SUM(gross_amount) AS gross, COUNT(*) AS n')
+            ->groupBy('module')->orderByDesc('gross')->get()
+            ->map(fn ($r) => ['module' => $r->module, 'gross' => (float) $r->gross, 'count' => (int) $r->n])
+            ->all();
+    }
+
+    /** Top marchands par revenu brut cumulé. */
+    public function topMerchants(int $limit = 10): array
+    {
+        return Commission::where('status', '!=', Commission::STATUS_VOID)
+            ->selectRaw('tenant_id, SUM(gross_amount) AS gross, COUNT(*) AS n')
+            ->groupBy('tenant_id')->orderByDesc('gross')->limit($limit)->get()
+            ->map(fn ($r) => ['tenant_id' => $r->tenant_id, 'gross' => (float) $r->gross, 'count' => (int) $r->n])
+            ->all();
+    }
+
+    /** Répartition des abonnements par forfait. */
+    public function planCounts(): array
+    {
+        $counts = Subscription::selectRaw('plan, status, COUNT(*) AS n')
+            ->groupBy('plan', 'status')->get();
+
+        $out = [];
+        foreach (array_keys((array) config('tagtoa.plans', [])) as $plan) {
+            $out[$plan] = ['plan' => $plan, 'active' => 0, 'total' => 0];
+        }
+        foreach ($counts as $c) {
+            $out[$c->plan] ??= ['plan' => $c->plan, 'active' => 0, 'total' => 0];
+            $out[$c->plan]['total'] += (int) $c->n;
+            if ($c->status === 'active') {
+                $out[$c->plan]['active'] += (int) $c->n;
+            }
+        }
+
+        return array_values($out);
+    }
+
+    /** Liste des marchands (abonnements) avec forfait + statut, paginable. */
+    public function merchants(int $perPage = 25)
+    {
+        return Subscription::orderByDesc('started_at')->paginate($perPage);
+    }
+
+    /** Compteurs de tête : marchands, abonnements actifs. */
+    public function totals(): array
+    {
+        $tenants = Subscription::distinct('tenant_id')->count('tenant_id');
+        $active = Subscription::where('status', 'active')->count();
+
+        return ['merchants' => $tenants, 'active_subscriptions' => $active];
+    }
+}

--- a/Modules/Tagtoa/resources/views/hub/index.blade.php
+++ b/Modules/Tagtoa/resources/views/hub/index.blade.php
@@ -3,6 +3,13 @@
 @section('page', __('Bonjour 👋'))
 
 @section('content')
+@if(!empty($isSuperAdmin))
+<a href="{{ route('tagtoa.superadmin.index') }}" class="card" style="display:flex;align-items:center;gap:14px;background:linear-gradient(135deg,#0d140c,#1D9E75);color:#fff;border:0;text-decoration:none;margin-bottom:16px">
+    <i class="fa-solid fa-shield-halved" style="font-size:22px"></i>
+    <div style="flex:1"><b style="font-family:var(--ft,sans-serif)">{{ __('Super-admin — vue plateforme') }}</b><div style="opacity:.85;font-size:13px">{{ __('Revenu global, commissions, abonnements, top marchands.') }}</div></div>
+    <i class="fa-solid fa-arrow-right"></i>
+</a>
+@endif
 @if(!empty($isNew))
 {{-- Hero onboarding : marchand sans aucune ressource --}}
 <div class="card" style="background:var(--blk);color:#fff;border:0;display:flex;gap:16px;align-items:center;flex-wrap:wrap;margin-bottom:20px">

--- a/Modules/Tagtoa/resources/views/overrides/auth/login.blade.php
+++ b/Modules/Tagtoa/resources/views/overrides/auth/login.blade.php
@@ -1,0 +1,115 @@
+{{-- TAGTOA — page de connexion (override versionné de auth/login).
+     Auto-suffisante : aucune dépendance externe (police système, CSS inline) pour
+     que la connexion RENDE TOUJOURS. Le formulaire poste sur route('login') avec
+     les champs email/password/remember/redirect attendus par le cœur (inchangés). --}}
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>{{ __('Connexion') }} — TAGTOA</title>
+    <style>
+        *{box-sizing:border-box;margin:0;padding:0}
+        :root{--g:#2cb809;--gd:#1D9E75;--ink:#0d140c;--mut:#5d6b5a;--bd:rgba(13,20,12,.12);--red:#E0473E}
+        body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;background:#f5f9f2;color:var(--ink);min-height:100vh;display:flex}
+        .split{display:flex;width:100%;min-height:100vh}
+        .brand{flex:1;background:linear-gradient(150deg,#0d140c 0%,#14361f 55%,#1D9E75 100%);color:#fff;padding:48px;display:none;flex-direction:column;justify-content:space-between;position:relative;overflow:hidden}
+        .brand .logo{display:flex;align-items:center;gap:12px;font-weight:800;font-size:26px;letter-spacing:.02em}
+        .brand .badge{width:44px;height:44px;border-radius:12px;background:var(--g);display:flex;align-items:center;justify-content:center;font-size:22px}
+        .brand h2{font-size:32px;line-height:1.2;font-weight:800;max-width:12ch}
+        .brand ul{list-style:none;display:flex;flex-direction:column;gap:14px;opacity:.92}
+        .brand li{display:flex;align-items:center;gap:12px;font-size:15px}
+        .brand li .dot{width:26px;height:26px;border-radius:8px;background:rgba(255,255,255,.14);display:flex;align-items:center;justify-content:center;font-size:14px}
+        .pane{flex:1;display:flex;align-items:center;justify-content:center;padding:28px 20px}
+        .card{width:100%;max-width:400px}
+        .mlogo{display:flex;align-items:center;justify-content:center;gap:10px;font-weight:800;font-size:24px;margin-bottom:6px}
+        .mlogo .badge{width:38px;height:38px;border-radius:11px;background:var(--g);color:#fff;display:flex;align-items:center;justify-content:center;font-size:20px}
+        h1{font-size:22px;text-align:center;margin-bottom:4px}
+        .sub{text-align:center;color:var(--mut);font-size:14px;margin-bottom:24px}
+        label{display:block;font-weight:600;font-size:13px;margin:0 0 7px}
+        .inp{width:100%;padding:13px 14px;border:1.5px solid var(--bd);border-radius:12px;font-size:16px;background:#fff;color:var(--ink);outline:none;transition:border-color .15s}
+        .inp:focus{border-color:var(--g)}
+        .field{margin-bottom:16px}
+        .pwrap{position:relative}
+        .pwrap .eye{position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:0;cursor:pointer;color:var(--mut);font-size:13px;padding:4px 6px}
+        .row{display:flex;align-items:center;justify-content:space-between;margin-bottom:20px;font-size:14px}
+        .row label{display:flex;align-items:center;gap:8px;font-weight:500;margin:0;cursor:pointer}
+        .row a{color:var(--gd);text-decoration:none;font-weight:600}
+        .btn{width:100%;border:0;border-radius:13px;padding:15px;background:var(--g);color:#fff;font-size:16px;font-weight:700;cursor:pointer;transition:filter .15s}
+        .btn:hover{filter:brightness(.95)}
+        .alert{border-radius:11px;padding:12px 14px;font-size:14px;margin-bottom:16px}
+        .alert.err{background:#fdecea;border:1px solid var(--red);color:#9a2820}
+        .alert.ok{background:#eef9e8;border:1px solid var(--g);color:#1b5e12}
+        .foot{text-align:center;color:var(--mut);font-size:13px;margin-top:22px}
+        .foot a{color:var(--gd);text-decoration:none;font-weight:600}
+        @media(min-width:900px){.brand{display:flex}}
+    </style>
+</head>
+<body>
+<div class="split">
+    <aside class="brand">
+        <div class="logo"><span class="badge">⚡</span> TAGTOA</div>
+        <div>
+            <h2>{{ __('Votre business, un seul tap.') }}</h2>
+            <ul style="margin-top:24px">
+                <li><span class="dot">✓</span> {{ __('Paiements, menu, boutique & événements') }}</li>
+                <li><span class="dot">✓</span> {{ __('Cartes NFC & QR pour tout') }}</li>
+                <li><span class="dot">✓</span> {{ __('Fidélité, réservations & analytics') }}</li>
+            </ul>
+        </div>
+        <div style="opacity:.7;font-size:13px">© {{ date('Y') }} TAGTOA · GOVIBE Ecosystem</div>
+    </aside>
+
+    <main class="pane">
+        <div class="card">
+            <div class="mlogo"><span class="badge">⚡</span> TAGTOA</div>
+            <h1>{{ __('Connexion') }}</h1>
+            <p class="sub">{{ __('Accédez à votre tableau de bord') }}</p>
+
+            @if($errors->any())
+                <div class="alert err">
+                    @foreach($errors->all() as $e)<div>{{ $e }}</div>@endforeach
+                </div>
+            @endif
+            @if(session('success'))<div class="alert ok">{{ session('success') }}</div>@endif
+            @if(session('error'))<div class="alert err">{{ session('error') }}</div>@endif
+
+            <form method="POST" action="{{ route('login') }}" novalidate>
+                @csrf
+                <input type="hidden" name="redirect" value="{{ request()->get('redirect') }}">
+
+                <div class="field">
+                    <label for="email">{{ __('E-mail') }}</label>
+                    <input class="inp" id="email" name="email" type="email" required autofocus
+                           autocomplete="username" placeholder="vous@exemple.com" value="{{ old('email') }}">
+                </div>
+
+                <div class="field">
+                    <label for="password">{{ __('Mot de passe') }}</label>
+                    <div class="pwrap">
+                        <input class="inp" id="password" name="password" type="password" required
+                               autocomplete="current-password" placeholder="••••••••">
+                        <button type="button" class="eye" onclick="var p=document.getElementById('password');p.type=p.type==='password'?'text':'password';this.textContent=p.type==='password'?'{{ __('Voir') }}':'{{ __('Cacher') }}';">{{ __('Voir') }}</button>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <label><input type="checkbox" name="remember"> {{ __('Se souvenir de moi') }}</label>
+                    @if(\Illuminate\Support\Facades\Route::has('password.request'))
+                        <a href="{{ route('password.request') }}">{{ __('Mot de passe oublié ?') }}</a>
+                    @endif
+                </div>
+
+                <button type="submit" class="btn">{{ __('Se connecter') }}</button>
+            </form>
+
+            @if(\Illuminate\Support\Facades\Route::has('register'))
+                <div class="foot">{{ __('Nouveau ?') }} <a href="{{ route('register') }}">{{ __('Créer un compte') }}</a></div>
+            @endif
+            <div class="foot"><a href="{{ url('/') }}">{{ __('← Retour à l\'accueil') }}</a></div>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/Modules/Tagtoa/resources/views/superadmin/index.blade.php
+++ b/Modules/Tagtoa/resources/views/superadmin/index.blade.php
@@ -1,0 +1,85 @@
+@extends('tagtoa::layouts.dashboard')
+@section('title', __('Super-admin TAGTOA'))
+@section('page', __('Super-admin — vue plateforme'))
+
+@section('content')
+{{-- Vue CROSS-TENANT réservée au fondateur (super_admin). Lecture seule. --}}
+
+{{-- Compteurs de tête --}}
+<div class="grid g3" style="margin-bottom:16px">
+    <div class="stat"><div class="ic" style="background:#eef2ff;color:#3344aa"><i class="fa-solid fa-store"></i></div><div class="v">{{ $totals['merchants'] }}</div><div class="k">{{ __('Marchands') }}</div></div>
+    <div class="stat"><div class="ic" style="background:#eafaf3;color:#0e5f44"><i class="fa-solid fa-circle-check"></i></div><div class="v">{{ $totals['active_subscriptions'] }}</div><div class="k">{{ __('Abonnements actifs') }}</div></div>
+    <div class="stat"><div class="ic" style="background:#fff5e6;color:#7a5200"><i class="fa-solid fa-layer-group"></i></div><div class="v">{{ count($byModule) }}</div><div class="k">{{ __('Modules générateurs') }}</div></div>
+</div>
+
+{{-- Revenu par devise --}}
+<div class="card" style="margin-bottom:16px">
+    <div class="h-row"><h2>{{ __('Revenu global par devise') }}</h2></div>
+    @forelse($revenue as $r)
+        <div class="kv"><span>{{ $r['currency'] }} · {{ $r['count'] }} {{ __('opérations') }}</span><b>{{ number_format($r['gross'], 2) }} {{ $r['currency'] }} <span style="color:#888;font-weight:400">· {{ __('commission') }} {{ number_format($r['commission'], 2) }}</span></b></div>
+    @empty
+        <p style="color:var(--muted,#888);font-size:14px">{{ __('Aucun revenu enregistré pour le moment.') }}</p>
+    @endforelse
+</div>
+
+<div class="grid g2" style="gap:16px;margin-bottom:16px">
+    {{-- Commissions à régler / réglées --}}
+    <div class="card">
+        <div class="h-row"><h2>{{ __('Commissions') }}</h2></div>
+        @forelse($commission as $c)
+            <div class="kv"><span>{{ $c['label'] }} ({{ $c['currency'] }})</span><b>{{ number_format($c['amount'], 2) }} {{ $c['currency'] }}</b></div>
+        @empty
+            <p style="color:#888;font-size:14px">{{ __('Aucune commission.') }}</p>
+        @endforelse
+    </div>
+
+    {{-- Abonnements par forfait --}}
+    <div class="card">
+        <div class="h-row"><h2>{{ __('Forfaits') }}</h2></div>
+        @foreach($plans as $p)
+            <div class="kv"><span>{{ ucfirst($p['plan']) }}</span><b>{{ $p['active'] }} {{ __('actifs') }} <span style="color:#888;font-weight:400">/ {{ $p['total'] }}</span></b></div>
+        @endforeach
+    </div>
+</div>
+
+{{-- Revenu par module --}}
+<div class="card" style="margin-bottom:16px">
+    <div class="h-row"><h2>{{ __('Revenu par module') }}</h2></div>
+    @forelse($byModule as $m)
+        <div class="kv"><span><i class="fa-solid fa-cube" style="opacity:.5"></i> {{ ucfirst($m['module']) }} · {{ $m['count'] }}</span><b>{{ number_format($m['gross'], 2) }}</b></div>
+    @empty
+        <p style="color:#888;font-size:14px">{{ __('Aucune donnée.') }}</p>
+    @endforelse
+</div>
+
+{{-- Top marchands --}}
+<div class="card" style="margin-bottom:16px">
+    <div class="h-row"><h2>{{ __('Top marchands') }}</h2></div>
+    @forelse($topMerchants as $i => $t)
+        <div class="kv"><span><b style="font-family:var(--fh)">#{{ $i + 1 }}</b> · {{ __('Tenant') }} {{ \Illuminate\Support\Str::limit($t['tenant_id'], 14) }} · {{ $t['count'] }}</span><b>{{ number_format($t['gross'], 2) }}</b></div>
+    @empty
+        <p style="color:#888;font-size:14px">{{ __('Aucun marchand avec revenu.') }}</p>
+    @endforelse
+</div>
+
+{{-- Liste des abonnements --}}
+<div class="card">
+    <div class="h-row"><h2>{{ __('Abonnements marchands') }}</h2></div>
+    <table style="width:100%;border-collapse:collapse;font-size:14px">
+        <thead><tr style="text-align:left;color:#888"><th style="padding:8px 6px">{{ __('Tenant') }}</th><th>{{ __('Forfait') }}</th><th>{{ __('Statut') }}</th><th>{{ __('Expire') }}</th></tr></thead>
+        <tbody>
+        @forelse($merchants as $s)
+            <tr style="border-top:1px solid rgba(0,0,0,.06)">
+                <td style="padding:8px 6px;font-family:var(--fh)">{{ \Illuminate\Support\Str::limit($s->tenant_id, 18) }}</td>
+                <td>{{ ucfirst($s->plan) }}</td>
+                <td>{{ $s->status === 'active' ? '🟢 '.__('Actif') : '⚪ '.$s->status }}</td>
+                <td style="color:#888">{{ $s->expires_at ? \Illuminate\Support\Carbon::parse($s->expires_at)->format('d/m/Y') : '—' }}</td>
+            </tr>
+        @empty
+            <tr><td colspan="4" style="padding:20px;text-align:center;color:#888">{{ __('Aucun abonnement.') }}</td></tr>
+        @endforelse
+        </tbody>
+    </table>
+    <div style="margin-top:12px">{{ $merchants->links() }}</div>
+</div>
+@endsection

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -270,3 +270,9 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
     Route::post('/billing/settle', [BillingController::class, 'settle'])->name('tagtoa.billing.settle');
     Route::get('/billing/export', [BillingController::class, 'export'])->name('tagtoa.billing.export');
 });
+
+// ---------- SUPER-ADMIN TAGTOA (fondateur, cross-tenant, role:super_admin) ----------
+// Hors du groupe multi_tenant : la vue plateforme agrège TOUS les tenants.
+Route::middleware(['auth', 'valid.user', 'role:super_admin'])->prefix('tagtoa/admin')->group(function () {
+    Route::get('/', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\DashboardController::class, 'index'])->name('tagtoa.superadmin.index');
+});


### PR DESCRIPTION
## Contexte

Deux demandes du fondateur : le **panneau super-admin TAGTOA** (Phase 8, intégré à la même connexion sécurisée que `/sadmin`) et une **page de connexion TAGTOA belle & pro**.

## 1) Super-admin TAGTOA — Phase 8

Vue **cross-tenant** réservée au fondateur (`role:super_admin`), même login que `/sadmin` mais **pages TAGTOA versionnées** (pas de hack du cœur Biztap).

- Route `/tagtoa/admin` (`role:super_admin`, hors `multi_tenant` → agrège **tous** les tenants). `tagtoa.superadmin.index`.
- `SuperAdminService` : revenu par devise, commissions à régler/réglées, revenu par module, top marchands, répartition des forfaits, abonnements.
- Vue `superadmin/index` : compteurs, revenu global, commissions, forfaits, revenu par module, top marchands, table des abonnements (paginée).
- Accès depuis le hub `/tagtoa/home` : carte **« Super-admin »** affichée uniquement si `hasRole('super_admin')` (tolérant).

## 2) Page de connexion TAGTOA (override)

Remplace le login Biztap générique (InfyVCards-SaaS) par une page TAGTOA moderne — **sans hacker le cœur** : le provider **prépend** un chemin de vues (`view('auth.login')` → `overrides/auth/login`).

- Design pro : panneau marque dégradé (desktop) + carte formulaire épurée, couleur TAGTOA, afficher/masquer mot de passe, responsive.
- **Auto-suffisante** (police système, CSS inline, zéro dépendance externe) → la connexion **rend toujours**.
- **Formulaire inchangé** côté cœur : `POST route('login')`, champs `email`/`password`/`remember` + `redirect` caché, erreurs/flash natifs. Liens mot de passe oublié / créer un compte conservés.
- **Réversible** : supprimer `overrides/` rétablit la vue Biztap.

## Validation

- Suite Unit : **93 tests, 477 assertions — OK** (`ViewCompileTest` compile la vue login + superadmin ; `RouteIntegrityTest` OK).
- `php -l` provider/contrôleurs/service OK.

Aucune migration. Login réversible, super-admin en lecture seule.

## Observation (hors périmètre)

Le log VPS montre une erreur cœur Biztap : `Attempt to read property "status" on null` à `app/Http/Controllers/HomeController.php:298` — à surveiller (probablement un abonnement/tenant null pour le super_admin sans vCard). Non corrigé ici (cœur Biztap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_