### PR TITLE
PAY: drivers PayPal + CoinPayments (crypto) — dormants jusqu'aux identifiants

### DIFF
--- a/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
+++ b/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
@@ -28,8 +28,10 @@ class CheckoutService
     protected function driver(string $gateway): ?GatewayDriver
     {
         return match ($gateway) {
-            'moncash' => new MonCashDriver,
-            default   => null,
+            'moncash'      => new MonCashDriver,
+            'paypal'       => new \Modules\Tagtoa\App\Support\Gateways\PayPalDriver,
+            'coinpayments' => new \Modules\Tagtoa\App\Support\Gateways\CoinPaymentsDriver,
+            default        => null,
         };
     }
 

--- a/Modules/Tagtoa/app/Support/Gateways/CoinPayments.php
+++ b/Modules/Tagtoa/app/Support/Gateways/CoinPayments.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Gateways;
+
+/**
+ * TAGTOA PAY — helpers PURS CoinPayments (crypto : USDT/USDC/BTC/ETH/BNB…),
+ * testables sans Laravel ni réseau.
+ *
+ * API : POST https://www.coinpayments.net/api.php (form-urlencoded), signée par
+ * HMAC-SHA512 du corps avec la clé privée, header HMAC. Flux : create_transaction
+ * → checkout_url (redirection) → IPN + get_tx_info pour confirmer.
+ */
+class CoinPayments
+{
+    public const API_URL = 'https://www.coinpayments.net/api.php';
+
+    /** Signature HMAC-SHA512 du corps (querystring) avec la clé privée. PUR. */
+    public static function sign(array $payload, string $privateKey): string
+    {
+        return hash_hmac('sha512', http_build_query($payload), $privateKey);
+    }
+
+    /** Devise crypto par défaut à recevoir si non précisée (stablecoin). PUR. */
+    public static function defaultCoin(?string $hint = null): string
+    {
+        $map = ['usdt' => 'USDT.TRC20', 'usdc' => 'USDC', 'btc' => 'BTC', 'eth' => 'ETH', 'bnb' => 'BNB.BSC'];
+
+        return $map[strtolower((string) $hint)] ?? 'USDT.TRC20';
+    }
+
+    /** Montant formaté (chaîne à 2 décimales). PUR. */
+    public static function amount($value): string
+    {
+        return number_format(max(0.01, (float) $value), 2, '.', '');
+    }
+
+    /**
+     * Traduit le statut numérique CoinPayments → statut interne. PUR.
+     *   >= 100 ou == 2 : payé/complété · < 0 : échec/annulé · 0/1 : en attente.
+     */
+    public static function mapStatus($status): string
+    {
+        $s = (int) $status;
+        if ($s >= 100 || $s === 2) {
+            return 'paid';
+        }
+        if ($s < 0) {
+            return 'failed';
+        }
+
+        return 'pending';
+    }
+}

