### PR TITLE
PAY: driver Stripe (carte) + paiement en ligne des pages de paiement

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Pay/CheckoutController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pay/CheckoutController.php
@@ -50,12 +50,38 @@ class CheckoutController extends Controller
     /** Webhook/IPN passerelle (idempotent). Répond toujours 200. */
     public function webhook(Request $request, string $gateway)
     {
-        $ref = $request->input('reference') ?: $request->input('orderId');
+        $ref = $this->webhookReference($request, $gateway);
         if ($ref) {
+            // confirm() re-vérifie l'état auprès de la passerelle (source de vérité) :
+            // un webhook falsifié ne peut donc pas marquer une commande payée.
             app(CheckoutService::class)->confirm($ref);
         }
 
         return response()->json(['ok' => true]);
+    }
+
+    /** Extrait la référence de transaction du corps du webhook selon la passerelle. */
+    protected function webhookReference(Request $request, string $gateway): ?string
+    {
+        if ($gateway === 'stripe') {
+            // Signature best-effort : si le secret est configuré et invalide, on ignore.
+            $secret = (string) config('tagtoa.gateways.stripe.webhook_secret', '');
+            if ($secret !== '') {
+                $valid = \Modules\Tagtoa\App\Support\Gateways\Stripe::verifySignature(
+                    $request->getContent(),
+                    (string) $request->header('Stripe-Signature', ''),
+                    $secret
+                );
+                if (! $valid) {
+                    return null;
+                }
+            }
+
+            return $request->input('data.object.client_reference_id')
+                ?: $request->input('data.object.metadata.reference');
+        }
+
+        return $request->input('reference') ?: $request->input('orderId');
     }
 
     public function result(): View

--- a/Modules/Tagtoa/app/Http/Controllers/Pay/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pay/PublicController.php
@@ -31,15 +31,31 @@ class PublicController extends Controller
      * Paiement en ligne via passerelle API (PayPal, CoinPayments, Stripe…).
      * Tant qu'aucun driver n'est branché, on retombe proprement sur le manuel.
      */
-    public function checkout(string $alias, int $method): RedirectResponse
+    public function checkout(Request $request, string $alias, int $method): RedirectResponse
     {
         $page = PaymentPage::where('alias', $alias)->where('is_active', true)->firstOrFail();
         $m = $page->activeMethods()->whereKey($method)->firstOrFail();
 
-        // Driver pas encore branché → retour à la page avec instructions manuelles.
-        return redirect()->route('tagtoa.pay.show', $page->alias)
-            ->with('proof_submitted', false)
-            ->with('error', __('Le paiement en ligne arrive bientôt. Utilisez les informations ci-dessous.'));
+        $gateway = \Modules\Tagtoa\App\Support\PaymentGateway::driver($m->type);
+        $amount = round((float) $request->input('amount', 0), 2);
+
+        // Passerelle non branchée/non configurée ou montant absent → repli manuel propre.
+        if (! $gateway || ! \Modules\Tagtoa\App\Support\GatewayManager::enabled($gateway) || $amount <= 0) {
+            return redirect()->route('tagtoa.pay.show', $page->alias)
+                ->with('error', __('Le paiement en ligne n\'est pas disponible pour le moment. Utilisez les informations ci-dessous.'));
+        }
+
+        $url = app(\Modules\Tagtoa\App\Services\Pay\CheckoutService::class)->startPayPage($page, $m, $gateway, $amount, [
+            'name'  => (string) $request->input('payer_name', ''),
+            'phone' => (string) $request->input('payer_phone', ''),
+        ]);
+
+        if (! $url) {
+            return redirect()->route('tagtoa.pay.show', $page->alias)
+                ->with('error', __('Le paiement en ligne n\'a pas pu démarrer. Réessayez ou utilisez les informations ci-dessous.'));
+        }
+
+        return redirect()->away($url);
     }
 
     public function submitProof(Request $request, string $alias): RedirectResponse