--- a/Modules/Tagtoa/app/Support/Gateways/CoinPaymentsDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/CoinPaymentsDriver.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Gateways;
+
+use Illuminate\Support\Facades\Http;
+use Modules\Tagtoa\App\Models\Pay\PayTransaction;
+use Modules\Tagtoa\App\Support\GatewayManager;
+
+/**
+ * TAGTOA PAY — driver CoinPayments (crypto : USDT/USDC/BTC/ETH/BNB…).
+ * Tolérant (jamais d'exception). Dormant tant que les identifiants ne sont pas
+ * configurés. La devise crypto reçue est déduite de meta['coin'] (défaut USDT).
+ *
+ * ⚠️ À tester avec un vrai compte avant la production.
+ */
+class CoinPaymentsDriver implements GatewayDriver
+{
+    protected ?string $publicKey;
+    protected ?string $privateKey;
+
+    public function __construct()
+    {
+        $cfg = GatewayManager::config('coinpayments');
+        $this->publicKey = $cfg['credentials']['public_key'] ?? null;
+        $this->privateKey = $cfg['credentials']['private_key'] ?? null;
+    }
+
+    public function createPayment(PayTransaction $txn): ?string
+    {
+        if (! $this->publicKey || ! $this->privateKey) {
+            return null;
+        }
+
+        $coin = CoinPayments::defaultCoin($txn->meta['coin'] ?? null);
+        $payload = [
+            'version'     => 1,
+            'cmd'         => 'create_transaction',
+            'key'         => $this->publicKey,
+            'format'      => 'json',
+            'amount'      => CoinPayments::amount($txn->amount),
+            'currency1'   => strtoupper($txn->currency),
+            'currency2'   => $coin,
+            'item_name'   => 'TAGTOA '.$txn->reference,
+            'invoice'     => $txn->reference,
+            'custom'      => $txn->reference,
+            'ipn_url'     => route('tagtoa.pay.online.webhook', ['gateway' => 'coinpayments']),
+            'success_url' => route('tagtoa.pay.online.return', ['gateway' => 'coinpayments']).'?reference='.urlencode($txn->reference),
+            'cancel_url'  => route('tagtoa.pay.result'),
+        ];
+
+        $result = $this->call($payload);
+        if ($result && ! empty($result['txn_id']) && ! empty($result['checkout_url'])) {
+            $txn->update(['gateway_ref' => $result['txn_id']]);
+
+            return $result['checkout_url'];
+        }
+
+        return null;
+    }
+
+    public function verify(PayTransaction $txn): string
+    {
+        if (! $txn->gateway_ref || ! $this->publicKey || ! $this->privateKey) {
+            return 'pending';
+        }
+
+        $result = $this->call([
+            'version' => 1,
+            'cmd'     => 'get_tx_info',
+            'key'     => $this->publicKey,
+            'format'  => 'json',
+            'txid'    => $txn->gateway_ref,
+        ]);
+
+        return $result && array_key_exists('status', $result)
+            ? CoinPayments::mapStatus($result['status'])
+            : 'pending';
+    }
+
+    /** Appel signé HMAC à l'API CoinPayments. Retourne result[] ou null. */
+    protected function call(array $payload): ?array
+    {
+        try {
+            $res = Http::asForm()->acceptJson()->timeout(20)
+                ->withHeaders(['HMAC' => CoinPayments::sign($payload, $this->privateKey)])
+                ->post(CoinPayments::API_URL, $payload);
+
+            if ($res->successful() && $res->json('error') === 'ok') {
+                return (array) $res->json('result', []);
+            }
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
+
+        return null;
+    }
+}

--- a/Modules/Tagtoa/app/Support/Gateways/PayPal.php
+++ b/Modules/Tagtoa/app/Support/Gateways/PayPal.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Gateways;
+
+/**
+ * TAGTOA PAY — helpers PURS PayPal (Orders v2 API), testables sans Laravel ni réseau.
+ *
+ * Flux : OAuth token (client_credentials) → Create Order (intent=CAPTURE) →
+ * redirection vers le lien « approve » → au retour, Capture Order → COMPLETED.
+ * Endpoints : sandbox api-m.sandbox.paypal.com · live api-m.paypal.com.
+ */
+class PayPal
+{
+    public const HOST_SANDBOX = 'https://api-m.sandbox.paypal.com';
+    public const HOST_LIVE = 'https://api-m.paypal.com';
+
+    /** Devises PayPal courantes (PayPal ne gère PAS la gourde HTG). */
+    public const CURRENCIES = ['USD', 'EUR', 'CAD', 'GBP', 'AUD', 'MXN', 'BRL', 'JPY', 'CHF'];
+
+    /** Base API selon le mode. PUR. */
+    public static function apiBase(string $mode): string
+    {
+        return $mode === 'live' ? self::HOST_LIVE : self::HOST_SANDBOX;
+    }
+
+    /** PayPal ne traite pas la HTG : seules les devises supportées passent. PUR. */
+    public static function supportsCurrency(?string $currency): bool
+    {
+        return in_array(strtoupper((string) $currency), self::CURRENCIES, true);
+    }
+
+    /** Montant formaté PayPal : chaîne à 2 décimales (« 10.00 »), min 0.01. PUR. */
+    public static function amount($value): string
+    {
+        return number_format(max(0.01, (float) $value), 2, '.', '');
+    }
+
+    /**
+     * Extrait le lien d'approbation (rel=approve) de la réponse Create Order. PUR.
+     *
+     * @param  array  $links  tableau links[] de la réponse PayPal
+     */
+    public static function approveLink(array $links): ?string
+    {
+        foreach ($links as $l) {
+            if (($l['rel'] ?? null) === 'approve' && ! empty($l['href'])) {
+                return $l['href'];
+            }
+        }
+
+        return null;
+    }
+
+    /** Traduit le statut d'un order PayPal → statut interne. PUR. */
+    public static function mapStatus(?string $status): string
+    {
+        $s = strtoupper(trim((string) $status));
+        if ($s === 'COMPLETED') {
+            return 'paid';
+        }
+        if (in_array($s, ['VOIDED', 'DECLINED', 'FAILED'], true)) {
+            return 'failed';
+        }
+
+        // CREATED / SAVED / APPROVED / PAYER_ACTION_REQUIRED → en attente (capture requise)
+        return 'pending';
+    }
+}

--- a/Modules/Tagtoa/app/Support/Gateways/PayPalDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/PayPalDriver.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Gateways;
+
+use Illuminate\Support\Facades\Http;
+use Modules\Tagtoa\App\Models\Pay\PayTransaction;
+use Modules\Tagtoa\App\Support\GatewayManager;
+
+/**
+ * TAGTOA PAY — driver PayPal (Orders v2). Tolérant (jamais d'exception qui casse
+ * le flux). Dormant tant que les identifiants ne sont pas configurés.
+ * PayPal ne gère pas la HTG → repli manuel si la devise n'est pas supportée.
+ *
+ * ⚠️ À tester en sandbox avant la production.
+ */
+class PayPalDriver implements GatewayDriver
+{
+    protected string $mode;
+    protected ?string $clientId;
+    protected ?string $secret;
+
+    public function __construct()
+    {
+        $cfg = GatewayManager::config('paypal');
+        $this->mode = $cfg['mode'] ?? 'sandbox';
+        $this->clientId = $cfg['credentials']['client_id'] ?? null;
+        $this->secret = $cfg['credentials']['secret'] ?? null;
+    }
+
+    public function createPayment(PayTransaction $txn): ?string
+    {
+        if (! PayPal::supportsCurrency($txn->currency)) {
+            return null;
+        }
+        $token = $this->accessToken();
+        if (! $token) {
+            return null;
+        }
+
+        try {
+            $res = Http::withToken($token)->acceptJson()->asJson()->timeout(20)
+                ->post(PayPal::apiBase($this->mode).'/v2/checkout/orders', [
+                    'intent'         => 'CAPTURE',
+                    'purchase_units' => [[
+                        'custom_id'  => $txn->reference,
+                        'invoice_id' => $txn->reference,
+                        'amount'     => [
+                            'currency_code' => strtoupper($txn->currency),
+                            'value'         => PayPal::amount($txn->amount),
+                        ],
+                    ]],
+                    'application_context' => [
+                        'brand_name'          => 'TAGTOA',
+                        'shipping_preference'  => 'NO_SHIPPING',
+                        'user_action'          => 'PAY_NOW',
+                        'return_url'           => route('tagtoa.pay.online.return', ['gateway' => 'paypal']).'?reference='.urlencode($txn->reference),
+                        'cancel_url'           => route('tagtoa.pay.result'),
+                    ],
+                ]);
+
+            $id = $res->json('id');
+            if ($res->successful() && $id) {
+                $txn->update(['gateway_ref' => $id]);
+
+                return PayPal::approveLink((array) $res->json('links', []));
+            }
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
+
+        return null;
+    }
+
+    public function verify(PayTransaction $txn): string
+    {
+        $token = $this->accessToken();
+        if (! $token || ! $txn->gateway_ref) {
+            return 'pending';
+        }
+        $base = PayPal::apiBase($this->mode);
+
+        try {
+            $res = Http::withToken($token)->acceptJson()->timeout(20)
+                ->get($base.'/v2/checkout/orders/'.$txn->gateway_ref);
+            $status = $res->json('status');
+
+            // Approuvé par le payeur → on capture pour encaisser.
+            if (strtoupper((string) $status) === 'APPROVED') {
+                $cap = Http::withToken($token)->acceptJson()->asJson()->timeout(20)
+                    ->post($base.'/v2/checkout/orders/'.$txn->gateway_ref.'/capture', new \stdClass);
+                $status = $cap->json('status', $status);
+            }
+
+            if (PayPal::mapStatus($status) === 'paid' && ! $this->amountMatches($res, $txn)) {
+                return 'failed';
+            }
+
+            return PayPal::mapStatus($status);
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
+
+        return 'pending';
+    }
+
+    /** Anti-fraude : le montant PayPal doit couvrir le montant attendu. */
+    protected function amountMatches($res, PayTransaction $txn): bool
+    {
+        $value = $res->json('purchase_units.0.amount.value');
+        if ($value === null) {
+            return true; // pas d'info → on ne bloque pas (la capture a réussi)
+        }
+
+        return (float) $value + 0.001 >= (float) $txn->amount;
+    }
+
+    /** Jeton OAuth (client_credentials, Basic auth). Null si indisponible. */
+    protected function accessToken(): ?string
+    {
+        if (! $this->clientId || ! $this->secret) {
+            return null;
+        }
+
+        try {
+            $res = Http::withBasicAuth($this->clientId, $this->secret)
+                ->asForm()->acceptJson()->timeout(20)
+                ->post(PayPal::apiBase($this->mode).'/v1/oauth2/token', [
+                    'grant_type' => 'client_credentials',
+                ]);
+
+            return $res->successful() ? $res->json('access_token') : null;
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+
+            return null;
+        }
+    }
+}

--- a/Modules/Tagtoa/tests/Unit/CoinPaymentsTest.php
+++ b/Modules/Tagtoa/tests/Unit/CoinPaymentsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Support\Gateways\CoinPayments;
+use PHPUnit\Framework\TestCase;
+
+/** Logique pure du driver CoinPayments (signature HMAC, statut, coin, montant). */
+class CoinPaymentsTest extends TestCase
+{
+    public function test_signature_is_deterministic_hmac_sha512(): void
+    {
+        $payload = ['cmd' => 'create_transaction', 'amount' => '10.00', 'currency1' => 'USD'];
+        $sig = CoinPayments::sign($payload, 'private-key');
+
+        // HMAC-SHA512 => 128 caractères hexadécimaux, déterministe.
+        $this->assertSame(128, strlen($sig));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{128}$/', $sig);
+        $this->assertSame($sig, CoinPayments::sign($payload, 'private-key'));
+        // Known-answer : identique à HMAC du querystring exact.
+        $this->assertSame(hash_hmac('sha512', http_build_query($payload), 'private-key'), $sig);
+    }
+
+    public function test_signature_is_key_and_payload_sensitive(): void
+    {
+        $p = ['cmd' => 'x'];
+        $this->assertNotSame(CoinPayments::sign($p, 'k1'), CoinPayments::sign($p, 'k2'));
+        $this->assertNotSame(CoinPayments::sign(['cmd' => 'x'], 'k'), CoinPayments::sign(['cmd' => 'y'], 'k'));
+    }
+
+    public function test_status_mapping(): void
+    {
+        $this->assertSame('paid', CoinPayments::mapStatus(100));
+        $this->assertSame('paid', CoinPayments::mapStatus(2));
+        $this->assertSame('pending', CoinPayments::mapStatus(0));
+        $this->assertSame('pending', CoinPayments::mapStatus(1));
+        $this->assertSame('failed', CoinPayments::mapStatus(-1));
+    }
+
+    public function test_default_coin(): void
+    {
+        $this->assertSame('BTC', CoinPayments::defaultCoin('btc'));
+        $this->assertSame('ETH', CoinPayments::defaultCoin('eth'));
+        $this->assertSame('USDT.TRC20', CoinPayments::defaultCoin(null));
+        $this->assertSame('USDT.TRC20', CoinPayments::defaultCoin('unknown'));
+    }
+
+    public function test_amount_format(): void
+    {
+        $this->assertSame('10.00', CoinPayments::amount(10));
+        $this->assertSame('0.01', CoinPayments::amount(0));
+    }
+}

--- a/Modules/Tagtoa/tests/Unit/PayPalTest.php
+++ b/Modules/Tagtoa/tests/Unit/PayPalTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Support\Gateways\PayPal;
+use PHPUnit\Framework\TestCase;
+
+/** Logique pure du driver PayPal (montant, devise, lien, statut). */
+class PayPalTest extends TestCase
+{
+    public function test_amount_is_two_decimals_string(): void
+    {
+        $this->assertSame('10.00', PayPal::amount(10));
+        $this->assertSame('10.50', PayPal::amount(10.5));
+        $this->assertSame('0.01', PayPal::amount(0));       // min 0.01
+        $this->assertSame('1234.57', PayPal::amount(1234.567));
+    }
+
+    public function test_currency_support_excludes_htg(): void
+    {
+        $this->assertTrue(PayPal::supportsCurrency('USD'));
+        $this->assertTrue(PayPal::supportsCurrency('eur'));
+        $this->assertFalse(PayPal::supportsCurrency('HTG'));
+        $this->assertFalse(PayPal::supportsCurrency(null));
+    }
+
+    public function test_approve_link_extraction(): void
+    {
+        $links = [
+            ['rel' => 'self', 'href' => 'https://x/self'],
+            ['rel' => 'approve', 'href' => 'https://x/approve'],
+            ['rel' => 'capture', 'href' => 'https://x/capture'],
+        ];
+        $this->assertSame('https://x/approve', PayPal::approveLink($links));
+        $this->assertNull(PayPal::approveLink([['rel' => 'self', 'href' => 'x']]));
+        $this->assertNull(PayPal::approveLink([]));
+    }
+
+    public function test_status_mapping(): void
+    {
+        $this->assertSame('paid', PayPal::mapStatus('COMPLETED'));
+        $this->assertSame('failed', PayPal::mapStatus('VOIDED'));
+        $this->assertSame('failed', PayPal::mapStatus('DECLINED'));
+        $this->assertSame('pending', PayPal::mapStatus('APPROVED'));
+        $this->assertSame('pending', PayPal::mapStatus('CREATED'));
+        $this->assertSame('pending', PayPal::mapStatus(null));
+    }
+
+    public function test_api_base_by_mode(): void
+    {
+        $this->assertStringContainsString('sandbox', PayPal::apiBase('sandbox'));
+        $this->assertSame('https://api-m.paypal.com', PayPal::apiBase('live'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,8 @@ require_once $base.'/Services/Event/StaffPinService.php';
 require_once $base.'/Services/Event/SyncReconciler.php';
 require_once $base.'/Support/Store/Cart.php';
 require_once $base.'/Support/Gateways/MonCash.php';
+require_once $base.'/Support/Gateways/PayPal.php';
+require_once $base.'/Support/Gateways/CoinPayments.php';
 require_once $base.'/Support/Event/Ledger.php';
 require_once $base.'/Support/Event/EventDays.php';
 require_once $base.'/Support/Money.php';


### PR DESCRIPTION
## Contexte

Ajout de vraies passerelles de paiement API demandées. **Réalité honnête** : seules les méthodes qui exposent une API marchand publique peuvent être automatisées. Ce PR ajoute **PayPal** et **CoinPayments** (crypto) aux côtés de **MonCash** (déjà fait). Les autres restent en **preuve manuelle** (voir plus bas).

## Drivers API ajoutés

- **PayPal** (Orders v2) : OAuth `client_credentials` → create order (`intent=CAPTURE`) → redirection « approve » → au retour, **capture** → `COMPLETED`. Contrôle **anti-fraude** du montant. PayPal ne gère pas la HTG → repli manuel automatique si devise non supportée.
- **CoinPayments** (crypto **USDT/USDC/BTC/ETH/BNB**) : `create_transaction` signé **HMAC-SHA512** → `checkout_url` → IPN/`get_tx_info` pour confirmer. Coin déduit de `meta['coin']` (défaut `USDT.TRC20`). ⇒ couvre aussi les coins Binance.

`CheckoutService::driver()` mappe désormais `moncash | paypal | coinpayments`.

## Méthodes SANS API marchand → preuve manuelle (inchangé)

**NatCash, Unibank, Sogebank, BNC, Zelle, CashApp, Binance (Pay), virements** n'ont pas d'API marchand publique exploitable → elles restent des **méthodes manuelles** (le marchand configure compte + QR, le client envoie une preuve). Déjà pris en charge par le module PAY.

## Validation

- Suite Unit : **103 tests, 513 assertions — OK** (10 nouveaux : `PayPalTest` + `CoinPaymentsTest` — montant, devise, lien, statut, signature HMAC).
- `php -l` sur les 4 nouveaux fichiers + `CheckoutService` : OK.

## Activation (action fondateur — `.env` VPS)

```
TAGTOA_PAYPAL_CLIENT_ID / TAGTOA_PAYPAL_SECRET / TAGTOA_PAYPAL_MODE=live
TAGTOA_COINPAYMENTS_MERCHANT_ID / _PUBLIC_KEY / _PRIVATE_KEY / _IPN_SECRET
```
Dormants (aucun effet) tant que non définis. Tester en sandbox avant la prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_