--- a/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
+++ b/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
@@ -31,6 +31,7 @@ class CheckoutService
             'moncash'      => new MonCashDriver,
             'paypal'       => new \Modules\Tagtoa\App\Support\Gateways\PayPalDriver,
             'coinpayments' => new \Modules\Tagtoa\App\Support\Gateways\CoinPaymentsDriver,
+            'stripe'       => new \Modules\Tagtoa\App\Support\Gateways\StripeDriver,
             default        => null,
         };
     }
@@ -103,6 +104,41 @@ class CheckoutService
     }
 
     /**
+     * Démarre le paiement en ligne d'une PAGE DE PAIEMENT (lien de paiement
+     * ouvert — le payeur saisit le montant). Retourne l'URL de redirection, ou
+     * null si indisponible.
+     */
+    public function startPayPage(\Modules\Tagtoa\App\Models\Pay\PaymentPage $page, \Modules\Tagtoa\App\Models\Pay\PaymentMethod $method, string $gateway, float $amount, array $payer = []): ?string
+    {
+        if ($amount <= 0 || ! GatewayManager::enabled($gateway)) {
+            return null;
+        }
+        $driver = $this->driver($gateway);
+        if (! $driver) {
+            return null;
+        }
+
+        $txn = PayTransaction::create([
+            'tenant_id'  => $page->tenant_id,
+            'gateway'    => $gateway,
+            'reference'  => PayTransaction::generateReference(),
+            'order_type' => 'pay_page',
+            'order_id'   => $page->id,
+            'amount'     => $amount,
+            'currency'   => $page->default_currency ?: 'USD',
+            'status'     => PayTransaction::STATUS_PENDING,
+            'meta'       => [
+                'method_id'   => $method->id,
+                'method_type' => $method->type,
+                'payer_name'  => $payer['name'] ?? null,
+                'payer_phone' => $payer['phone'] ?? null,
+            ],
+        ]);
+
+        return $driver->createPayment($txn);
+    }
+
+    /**
      * Démarre le paiement d'un ABONNEMENT (forfait). Retourne l'URL de
      * redirection, ou null si le forfait est gratuit / passerelle indisponible.
      */
@@ -156,6 +192,12 @@ class CheckoutService
             return;
         }
 
+        if ($txn->order_type === 'pay_page') {
+            $this->applyPayPagePaid($txn);
+
+            return;
+        }
+
         $order = $this->loadOrder($txn->order_type, (int) $txn->order_id);
         if (! $order || $order->isPaid()) {
             return;
@@ -173,5 +215,30 @@ class CheckoutService
                 app(RevenueService::class)->record('event_order', $order->id, 'event', (float) $order->total, $order->tenant_id, $order->currency);
                 break;
         }
+    }
+
+    /**
+     * Paiement en ligne d'une page de paiement confirmé : enregistre une preuve
+     * APPROUVÉE (visible au tableau de bord) + la commission. Idempotent.
+     */
+    protected function applyPayPagePaid(PayTransaction $txn): void
+    {
+        $meta = (array) $txn->meta;
+
+        \Modules\Tagtoa\App\Models\Pay\PaymentProof::firstOrCreate(
+            ['reference' => $txn->reference, 'payment_page_id' => (int) $txn->order_id],
+            [
+                'payment_method_id' => $meta['method_id'] ?? null,
+                'payer_name'        => ($meta['payer_name'] ?? '') ?: 'Paiement en ligne',
+                'payer_phone'       => $meta['payer_phone'] ?? null,
+                'amount'            => (float) $txn->amount,
+                'currency'          => $txn->currency,
+                'status'            => \Modules\Tagtoa\App\Models\Pay\PaymentProof::STATUS_APPROVED,
+                'note'              => 'Payé en ligne ('.$txn->gateway.')',
+                'reviewed_at'       => now(),
+            ]
+        );
+
+        app(RevenueService::class)->record('pay_page', (int) $txn->id, 'pay', (float) $txn->amount, $txn->tenant_id, $txn->currency);
     }
 }

--- a/Modules/Tagtoa/app/Support/Gateways/Stripe.php
+++ b/Modules/Tagtoa/app/Support/Gateways/Stripe.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Gateways;
+
+/**
+ * TAGTOA PAY — helpers PURS Stripe (Checkout Sessions), testables sans Laravel
+ * ni réseau.
+ *
+ * Flux : Create Checkout Session (mode=payment) → redirection vers session.url →
+ * au retour, Retrieve Session → payment_status=paid. Webhook signé (HMAC-SHA256).
+ * Endpoint : https://api.stripe.com (form-urlencoded, clé secrète en Bearer).
+ * Stripe ne traite PAS la gourde HTG → repli manuel si devise non supportée.
+ */
+class Stripe
+{
+    public const API_BASE = 'https://api.stripe.com';
+
+    /** Devises Stripe courantes (Stripe ne gère PAS la HTG). */
+    public const CURRENCIES = ['USD', 'EUR', 'CAD', 'GBP', 'AUD', 'MXN', 'BRL', 'JPY', 'CHF', 'DOP'];
+
+    /** Devises « zéro décimale » (montant déjà en plus petite unité). */
+    public const ZERO_DECIMAL = ['JPY', 'KRW', 'VND', 'CLP', 'XAF', 'XOF', 'BIF', 'DJF', 'GNF', 'PYG', 'RWF', 'UGX', 'VUV', 'XPF'];
+
+    /** Stripe ne traite pas la HTG : seules les devises supportées passent. PUR. */
+    public static function supportsCurrency(?string $currency): bool
+    {
+        return in_array(strtoupper((string) $currency), self::CURRENCIES, true);
+    }
+
+    /** Une devise est-elle « zéro décimale » chez Stripe ? PUR. */
+    public static function isZeroDecimal(?string $currency): bool
+    {
+        return in_array(strtoupper((string) $currency), self::ZERO_DECIMAL, true);
+    }
+
+    /**
+     * Montant Stripe en plus petite unité (centimes), entier ≥ 1. PUR.
+     *   USD 10.00 → 1000 · JPY 500 → 500 (zéro décimale).
+     */
+    public static function amount($value, ?string $currency = 'USD'): int
+    {
+        $v = max(0.0, (float) $value);
+        $minor = self::isZeroDecimal($currency) ? round($v) : round($v * 100);
+
+        return (int) max(1, $minor);
+    }
+
+    /**
+     * Traduit l'état d'une Checkout Session → statut interne. PUR.
+     *   payment_status=paid|no_payment_required → payé · session.status=expired → échec ·
+     *   sinon → en attente.
+     *
+     * @param  string|null  $paymentStatus  session.payment_status
+     * @param  string|null  $sessionStatus  session.status
+     */
+    public static function mapStatus(?string $paymentStatus, ?string $sessionStatus = null): string
+    {
+        $ps = strtolower(trim((string) $paymentStatus));
+        if ($ps === 'paid' || $ps === 'no_payment_required') {
+            return 'paid';
+        }
+        if (strtolower(trim((string) $sessionStatus)) === 'expired') {
+            return 'failed';
+        }
+
+        return 'pending';
+    }
+
+    /**
+     * Vérifie la signature d'un webhook Stripe (header « Stripe-Signature »). PUR.
+     *
+     * Format du header : « t=<timestamp>,v1=<hmac>,... ». On recalcule
+     * HMAC-SHA256("<t>.<payload>") avec le secret et on compare en temps constant.
+     *
+     * @param  string  $payload    corps brut de la requête
+     * @param  string  $header     valeur du header Stripe-Signature
+     * @param  string  $secret     whsec_… (webhook signing secret)
+     * @param  int     $tolerance  fenêtre temporelle autorisée en secondes (0 = ignorer)
+     * @param  int|null $now       horodatage courant (injectable pour les tests)
+     */
+    public static function verifySignature(string $payload, string $header, string $secret, int $tolerance = 300, ?int $now = null): bool
+    {
+        if ($secret === '' || $header === '') {
+            return false;
+        }
+
+        $timestamp = null;
+        $signatures = [];
+        foreach (explode(',', $header) as $part) {
+            $kv = explode('=', trim($part), 2);
+            if (count($kv) !== 2) {
+                continue;
+            }
+            [$k, $v] = $kv;
+            if ($k === 't') {
+                $timestamp = $v;
+            } elseif ($k === 'v1') {
+                $signatures[] = $v;
+            }
+        }
+
+        if ($timestamp === null || $signatures === []) {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $timestamp.'.'.$payload, $secret);
+        $ok = false;
+        foreach ($signatures as $sig) {
+            if (hash_equals($expected, $sig)) {
+                $ok = true;
+                break;
+            }
+        }
+        if (! $ok) {
+            return false;
+        }
+
+        if ($tolerance > 0) {
+            $current = $now ?? time();
+            if (abs($current - (int) $timestamp) > $tolerance) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Modules/Tagtoa/app/Support/Gateways/StripeDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/StripeDriver.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Gateways;
+
+use Illuminate\Support\Facades\Http;
+use Modules\Tagtoa\App\Models\Pay\PayTransaction;
+use Modules\Tagtoa\App\Support\GatewayManager;
+
+/**
+ * TAGTOA PAY — driver Stripe (Checkout Sessions, carte crédit/débit).
+ * Tolérant (jamais d'exception qui casse le flux). Dormant tant que les
+ * identifiants ne sont pas configurés. Stripe ne gère pas la HTG → repli manuel
+ * si la devise n'est pas supportée.
+ *
+ * ⚠️ À tester en mode test (clé sk_test_…) avant la production.
+ */
+class StripeDriver implements GatewayDriver
+{
+    protected ?string $secret;
+
+    public function __construct()
+    {
+        $cfg = GatewayManager::config('stripe');
+        // credentials.secret = clé secrète (sk_live_… / sk_test_…).
+        $this->secret = $cfg['credentials']['secret'] ?? null;
+    }
+
+    public function createPayment(PayTransaction $txn): ?string
+    {
+        if (! $this->secret || ! Stripe::supportsCurrency($txn->currency)) {
+            return null;
+        }
+
+        $params = [
+            'mode'                => 'payment',
+            'client_reference_id' => $txn->reference,
+            'success_url'         => route('tagtoa.pay.online.return', ['gateway' => 'stripe']).'?reference='.urlencode($txn->reference),
+            'cancel_url'          => route('tagtoa.pay.result'),
+            'metadata'            => ['reference' => $txn->reference],
+            'payment_intent_data' => ['metadata' => ['reference' => $txn->reference]],
+            'line_items'          => [[
+                'quantity'   => 1,
+                'price_data' => [
+                    'currency'     => strtolower((string) $txn->currency),
+                    'unit_amount'  => Stripe::amount($txn->amount, $txn->currency),
+                    'product_data' => ['name' => 'TAGTOA — '.$txn->reference],
+                ],
+            ]],
+        ];
+
+        try {
+            $res = Http::withToken($this->secret)->asForm()->acceptJson()->timeout(20)
+                ->post(Stripe::API_BASE.'/v1/checkout/sessions', $params);
+
+            $id = $res->json('id');
+            $url = $res->json('url');
+            if ($res->successful() && $id && $url) {
+                $txn->update(['gateway_ref' => $id]);
+
+                return $url;
+            }
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
+
+        return null;
+    }
+
+    public function verify(PayTransaction $txn): string
+    {
+        if (! $this->secret || ! $txn->gateway_ref) {
+            return 'pending';
+        }
+
+        try {
+            $res = Http::withToken($this->secret)->acceptJson()->timeout(20)
+                ->get(Stripe::API_BASE.'/v1/checkout/sessions/'.$txn->gateway_ref);
+
+            if (! $res->successful()) {
+                return 'pending';
+            }
+
+            $status = Stripe::mapStatus($res->json('payment_status'), $res->json('status'));
+
+            // Anti-fraude : le montant encaissé doit couvrir le montant attendu.
+            if ($status === 'paid' && ! $this->amountMatches($res, $txn)) {
+                return 'failed';
+            }
+
+            return $status;
+        } catch (\Throwable $e) {
+            if (function_exists('report')) {
+                report($e);
+            }
+        }
+
+        return 'pending';
+    }
+
+    /** Anti-fraude : amount_total Stripe (unité mineure) ≥ montant attendu. */
+    protected function amountMatches($res, PayTransaction $txn): bool
+    {
+        $total = $res->json('amount_total');
+        if ($total === null) {
+            return true; // pas d'info → on ne bloque pas
+        }
+
+        return (int) $total + 1 >= Stripe::amount($txn->amount, $txn->currency);
+    }
+}

--- a/Modules/Tagtoa/resources/views/pay/show.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/show.blade.php
@@ -97,7 +97,16 @@
                             <b style="font-family:var(--fh);font-size:16px">{{ $m->display_label }}</b>
                         </div>
                         @if($m->onlineAvailable())
-                            <a class="btn btn-p" href="{{ route('tagtoa.pay.checkout', [$page->alias, $m->id]) }}" style="margin-bottom:14px"><i class="fa-solid fa-bolt"></i> {{ __('Payer en ligne') }}</a>
+                            <form method="GET" action="{{ route('tagtoa.pay.checkout', [$page->alias, $m->id]) }}" style="margin-bottom:14px">
+                                <label class="lbl">{{ __('Montant à payer') }} ({{ $page->default_currency }}) *</label>
+                                <input class="inp" name="amount" type="number" step="0.01" min="1" required placeholder="0.00">
+                                <label class="lbl">{{ __('Votre nom') }}</label>
+                                <input class="inp" name="payer_name" maxlength="120" placeholder="{{ __('Optionnel') }}">
+                                <label class="lbl">{{ __('Téléphone (WhatsApp)') }}</label>
+                                <input class="inp" name="payer_phone" maxlength="40" placeholder="+509 ...">
+                                <button class="btn btn-p" type="submit" style="margin-top:10px"><i class="fa-solid fa-bolt"></i> {{ __('Payer en ligne maintenant') }}</button>
+                            </form>
+                            <div class="sep-or" style="text-align:center;color:#9aa;margin:8px 0;font-size:13px">{{ __('ou payez manuellement ci-dessous') }}</div>
                         @endif
                         @if($m->qr_url)<div class="qr"><img src="{{ $m->qr_url }}" alt="QR" loading="lazy"></div>@endif
                         @if($m->institution)<div class="kv"><span>{{ __('Institution') }}</span><b>{{ $m->institution }}</b></div>@endif

--- a/Modules/Tagtoa/tests/Unit/StripeTest.php
+++ b/Modules/Tagtoa/tests/Unit/StripeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Support\Gateways\Stripe;
+use PHPUnit\Framework\TestCase;
+
+/** Logique pure du driver Stripe (montant en unité mineure, devise, statut, signature). */
+class StripeTest extends TestCase
+{
+    public function test_amount_in_minor_units(): void
+    {
+        $this->assertSame(1000, Stripe::amount(10, 'USD'));
+        $this->assertSame(1050, Stripe::amount(10.5, 'USD'));
+        $this->assertSame(123457, Stripe::amount(1234.567, 'EUR'));
+        $this->assertSame(1, Stripe::amount(0, 'USD'));   // min 1
+    }
+
+    public function test_zero_decimal_currency_amount(): void
+    {
+        $this->assertTrue(Stripe::isZeroDecimal('JPY'));
+        $this->assertFalse(Stripe::isZeroDecimal('USD'));
+        // JPY : le montant est déjà en plus petite unité (pas de ×100).
+        $this->assertSame(500, Stripe::amount(500, 'JPY'));
+    }
+
+    public function test_currency_support_excludes_htg(): void
+    {
+        $this->assertTrue(Stripe::supportsCurrency('USD'));
+        $this->assertTrue(Stripe::supportsCurrency('eur'));
+        $this->assertTrue(Stripe::supportsCurrency('DOP'));
+        $this->assertFalse(Stripe::supportsCurrency('HTG'));
+        $this->assertFalse(Stripe::supportsCurrency(null));
+    }
+
+    public function test_status_mapping(): void
+    {
+        $this->assertSame('paid', Stripe::mapStatus('paid'));
+        $this->assertSame('paid', Stripe::mapStatus('no_payment_required'));
+        $this->assertSame('pending', Stripe::mapStatus('unpaid'));
+        $this->assertSame('pending', Stripe::mapStatus(null));
+        $this->assertSame('failed', Stripe::mapStatus('unpaid', 'expired'));
+        // payé prime sur un statut de session « open ».
+        $this->assertSame('paid', Stripe::mapStatus('paid', 'complete'));
+    }
+
+    public function test_webhook_signature_valid_and_tampered(): void
+    {
+        $payload = '{"id":"evt_1","type":"checkout.session.completed"}';
+        $secret = 'whsec_test';
+        $t = 1700000000;
+        $good = hash_hmac('sha256', $t.'.'.$payload, $secret);
+        $header = 't='.$t.',v1='.$good;
+
+        // Signature correcte, dans la fenêtre de tolérance.
+        $this->assertTrue(Stripe::verifySignature($payload, $header, $secret, 300, $t + 10));
+        // Corps falsifié → signature invalide.
+        $this->assertFalse(Stripe::verifySignature($payload.'x', $header, $secret, 300, $t + 10));
+        // Mauvais secret → invalide.
+        $this->assertFalse(Stripe::verifySignature($payload, $header, 'whsec_other', 300, $t + 10));
+        // Hors fenêtre temporelle → rejeté.
+        $this->assertFalse(Stripe::verifySignature($payload, $header, $secret, 300, $t + 10000));
+        // Header/secret vide → rejeté.
+        $this->assertFalse(Stripe::verifySignature($payload, '', $secret));
+        $this->assertFalse(Stripe::verifySignature($payload, $header, ''));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,6 +25,7 @@ require_once $base.'/Support/Store/Cart.php';
 require_once $base.'/Support/Gateways/MonCash.php';
 require_once $base.'/Support/Gateways/PayPal.php';
 require_once $base.'/Support/Gateways/CoinPayments.php';
+require_once $base.'/Support/Gateways/Stripe.php';
 require_once $base.'/Support/Event/Ledger.php';
 require_once $base.'/Support/Event/EventDays.php';
 require_once $base.'/Support/Money.php';


### PR DESCRIPTION
## Objectif
Compléter TAGTOA Pay : dernière passerelle API (Stripe carte) + activer le paiement en ligne des **pages de paiement** (liens ouverts).

## Changements
- **Stripe (Checkout Sessions)** — helper pur testé : montant en unité mineure (+ devises zéro-décimale), mapping statut, vérification de la signature webhook (HMAC-SHA256, fenêtre de tolérance). Driver tolérant/dormant (aucune dépendance tant que `TAGTOA_STRIPE_*` n'est pas configuré). Le registre pointait déjà `card` → `stripe`, la config existait — seul le driver manquait.
- **Pages de paiement en ligne** — `CheckoutService::startPayPage()` : une page de paiement (le payeur saisit le montant) peut désormais être réglée en ligne via n'importe quel driver actif. Paiement confirmé → **preuve APPROUVÉE** au tableau de bord + **commission** enregistrée. Idempotent.
- **`checkout()` n'est plus un stub** — il démarre réellement le paiement (repli manuel propre si passerelle non configurée).
- **Webhook Stripe** — signature vérifiée + extraction de la référence (`client_reference_id` / `metadata`). `confirm()` reste la source de vérité (un webhook falsifié ne peut pas marquer payé).
- **Page publique PAY** — le bouton « Payer en ligne » collecte le montant (+ nom/téléphone optionnels).

## Tests
- `StripeTest` (5 tests) : montant mineur, zéro-décimale, devises (exclut HTG), statut, signature webhook (valide/falsifiée/hors-fenêtre).
- `ViewCompileTest` + `RouteIntegrityTest` verts (la page PAY modifiée compile).
- Suite Unit complète : 108 tests OK.

## Action fondateur (pour activer)
Configurer sur le VPS : `TAGTOA_STRIPE_KEY`, `TAGTOA_STRIPE_SECRET`, `TAGTOA_STRIPE_WEBHOOK_SECRET`. Sans ça, la carte reste en mode manuel (aucun échec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_