### PR TITLE
CARD: carte NFC prépayée TAGTOA closed-loop (PAY + EVENT)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,13 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
     aktivasyon (`Support/GatewayManager`, kredansyèl nan config/.env), afichaj piblik
     rich (logo+koulè mak, institution, nom du compte, numéro, QR), chan institution+logo
     nan dashboard. Doc kredansyèl: `Modules/Tagtoa/PAYMENTS.md`.
+  - ✅ Driver Stripe (kat) + paiement en ligne PAGES PAY (payer sezi montan → preuve
+    approuvée + komisyon). ✅ CARTE TAGTOA (closed-loop, valab sou TOUT TAGTOA):
+    `Support/Card/CardWallet` pi teste (UID normalize/hash, matematik solde antye, PIN),
+    tab `tagtoa_card_accounts`+`_card_txns` (grand livre imuab), `CardWalletService`
+    (charge/topup/refund atomik+idempotan+lockForUpdate), dashboard `/tagtoa/cards`
+    (émèt/rechaje/bloke/istwa), paj piblik PAY (tap NFC+PIN → débit enstantane),
+    terminal staff EVENT (peye biyè ak kat, `skip_commission` pou pa konte 2 fwa).
   - ⏳ RES: drivers API reyèl (1 PR pa pasrèl, teste ak kredansyèl): MonCash, PayPal(+kat),
     CoinPayments (USDT/USDC/BTC/ETH), Stripe, Authorize.Net — route `tagtoa.pay.checkout`
     + webhook/IPN. Metòd manyèl yo (NatCash, Zelle, CashApp, Unibank, Sogebank, Capital
@@ -187,6 +194,8 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
 ## 7. Done demo (pou teste)
 - MENU: `demo-menu` · PAY: `demo` · LINKS: `demo-links` · EVENT: `demo-concert` · BOOKING: `demo-booking`
 - LOYALTY token: `uvcudqvm9xsie6knrkhbdcok` · POS terminal id: `1`
+- CARTE TAGTOA (closed-loop): code `TAGDEMO` · PIN `1234` · solde 1000 G — teste sou
+  `/pay/demo` → « Carte TAGTOA » (tape/sezi kòd + PIN) oswa sou terminal staff event.
 - EVENT WALLET: tag NFC demo UID `TAGTOA-DEMO-TAG` (solde 1000 G, stand « Bar Demo ») sou
   `demo-concert` → teste sou `/tagtoa/event/{id}/wallet/terminal` (tape UID a oswa tap NFC).
 - Teste lang: ajoute `?lang=ht|en|es|fr` sou nenpòt paj.

--- a/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
+++ b/Modules/Tagtoa/Database/Seeders/TagtoaDemoSeeder.php
@@ -59,6 +59,17 @@ class TagtoaDemoSeeder extends Seeder
             );
         }
 
+        // Carte TAGTOA démo (closed-loop) : code TAGDEMO, PIN 1234, solde 1000 G.
+        // Teste sur /pay/demo → « Carte TAGTOA » (tape ou saisis le code + PIN).
+        $cardSvc = app(\Modules\Tagtoa\App\Services\Card\CardWalletService::class);
+        $demoCard = $cardSvc->issue('TAGTOA-CARD-DEMO', [
+            'tenant_id' => $pay->tenant_id, 'holder_name' => 'Client Démo',
+            'holder_phone' => '+509 0000 0000', 'currency' => 'HTG', 'pin' => '1234', 'code' => 'TAGDEMO',
+        ]);
+        if ((int) $demoCard->balance_minor === 0) {
+            $cardSvc->topUp($demoCard, 1000, ['reference' => 'demo-card-topup', 'context_type' => 'issue']);
+        }
+
         // 2) LOYALTY — programme + 1 carte
         $program = Program::firstOrCreate(
             ['alias' => 'demo-fidelite'],

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000093_create_tagtoa_card_accounts_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000093_create_tagtoa_card_accounts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA CARD — carte NFC prépayée « closed-loop », valable chez TOUS les
+ * marchands TAGTOA. L'UID n'est jamais stocké en clair : uid_hash (lookup) +
+ * uid_enc (chiffré). balance_minor = solde en unités mineures (entier).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_card_accounts', function (Blueprint $table) {
+            $table->id();
+            $table->string('tenant_id')->nullable()->index();   // marchand émetteur (null = plateforme)
+            $table->string('uid_hash', 64)->unique();           // sha256 de l'UID normalisé
+            $table->text('uid_enc')->nullable();                // UID chiffré (récupérable si besoin)
+            $table->string('code', 32)->nullable()->index();    // code lisible imprimé sur la carte
+            $table->string('holder_name')->nullable();
+            $table->string('holder_phone', 40)->nullable();
+            $table->string('currency', 8)->default('HTG');
+            $table->bigInteger('balance_minor')->default(0);    // solde (unités mineures)
+            $table->string('pin_hash')->nullable();             // bcrypt du PIN (autorisation de dépense)
+            $table->string('status', 12)->default('active');    // active | blocked | lost
+            $table->timestamp('issued_at')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_card_accounts');
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000094_create_tagtoa_card_txns_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000094_create_tagtoa_card_txns_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA CARD — grand livre IMMUABLE des mouvements d'une carte (recharge, débit,
+ * remboursement). Append-only : chaque ligne porte un instantané du solde après
+ * l'opération. reference = idempotence (une même opération ne s'applique qu'une fois).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_card_txns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('card_account_id')->constrained('tagtoa_card_accounts')->cascadeOnDelete();
+            $table->string('tenant_id')->nullable()->index();   // marchand qui encaisse (débit)
+            $table->string('type', 12);                         // topup | charge | refund | adjust
+            $table->bigInteger('amount_minor');                 // toujours positif
+            $table->bigInteger('balance_after_minor');          // instantané après opération
+            $table->string('currency', 8)->default('HTG');
+            $table->string('reference', 40)->unique();          // idempotence
+            $table->string('context_type', 24)->nullable();     // pay_page | menu | event | pos | store
+            $table->unsignedBigInteger('context_id')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+
+            $table->index(['card_account_id', 'created_at']);
+            $table->index(['context_type', 'context_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_card_txns');
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\Card;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Models\Card\CardAccount;
+use Modules\Tagtoa\App\Services\Audit\AuditService;
+use Modules\Tagtoa\App\Services\Card\CardWalletService;
+use Modules\Tagtoa\App\Support\Card\CardWallet;
+use Modules\Tagtoa\App\Support\Money;
+use Modules\Tagtoa\App\Support\Tenant;
+
+/**
+ * TAGTOA CARD — gestion des cartes NFC prépayées closed-loop (émission,
+ * recharge, blocage, historique). Scopé au marchand courant.
+ */
+class DashboardController extends Controller
+{
+    public function index(Request $request): View
+    {
+        $q = trim((string) $request->query('q', ''));
+        $query = CardAccount::where('tenant_id', Tenant::id());
+        if ($q !== '') {
+            $query->where(function ($w) use ($q) {
+                $w->where('code', 'like', '%'.strtoupper($q).'%')
+                    ->orWhere('holder_name', 'like', '%'.$q.'%')
+                    ->orWhere('holder_phone', 'like', '%'.$q.'%');
+            });
+        }
+
+        $cards = $query->orderByDesc('created_at')->paginate(30)->withQueryString();
+
+        // Solde total en circulation (par devise).
+        $totals = CardAccount::where('tenant_id', Tenant::id())
+            ->selectRaw('currency, SUM(balance_minor) as bal, COUNT(*) as n')
+            ->groupBy('currency')->get()
+            ->map(fn ($r) => [
+                'currency' => $r->currency,
+                'label'    => Money::formatMinor((int) $r->bal, $r->currency),
+                'count'    => (int) $r->n,
+            ]);
+
+        return view('tagtoa::card.index', [
+            'cards'      => $cards,
+            'totals'     => $totals,
+            'q'          => $q,
+            'currencies' => Money::options(),
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'card_uid'       => ['required', 'string', 'max:120'],
+            'holder_name'    => ['nullable', 'string', 'max:120'],
+            'holder_phone'   => ['nullable', 'string', 'max:40'],
+            'currency'       => ['required', 'string', 'size:3'],
+            'pin'            => ['nullable', 'regex:/^\d{4,6}$/'],
+            'initial_amount' => ['nullable', 'numeric', 'min:0', 'max:99999999'],
+        ]);
+
+        $svc = app(CardWalletService::class);
+        $card = $svc->issue($data['card_uid'], [
+            'tenant_id'    => Tenant::id(),
+            'holder_name'  => $data['holder_name'] ?? null,
+            'holder_phone' => $data['holder_phone'] ?? null,
+            'currency'     => strtoupper($data['currency']),
+            'pin'          => $data['pin'] ?? null,
+        ]);
+
+        if (! empty($data['initial_amount']) && (float) $data['initial_amount'] > 0) {
+            $svc->topUp($card, (float) $data['initial_amount'], [
+                'tenant_id' => Tenant::id(), 'context_type' => 'issue', 'meta' => ['reason' => 'initial'],
+            ]);
+        }
+
+        app(AuditService::class)->log('card.issued', $card, $card->masked_code);
+
+        return back()->with('success', __('Carte émise : :code', ['code' => $card->code]));
+    }
+
+    public function topUp(Request $request, CardAccount $card): RedirectResponse
+    {
+        $this->authorizeCard($card);
+        $data = $request->validate([
+            'amount' => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+        ]);
+
+        $txn = app(CardWalletService::class)->topUp($card, (float) $data['amount'], [
+            'tenant_id' => Tenant::id(), 'context_type' => 'dashboard',
+        ]);
+
+        if ($txn) {
+            app(AuditService::class)->log('card.top_up', $card, Money::formatMinor((int) $txn->amount_minor, $card->currency));
+        }
+
+        return back()->with('success', __('Carte rechargée. Nouveau solde : :bal', ['bal' => $card->fresh()->balance_label]));
+    }
+
+    public function setStatus(Request $request, CardAccount $card): RedirectResponse
+    {
+        $this->authorizeCard($card);
+        $data = $request->validate([
+            'status' => ['required', 'in:'.implode(',', CardWallet::STATUSES)],
+        ]);
+
+        app(CardWalletService::class)->setStatus($card, $data['status']);
+        app(AuditService::class)->log('card.status', $card, $data['status']);
+
+        return back()->with('success', __('Statut de la carte mis à jour.'));
+    }
+
+    public function show(CardAccount $card): View
+    {
+        $this->authorizeCard($card);
+        $txns = $card->txns()->paginate(40);
+
+        return view('tagtoa::card.show', compact('card', 'txns'));
+    }
+
+    protected function authorizeCard(CardAccount $card): void
+    {
+        abort_unless($card->tenant_id === Tenant::id(), 403);
+    }
+}

--- a/Modules/Tagtoa/app/Http/Controllers/Event/StaffTerminalController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/StaffTerminalController.php
@@ -195,6 +195,10 @@ class StaffTerminalController extends Controller
             'ticket_type_id' => ['nullable', 'integer'],
             'credit'         => ['nullable', 'numeric', 'min:0', 'max:1000000'], // crédit initial du wallet
             'payment_method' => ['nullable', 'string', 'max:60'],               // moyen de paiement (TAGTOA Pay)
+            'pay_card_uid'   => ['nullable', 'string', 'max:120'],              // Carte TAGTOA : UID (tap)
+            'pay_card_code'  => ['nullable', 'string', 'max:40'],              // Carte TAGTOA : code imprimé
+            'pay_card_pin'   => ['nullable', 'string', 'max:6'],
+            'client_uuid'    => ['nullable', 'string', 'max:80'],
         ]);
 
         if (! empty($data['ticket_type_id'])) {
@@ -204,15 +208,49 @@ class StaffTerminalController extends Controller
             }
         }
 
-        // Le moyen de paiement doit provenir de TAGTOA Pay (page liée) ou être « Espèces ».
+        // Le moyen de paiement doit provenir de TAGTOA Pay (page liée), « Espèces »
+        // ou « Carte TAGTOA » (closed-loop).
         $method = trim((string) ($data['payment_method'] ?? ''));
-        if ($method !== '' && $method !== 'Espèces') {
+        if ($method !== '' && $method !== 'Espèces' && $method !== 'Carte TAGTOA') {
             $allowed = $event->payPage
                 ? $event->payPage->activeMethods()->pluck('label')->all()
                 : [];
             if (! in_array($method, $allowed, true)) {
                 $method = ''; // valeur inconnue ignorée (anti-spoof)
             }
+        }
+
+        // Prix du billet (imposé côté serveur depuis le type sélectionné).
+        $ticketPrice = 0.0;
+        if (! empty($data['ticket_type_id'])) {
+            $tt = $event->ticketTypes()->whereKey($data['ticket_type_id'])->first();
+            $ticketPrice = $tt ? (float) $tt->price : 0.0;
+        }
+
+        // Paiement par CARTE TAGTOA : on débite AVANT d'émettre le billet — un
+        // débit refusé annule la vente (pas de billet fantôme).
+        $cardTxnRef = null;
+        if ($method === 'Carte TAGTOA' && $ticketPrice > 0) {
+            $svc = app(\Modules\Tagtoa\App\Services\Card\CardWalletService::class);
+            $card = ! empty($data['pay_card_uid'])
+                ? $svc->resolveByUid($data['pay_card_uid'])
+                : $svc->resolveByCode((string) ($data['pay_card_code'] ?? ''));
+            if (! $card) {
+                return response()->json(['ok' => false, 'message' => __('Carte TAGTOA introuvable.')], 422);
+            }
+            $ref = ! empty($data['client_uuid']) ? 'evsale-'.$data['client_uuid'] : \Modules\Tagtoa\App\Support\Card\CardWallet::reference();
+            $res = $svc->charge($card, $ticketPrice, $data['pay_card_pin'] ?? null, [
+                'tenant_id'       => $event->tenant_id,
+                'context_type'    => 'event',
+                'context_id'      => $event->id,
+                'module'          => 'event',
+                'reference'       => $ref,
+                'skip_commission' => true, // la commission est prise sur le billet (event_ticket)
+            ]);
+            if (! $res['ok']) {
+                return response()->json(['ok' => false, 'message' => $res['message']], 422);
+            }
+            $cardTxnRef = $res['txn']?->reference;
         }
 
         try {

--- a/Modules/Tagtoa/app/Http/Controllers/Pay/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pay/PublicController.php
@@ -58,6 +58,66 @@ class PublicController extends Controller
         return redirect()->away($url);
     }
 
+    /**
+     * Paiement par CARTE TAGTOA (closed-loop) : le payeur tape sa carte NFC
+     * (UID) ou saisit son code + PIN + montant → débit instantané du solde.
+     * Aucune passerelle externe : l'argent reste dans TAGTOA.
+     */
+    public function cardCharge(Request $request, string $alias): RedirectResponse
+    {
+        $page = PaymentPage::where('alias', $alias)->where('is_active', true)->firstOrFail();
+
+        $data = $request->validate([
+            'card_uid'  => ['nullable', 'string', 'max:120'],
+            'card_code' => ['nullable', 'string', 'max:40'],
+            'pin'       => ['nullable', 'string', 'max:6'],
+            'amount'    => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+        ]);
+
+        if (empty($data['card_uid']) && empty($data['card_code'])) {
+            return back()->withInput()->with('error', __('Tapez la carte ou saisissez son code.'));
+        }
+
+        $svc = app(\Modules\Tagtoa\App\Services\Card\CardWalletService::class);
+        $card = ! empty($data['card_uid'])
+            ? $svc->resolveByUid($data['card_uid'])
+            : $svc->resolveByCode($data['card_code']);
+
+        if (! $card) {
+            return back()->withInput()->with('error', __('Carte TAGTOA introuvable.'));
+        }
+
+        $res = $svc->charge($card, (float) $data['amount'], $data['pin'] ?? null, [
+            'tenant_id'    => $page->tenant_id,
+            'context_type' => 'pay_page',
+            'context_id'   => $page->id,
+            'module'       => 'pay',
+        ]);
+
+        if (! $res['ok']) {
+            return back()->withInput()->with('error', $res['message']);
+        }
+
+        // Trace la recette pour le marchand (preuve APPROUVÉE au tableau de bord).
+        \Modules\Tagtoa\App\Models\Pay\PaymentProof::firstOrCreate(
+            ['reference' => $res['txn']->reference, 'payment_page_id' => $page->id],
+            [
+                'payment_method_id' => $page->activeMethods()->where('type', 'tagtoa_card')->value('id'),
+                'payer_name'        => $card->holder_name ?: __('Carte TAGTOA'),
+                'payer_phone'       => $card->holder_phone,
+                'amount'            => (float) $data['amount'],
+                'currency'          => $card->currency,
+                'status'            => \Modules\Tagtoa\App\Models\Pay\PaymentProof::STATUS_APPROVED,
+                'note'              => __('Payé par Carte TAGTOA').' ('.$card->masked_code.')',
+                'reviewed_at'       => now(),
+            ]
+        );
+
+        return redirect()->route('tagtoa.pay.show', $page->alias)
+            ->with('proof_submitted', true)
+            ->with('card_paid', __('Paiement accepté. Nouveau solde : :bal', ['bal' => $card->fresh()->balance_label]));
+    }
+
     public function submitProof(Request $request, string $alias): RedirectResponse
     {
         $page = PaymentPage::where('alias', $alias)->where('is_active', true)->firstOrFail();

--- a/Modules/Tagtoa/app/Models/Card/CardAccount.php
+++ b/Modules/Tagtoa/app/Models/Card/CardAccount.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Card;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Modules\Tagtoa\App\Support\Card\CardWallet;
+use Modules\Tagtoa\App\Support\Money;
+
+/**
+ * TAGTOA CARD — compte d'une carte NFC prépayée closed-loop (valable partout
+ * sur TAGTOA). Le solde en clair (balance_minor) est un cache ; la vérité est la
+ * somme du grand livre immuable (tagtoa_card_txns).
+ */
+class CardAccount extends Model
+{
+    protected $table = 'tagtoa_card_accounts';
+
+    protected $fillable = [
+        'tenant_id', 'uid_hash', 'uid_enc', 'code', 'holder_name', 'holder_phone',
+        'currency', 'balance_minor', 'pin_hash', 'status', 'issued_at', 'last_used_at',
+    ];
+
+    protected $casts = [
+        'balance_minor' => 'integer',
+        'issued_at'     => 'datetime',
+        'last_used_at'  => 'datetime',
+    ];
+
+    protected $hidden = ['uid_hash', 'uid_enc', 'pin_hash'];
+
+    public function txns(): HasMany
+    {
+        return $this->hasMany(CardTxn::class, 'card_account_id')->latest();
+    }
+
+    public function isSpendable(): bool
+    {
+        return CardWallet::isSpendable($this->status);
+    }
+
+    public function hasPin(): bool
+    {
+        return ! empty($this->pin_hash);
+    }
+
+    /** Solde formaté (ex. « 250 G »). */
+    public function getBalanceLabelAttribute(): string
+    {
+        return Money::formatMinor((int) $this->balance_minor, $this->currency);
+    }
+
+    public function getMaskedCodeAttribute(): string
+    {
+        return $this->code ?: ('#'.$this->id);
+    }
+}

--- a/Modules/Tagtoa/app/Models/Card/CardTxn.php
+++ b/Modules/Tagtoa/app/Models/Card/CardTxn.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Card;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Tagtoa\App\Support\Money;
+
+/**
+ * TAGTOA CARD — ligne IMMUABLE du grand livre d'une carte (recharge/débit/remb.).
+ */
+class CardTxn extends Model
+{
+    protected $table = 'tagtoa_card_txns';
+
+    protected $fillable = [
+        'card_account_id', 'tenant_id', 'type', 'amount_minor', 'balance_after_minor',
+        'currency', 'reference', 'context_type', 'context_id', 'meta',
+    ];
+
+    protected $casts = [
+        'amount_minor'        => 'integer',
+        'balance_after_minor' => 'integer',
+        'meta'                => 'array',
+    ];
+
+    public function account(): BelongsTo
+    {
+        return $this->belongsTo(CardAccount::class, 'card_account_id');
+    }
+
+    public function getAmountLabelAttribute(): string
+    {
+        $sign = $this->type === 'charge' ? '−' : '+';
+
+        return $sign.' '.Money::formatMinor((int) $this->amount_minor, $this->currency);
+    }
+}

--- a/Modules/Tagtoa/app/Services/Audit/AuditService.php
+++ b/Modules/Tagtoa/app/Services/Audit/AuditService.php
@@ -30,6 +30,10 @@ class AuditService
         'wallet.purchase'   => 'Achat wallet',
         'wallet.refund'     => 'Remboursement wallet',
         'wallet.payout'     => 'Règlement vendeur',
+        'card.issued'       => 'Carte TAGTOA émise',
+        'card.top_up'       => 'Recharge carte TAGTOA',
+        'card.charged'      => 'Paiement par carte TAGTOA',
+        'card.status'       => 'Statut carte TAGTOA modifié',
     ];
 
     /** Libellé lisible d'une action (repli = action brute). LOGIQUE PURE. */

--- a/Modules/Tagtoa/app/Services/Card/CardWalletService.php
+++ b/Modules/Tagtoa/app/Services/Card/CardWalletService.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace Modules\Tagtoa\App\Services\Card;
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Modules\Tagtoa\App\Models\Card\CardAccount;
+use Modules\Tagtoa\App\Models\Card\CardTxn;
+use Modules\Tagtoa\App\Services\Billing\RevenueService;
+use Modules\Tagtoa\App\Support\Card\CardWallet;
+use Modules\Tagtoa\App\Support\Money;
+
+/**
+ * TAGTOA CARD — service de la carte closed-loop plateforme.
+ *
+ * Débit/recharge ATOMIQUES (lockForUpdate) + IDEMPOTENTS (une référence ne
+ * s'applique qu'une fois) + grand livre immuable. Une carte débitée chez un
+ * marchand crée une commission plateforme (RevenueService).
+ */
+class CardWalletService
+{
+    /** Résout un UID NFC (tap) → compte carte, ou null si inconnu. */
+    public function resolveByUid(string $uid): ?CardAccount
+    {
+        $uid = trim($uid);
+        if ($uid === '') {
+            return null;
+        }
+
+        return CardAccount::where('uid_hash', CardWallet::hashUid($uid))->first();
+    }
+
+    /** Résout par code imprimé (repli quand le NFC n'est pas lisible). */
+    public function resolveByCode(string $code): ?CardAccount
+    {
+        $code = strtoupper(trim($code));
+
+        return $code === '' ? null : CardAccount::where('code', $code)->first();
+    }
+
+    /**
+     * Émet (ou récupère) une carte pour un UID. Idempotent sur l'UID.
+     *
+     * @param  array{tenant_id?:?string,holder_name?:?string,holder_phone?:?string,currency?:string,pin?:?string,code?:?string}  $opts
+     */
+    public function issue(string $uid, array $opts = []): CardAccount
+    {
+        $currency = strtoupper($opts['currency'] ?? 'HTG');
+        $pin = $opts['pin'] ?? null;
+
+        return CardAccount::firstOrCreate(
+            ['uid_hash' => CardWallet::hashUid($uid)],
+            [
+                'tenant_id'     => $opts['tenant_id'] ?? null,
+                'uid_enc'       => Crypt::encryptString(CardWallet::normalizeUid($uid)),
+                'code'          => $opts['code'] ?? $this->generateCode(),
+                'holder_name'   => $opts['holder_name'] ?? null,
+                'holder_phone'  => $opts['holder_phone'] ?? null,
+                'currency'      => $currency,
+                'balance_minor' => 0,
+                'pin_hash'      => (CardWallet::isValidPinFormat($pin) && $pin) ? Hash::make($pin) : null,
+                'status'        => CardWallet::STATUS_ACTIVE,
+                'issued_at'     => now(),
+            ]
+        );
+    }
+
+    /**
+     * Recharge une carte (cash chez un marchand, ou en ligne). Atomique + idempotent.
+     * Retourne la transaction, ou null si montant invalide.
+     */
+    public function topUp(CardAccount $card, float $amount, array $ctx = []): ?CardTxn
+    {
+        $minor = Money::toMinor($amount, $card->currency);
+        if ($minor <= 0) {
+            return null;
+        }
+        $reference = $ctx['reference'] ?? CardWallet::reference();
+
+        return DB::transaction(function () use ($card, $minor, $reference, $ctx) {
+            if ($existing = CardTxn::where('reference', $reference)->first()) {
+                return $existing; // idempotence
+            }
+            /** @var CardAccount $locked */
+            $locked = CardAccount::whereKey($card->id)->lockForUpdate()->first();
+            $newBalance = CardWallet::applyTopup((int) $locked->balance_minor, $minor);
+            $locked->update(['balance_minor' => $newBalance, 'last_used_at' => now()]);
+
+            return CardTxn::create([
+                'card_account_id'     => $locked->id,
+                'tenant_id'           => $ctx['tenant_id'] ?? $locked->tenant_id,
+                'type'                => CardWallet::TYPE_TOPUP,
+                'amount_minor'        => $minor,
+                'balance_after_minor' => $newBalance,
+                'currency'            => $locked->currency,
+                'reference'           => $reference,
+                'context_type'        => $ctx['context_type'] ?? null,
+                'context_id'          => $ctx['context_id'] ?? null,
+                'meta'                => $ctx['meta'] ?? null,
+            ]);
+        });
+    }
+
+    /**
+     * Débite une carte pour un paiement chez un marchand. Vérifie statut + PIN +
+     * solde. Atomique + idempotent. Enregistre la commission plateforme.
+     *
+     * @return array{ok:bool,code:string,message:string,txn:?CardTxn,card:CardAccount}
+     */
+    public function charge(CardAccount $card, float $amount, ?string $pin = null, array $ctx = []): array
+    {
+        $fail = fn (string $code, string $msg) => ['ok' => false, 'code' => $code, 'message' => $msg, 'txn' => null, 'card' => $card];
+
+        if (! $card->isSpendable()) {
+            return $fail('blocked', __('Carte inactive (bloquée ou perdue).'));
+        }
+        if ($card->hasPin() && ! Hash::check((string) $pin, (string) $card->pin_hash)) {
+            return $fail('pin', __('Code PIN incorrect.'));
+        }
+
+        $minor = Money::toMinor($amount, $card->currency);
+        if ($minor <= 0) {
+            return $fail('amount', __('Montant invalide.'));
+        }
+        $reference = $ctx['reference'] ?? CardWallet::reference();
+
+        $result = DB::transaction(function () use ($card, $minor, $reference, $ctx, $fail) {
+            if ($existing = CardTxn::where('reference', $reference)->first()) {
+                return ['ok' => true, 'code' => 'ok', 'message' => __('Paiement déjà appliqué.'), 'txn' => $existing, 'card' => $card->fresh()];
+            }
+            /** @var CardAccount $locked */
+            $locked = CardAccount::whereKey($card->id)->lockForUpdate()->first();
+
+            if (! CardWallet::canCharge((int) $locked->balance_minor, $minor)) {
+                return $fail('insufficient', __('Solde insuffisant.'));
+            }
+
+            $newBalance = CardWallet::applyCharge((int) $locked->balance_minor, $minor);
+            $locked->update(['balance_minor' => $newBalance, 'last_used_at' => now()]);
+
+            $txn = CardTxn::create([
+                'card_account_id'     => $locked->id,
+                'tenant_id'           => $ctx['tenant_id'] ?? null,
+                'type'                => CardWallet::TYPE_CHARGE,
+                'amount_minor'        => $minor,
+                'balance_after_minor' => $newBalance,
+                'currency'            => $locked->currency,
+                'reference'           => $reference,
+                'context_type'        => $ctx['context_type'] ?? null,
+                'context_id'          => $ctx['context_id'] ?? null,
+                'meta'                => $ctx['meta'] ?? null,
+            ]);
+
+            return ['ok' => true, 'code' => 'ok', 'message' => __('Paiement accepté.'), 'txn' => $txn, 'card' => $locked->fresh()];
+        });
+
+        // Commission plateforme sur le débit (marchand encaisseur). On la saute
+        // quand la carte règle une vente d'un autre module qui enregistre déjà sa
+        // propre commission (ex. billet event) — pour ne pas compter deux fois.
+        if (empty($ctx['skip_commission']) && $result['ok'] && $result['txn'] && $result['txn']->wasRecentlyCreated) {
+            app(RevenueService::class)->record(
+                'card_charge',
+                (int) $result['txn']->id,
+                $ctx['module'] ?? 'pay',
+                (float) Money::fromMinor($minor, $card->currency),
+                $ctx['tenant_id'] ?? null,
+                $card->currency
+            );
+        }
+
+        return $result;
+    }
+
+    /** Rembourse un débit sur la carte (recrédit). Atomique + idempotent. */
+    public function refund(CardAccount $card, float $amount, array $ctx = []): ?CardTxn
+    {
+        $minor = Money::toMinor($amount, $card->currency);
+        if ($minor <= 0) {
+            return null;
+        }
+        $reference = $ctx['reference'] ?? CardWallet::reference();
+
+        return DB::transaction(function () use ($card, $minor, $reference, $ctx) {
+            if ($existing = CardTxn::where('reference', $reference)->first()) {
+                return $existing;
+            }
+            /** @var CardAccount $locked */
+            $locked = CardAccount::whereKey($card->id)->lockForUpdate()->first();
+            $newBalance = CardWallet::applyTopup((int) $locked->balance_minor, $minor);
+            $locked->update(['balance_minor' => $newBalance]);
+
+            return CardTxn::create([
+                'card_account_id'     => $locked->id,
+                'tenant_id'           => $ctx['tenant_id'] ?? $locked->tenant_id,
+                'type'                => CardWallet::TYPE_REFUND,
+                'amount_minor'        => $minor,
+                'balance_after_minor' => $newBalance,
+                'currency'            => $locked->currency,
+                'reference'           => $reference,
+                'context_type'        => $ctx['context_type'] ?? null,
+                'context_id'          => $ctx['context_id'] ?? null,
+                'meta'                => $ctx['meta'] ?? null,
+            ]);
+        });
+    }
+
+    /** Change le statut d'une carte (active|blocked|lost). */
+    public function setStatus(CardAccount $card, string $status): bool
+    {
+        if (! in_array($status, CardWallet::STATUSES, true)) {
+            return false;
+        }
+
+        return $card->update(['status' => $status]);
+    }
+
+    /** Définit/retire le PIN d'une carte. */
+    public function setPin(CardAccount $card, ?string $pin): bool
+    {
+        if (! CardWallet::isValidPinFormat($pin)) {
+            return false;
+        }
+
+        return $card->update(['pin_hash' => $pin ? Hash::make($pin) : null]);
+    }
+
+    /** Code lisible unique imprimé sur la carte. */
+    protected function generateCode(): string
+    {
+        do {
+            $code = 'TAG'.strtoupper(bin2hex(random_bytes(3)));
+        } while (CardAccount::where('code', $code)->exists());
+
+        return $code;
+    }
+}

--- a/Modules/Tagtoa/app/Support/Card/CardWallet.php
+++ b/Modules/Tagtoa/app/Support/Card/CardWallet.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Card;
+
+/**
+ * TAGTOA CARD — helpers PURS de la carte NFC prépayée « closed-loop » TAGTOA,
+ * testables sans Laravel ni réseau.
+ *
+ * Une carte TAGTOA est une carte NFC (NTAG213/216) qui porte un SOLDE dans
+ * l'écosystème TAGTOA. Le client recharge (cash chez un marchand, ou en ligne),
+ * puis paie chez N'IMPORTE QUEL marchand TAGTOA en tapant la carte + PIN.
+ * « Closed-loop » = l'argent reste dans TAGTOA (aucun réseau carte externe).
+ *
+ * L'UID NFC n'est JAMAIS stocké/recherché en clair : on normalise puis on hashe.
+ * Les montants sont manipulés en UNITÉS MINEURES (entiers) — aucune erreur de
+ * virgule flottante sur un solde.
+ */
+class CardWallet
+{
+    public const STATUS_ACTIVE  = 'active';
+    public const STATUS_BLOCKED = 'blocked';
+    public const STATUS_LOST    = 'lost';
+
+    public const STATUSES = [self::STATUS_ACTIVE, self::STATUS_BLOCKED, self::STATUS_LOST];
+
+    public const TYPE_TOPUP  = 'topup';
+    public const TYPE_CHARGE = 'charge';
+    public const TYPE_REFUND = 'refund';
+    public const TYPE_ADJUST = 'adjust';
+
+    /**
+     * Normalise un UID NFC : retire séparateurs (: - espaces) et met en
+     * majuscules, de sorte que « 04:A2:1B » et « 04a21b » désignent la même carte. PUR.
+     */
+    public static function normalizeUid(string $uid): string
+    {
+        return strtoupper(preg_replace('/[^0-9A-Za-z]/', '', trim($uid)) ?? '');
+    }
+
+    /** Hash stable d'un UID NFC (jamais l'UID en clair). Sel optionnel. PUR. */
+    public static function hashUid(string $uid, string $salt = ''): string
+    {
+        return hash('sha256', $salt.self::normalizeUid($uid));
+    }
+
+    /** Masque un UID pour affichage : garde les 4 derniers. PUR. */
+    public static function maskUid(string $uid): string
+    {
+        $n = self::normalizeUid($uid);
+        $len = strlen($n);
+        if ($len <= 4) {
+            return $n;
+        }
+
+        return str_repeat('•', $len - 4).substr($n, -4);
+    }
+
+    /** Une carte peut-elle dépenser ? (statut actif seulement). PUR. */
+    public static function isSpendable(?string $status): bool
+    {
+        return $status === self::STATUS_ACTIVE;
+    }
+
+    /** Le solde couvre-t-il le montant demandé ? (montant > 0). PUR. Unités mineures. */
+    public static function canCharge(int $balanceMinor, int $amountMinor): bool
+    {
+        return $amountMinor > 0 && $balanceMinor >= $amountMinor;
+    }
+
+    /** Nouveau solde après un débit (jamais négatif). PUR. Unités mineures. */
+    public static function applyCharge(int $balanceMinor, int $amountMinor): int
+    {
+        return max(0, $balanceMinor - max(0, $amountMinor));
+    }
+
+    /** Nouveau solde après une recharge. PUR. Unités mineures. */
+    public static function applyTopup(int $balanceMinor, int $amountMinor): int
+    {
+        return $balanceMinor + max(0, $amountMinor);
+    }
+
+    /** Un PIN de carte est-il au bon format ? (4 à 6 chiffres) ou vide (pas de PIN). PUR. */
+    public static function isValidPinFormat(?string $pin): bool
+    {
+        if ($pin === null || $pin === '') {
+            return true; // carte sans PIN autorisée
+        }
+
+        return (bool) preg_match('/^\d{4,6}$/', $pin);
+    }
+
+    /** Génère une référence de transaction carte (idempotence). */
+    public static function reference(): string
+    {
+        return 'CARD-'.strtoupper(bin2hex(random_bytes(5)));
+    }
+}

--- a/Modules/Tagtoa/resources/views/card/index.blade.php
+++ b/Modules/Tagtoa/resources/views/card/index.blade.php
@@ -1,0 +1,118 @@
+@extends('tagtoa::layouts.dashboard')
+@section('title', __('Cartes TAGTOA'))
+@section('page', __('Cartes TAGTOA'))
+
+@section('content')
+
+<div class="card" style="margin-bottom:18px">
+    <div class="h-row"><h2><i class="fa-solid fa-credit-card"></i> {{ __('Carte prépayée closed-loop') }}</h2></div>
+    <p style="color:var(--muted);margin:0 0 14px">{{ __('Une carte NFC TAGTOA porte un solde utilisable chez tous vos points de vente TAGTOA (paiements, menu, événements, caisse). Le client recharge, puis paie en tapant sa carte + PIN — sans espèces, sans réseau externe.') }}</p>
+    @if($totals->isNotEmpty())
+        <div style="display:flex;flex-wrap:wrap;gap:12px">
+            @foreach($totals as $t)
+                <div style="background:var(--soft,#f4f6f8);border-radius:14px;padding:14px 18px;min-width:150px">
+                    <div style="font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em">{{ __('Solde en circulation') }} · {{ $t['currency'] }}</div>
+                    <div style="font-family:var(--fh);font-size:22px;font-weight:700">{{ $t['label'] }}</div>
+                    <div style="font-size:12px;color:var(--muted)">{{ $t['count'] }} {{ __('carte(s)') }}</div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>
+
+<div class="card" style="margin-bottom:18px">
+    <div class="h-row"><h2>{{ __('Émettre une carte') }}</h2></div>
+    <form method="POST" action="{{ route('tagtoa.cards.store') }}">
+        @csrf
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:12px">
+            <div>
+                <label class="lbl">{{ __('UID de la carte (NFC)') }} *</label>
+                <div style="display:flex;gap:8px">
+                    <input class="inp" id="issue-uid" name="card_uid" value="{{ old('card_uid') }}" placeholder="{{ __('Tapez la carte…') }}" required>
+                    <button type="button" class="btn btn-o" style="flex:0;white-space:nowrap" onclick="readIssue()"><i class="fa-solid fa-wifi"></i></button>
+                </div>
+            </div>
+            <div><label class="lbl">{{ __('Titulaire') }}</label><input class="inp" name="holder_name" value="{{ old('holder_name') }}" placeholder="{{ __('Nom (optionnel)') }}"></div>
+            <div><label class="lbl">{{ __('Téléphone') }}</label><input class="inp" name="holder_phone" value="{{ old('holder_phone') }}" placeholder="+509 ..."></div>
+            <div>
+                <label class="lbl">{{ __('Devise') }}</label>
+                <select class="sel inp" name="currency">
+                    @foreach($currencies as $code => $label)
+                        <option value="{{ $code }}" @selected(old('currency','HTG')===$code)>{{ $label }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div><label class="lbl">{{ __('PIN (4-6 chiffres)') }}</label><input class="inp" name="pin" inputmode="numeric" maxlength="6" pattern="\d{4,6}" value="{{ old('pin') }}" placeholder="{{ __('Optionnel') }}"></div>
+            <div><label class="lbl">{{ __('Recharge initiale') }}</label><input class="inp" name="initial_amount" type="number" step="0.01" min="0" value="{{ old('initial_amount') }}" placeholder="0.00"></div>
+        </div>
+        <button class="btn btn-p" type="submit" style="margin-top:14px"><i class="fa-solid fa-plus"></i> {{ __('Émettre la carte') }}</button>
+    </form>
+</div>
+
+<div class="card">
+    <div class="h-row">
+        <h2>{{ __('Cartes émises') }}</h2>
+        <form method="GET" style="flex:0">
+            <input class="inp" name="q" value="{{ $q }}" placeholder="{{ __('Code, nom, téléphone…') }}" style="min-width:220px">
+        </form>
+    </div>
+
+    @if($cards->isEmpty())
+        <div class="empty"><i class="fa-solid fa-credit-card"></i>{{ __('Aucune carte pour le moment.') }}</div>
+    @else
+        <table>
+            <thead><tr>
+                <th>{{ __('Code') }}</th>
+                <th>{{ __('Titulaire') }}</th>
+                <th>{{ __('Solde') }}</th>
+                <th>{{ __('Statut') }}</th>
+                <th style="text-align:right">{{ __('Actions') }}</th>
+            </tr></thead>
+            <tbody>
+            @foreach($cards as $c)
+                <tr>
+                    <td><b>{{ $c->code }}</b>@if($c->hasPin()) <i class="fa-solid fa-lock" title="{{ __('PIN activé') }}" style="color:var(--muted);font-size:11px"></i>@endif</td>
+                    <td>{{ $c->holder_name ?: '—' }}<br><span style="color:var(--muted);font-size:12px">{{ $c->holder_phone }}</span></td>
+                    <td><b>{{ $c->balance_label }}</b></td>
+                    <td>
+                        @if($c->status==='active')<span class="pill ok">{{ __('Active') }}</span>
+                        @elseif($c->status==='blocked')<span class="pill n">{{ __('Bloquée') }}</span>
+                        @else<span class="pill n" style="opacity:.7">{{ __('Perdue') }}</span>@endif
+                    </td>
+                    <td>
+                        <div style="display:flex;gap:6px;justify-content:flex-end;flex-wrap:wrap">
+                            <form method="POST" action="{{ route('tagtoa.cards.topup',$c->id) }}" style="display:flex;gap:4px;flex:0">
+                                @csrf
+                                <input class="inp" name="amount" type="number" step="0.01" min="0.01" placeholder="{{ __('Recharge') }}" style="width:110px" required>
+                                <button class="btn btn-p btn-sm" style="flex:0"><i class="fa-solid fa-plus"></i></button>
+                            </form>
+                            @if($c->status==='active')
+                                <form method="POST" action="{{ route('tagtoa.cards.status',$c->id) }}" style="flex:0" onsubmit="return confirm('{{ __('Bloquer cette carte ?') }}')">
+                                    @csrf<input type="hidden" name="status" value="blocked">
+                                    <button class="btn btn-o btn-sm" style="flex:0;color:var(--red)"><i class="fa-solid fa-ban"></i></button>
+                                </form>
+                            @else
+                                <form method="POST" action="{{ route('tagtoa.cards.status',$c->id) }}" style="flex:0">
+                                    @csrf<input type="hidden" name="status" value="active">
+                                    <button class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-rotate-left"></i></button>
+                                </form>
+                            @endif
+                            <a href="{{ route('tagtoa.cards.show',$c->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-list"></i></a>
+                        </div>
+                    </td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+        <div style="margin-top:16px">{{ $cards->links() }}</div>
+    @endif
+</div>
+
+<script>
+function nfcInto(input){
+    if(!('NDEFReader' in window)){alert('{{ __('NFC non supporté ici. Saisissez l\'UID manuellement.') }}');return;}
+    try{var r=new NDEFReader();r.scan().then(function(){r.onreading=function(e){if(e.serialNumber){input.value=e.serialNumber;}};}).catch(function(){alert('{{ __('Lecture NFC refusée.') }}');});}catch(err){}
+}
+function readIssue(){nfcInto(document.getElementById('issue-uid'));}
+</script>
+@endsection

--- a/Modules/Tagtoa/resources/views/card/show.blade.php
+++ b/Modules/Tagtoa/resources/views/card/show.blade.php
@@ -1,0 +1,63 @@
+@extends('tagtoa::layouts.dashboard')
+@section('title', __('Carte :code', ['code' => $card->code]))
+@section('page', __('Carte').' '.$card->code)
+
+@section('content')
+
+<div class="card" style="margin-bottom:18px">
+    <div class="h-row">
+        <h2><i class="fa-solid fa-credit-card"></i> {{ $card->code }}</h2>
+        <a href="{{ route('tagtoa.cards.index') }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-arrow-left"></i> {{ __('Retour') }}</a>
+    </div>
+    <div style="display:flex;flex-wrap:wrap;gap:24px;align-items:center">
+        <div>
+            <div style="font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.04em">{{ __('Solde') }}</div>
+            <div style="font-family:var(--fh);font-size:28px;font-weight:700">{{ $card->balance_label }}</div>
+        </div>
+        <div>
+            <div style="font-size:12px;color:var(--muted)">{{ __('Titulaire') }}</div>
+            <div>{{ $card->holder_name ?: '—' }} <span style="color:var(--muted)">{{ $card->holder_phone }}</span></div>
+        </div>
+        <div>
+            <div style="font-size:12px;color:var(--muted)">{{ __('Statut') }}</div>
+            @if($card->status==='active')<span class="pill ok">{{ __('Active') }}</span>
+            @elseif($card->status==='blocked')<span class="pill n">{{ __('Bloquée') }}</span>
+            @else<span class="pill n" style="opacity:.7">{{ __('Perdue') }}</span>@endif
+        </div>
+    </div>
+</div>
+
+<div class="card">
+    <div class="h-row"><h2>{{ __('Historique des mouvements') }}</h2></div>
+    @if($txns->isEmpty())
+        <div class="empty"><i class="fa-solid fa-clock-rotate-left"></i>{{ __('Aucun mouvement.') }}</div>
+    @else
+        <table>
+            <thead><tr>
+                <th>{{ __('Date') }}</th>
+                <th>{{ __('Type') }}</th>
+                <th>{{ __('Montant') }}</th>
+                <th>{{ __('Solde après') }}</th>
+                <th>{{ __('Contexte') }}</th>
+            </tr></thead>
+            <tbody>
+            @foreach($txns as $t)
+                <tr>
+                    <td style="white-space:nowrap;color:var(--muted)">{{ optional($t->created_at)->format('d/m/Y H:i') }}</td>
+                    <td>
+                        @if($t->type==='topup')<span class="pill ok">{{ __('Recharge') }}</span>
+                        @elseif($t->type==='charge')<span class="pill n">{{ __('Paiement') }}</span>
+                        @elseif($t->type==='refund')<span class="pill">{{ __('Remboursement') }}</span>
+                        @else<span class="pill">{{ __('Ajustement') }}</span>@endif
+                    </td>
+                    <td><b>{{ $t->amount_label }}</b></td>
+                    <td>{{ \Modules\Tagtoa\App\Support\Money::formatMinor((int) $t->balance_after_minor, $t->currency) }}</td>
+                    <td style="color:var(--muted)">{{ $t->context_type ? $t->context_type.($t->context_id ? ' #'.$t->context_id : '') : '—' }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+        <div style="margin-top:16px">{{ $txns->links() }}</div>
+    @endif
+</div>
+@endsection

--- a/Modules/Tagtoa/resources/views/event/staff-terminal.blade.php
+++ b/Modules/Tagtoa/resources/views/event/staff-terminal.blade.php
@@ -119,11 +119,18 @@
                 <label>{{ __('Type de billet') }}</label>
                 <select id="slType"><option value="">{{ __('— Aucun —') }}</option>@foreach($ticketTypes as $tt)<option value="{{ $tt->id }}">{{ $tt->name }}</option>@endforeach</select>
                 <label>{{ __('Moyen de paiement') }}</label>
-                <select id="slPay">
+                <select id="slPay" onchange="togglePayCard()">
                     <option value="Espèces">{{ __('Espèces (cash)') }}</option>
+                    <option value="Carte TAGTOA">{{ __('Carte TAGTOA (closed-loop)') }}</option>
                     @foreach($payMethods as $pm)<option value="{{ $pm->label }}">{{ $pm->label }}</option>@endforeach
                 </select>
                 @if($payMethods->isEmpty())<div class="nfc" style="text-align:left">{{ __('Astuce : configurez vos moyens dans TAGTOA Pay et liez la page à l\'événement.') }}</div>@endif
+                <div id="slCardPay" style="display:none;background:rgba(44,184,9,.06);border-radius:12px;padding:12px;margin-top:8px">
+                    <div class="nfc" style="text-align:left;margin-bottom:8px"><i class="fa-solid fa-id-card"></i> {{ __('Le participant paie avec sa carte prépayée TAGTOA (tap + PIN).') }}</div>
+                    <div style="display:flex;gap:8px"><input class="inp" id="slPayUid" autocomplete="off" placeholder="{{ __('UID carte TAGTOA') }}" style="flex:1;margin-top:0"><button class="btn btn-o" id="slPayNfcBtn" type="button" style="margin-top:0;flex:0"><i class="fa-solid fa-wifi"></i></button></div>
+                    <input class="inp" id="slPayCode" autocomplete="off" placeholder="{{ __('ou code TAG…') }}" style="text-transform:uppercase">
+                    <input class="inp" id="slPayPin" inputmode="numeric" maxlength="6" placeholder="{{ __('PIN') }}">
+                </div>
                 <label>{{ __('UID carte NFC (vide = e-billet QR)') }}</label>
                 <div style="display:flex;gap:8px"><input class="inp" id="slUid" autocomplete="off" placeholder="04:A2:..." style="flex:1"><button class="btn btn-o" id="slNfcBtn" type="button" style="margin-top:0;flex:0;white-space:nowrap"><i class="fa-solid fa-wifi"></i> {{ __('Lire') }}</button></div>
                 <div class="nfc" id="slNfcHint" style="text-align:left"></div>
@@ -242,18 +249,27 @@
         var name=el('slName').value.trim(),phone=el('slPhone').value.trim();
         var errB=el('slErr');errB.style.display='none';
         if(!name||!phone){errB.textContent=T.need;errB.style.display='block';return;}
+        var pm=el('slPay')?el('slPay').value:null;
+        if(pm==='Carte TAGTOA' && !el('slPayUid').value.trim() && !el('slPayCode').value.trim()){errB.textContent='{{ __('Tapez la carte TAGTOA ou saisissez son code.') }}';errB.style.display='block';return;}
         var btn=el('slBtn');btn.disabled=true;
         post(URL_SELL,{name:name,phone:phone,email:el('slEmail').value.trim()||null,
             ticket_type_id:el('slType').value?Number(el('slType').value):null,
             uid:el('slUid').value.trim()||null,
-            payment_method:el('slPay')?el('slPay').value:null,
+            payment_method:pm,
+            pay_card_uid:el('slPayUid').value.trim()||null,
+            pay_card_code:el('slPayCode').value.trim()||null,
+            pay_card_pin:el('slPayPin').value.trim()||null,
+            client_uuid:uuid(),
             credit:el('slCredit').value.trim()?Number(el('slCredit').value):null})
         .then(function(j){btn.disabled=false;
             if(!j.ok){errB.textContent=j.message||T.err;errB.style.display='block';return;}
             el('slCode').textContent=j.code;el('slWho').textContent=j.name;el('slOk').classList.add('show');
-            el('slName').value='';el('slPhone').value='';el('slEmail').value='';el('slUid').value='';el('slCredit').value='';el('slName').focus();
+            el('slName').value='';el('slPhone').value='';el('slEmail').value='';el('slUid').value='';el('slCredit').value='';
+            el('slPayUid').value='';el('slPayCode').value='';el('slPayPin').value='';el('slName').focus();
         }).catch(function(){btn.disabled=false;errB.textContent=T.err;errB.style.display='block';});
     });
+    function togglePayCard(){var s=el('slPay'),b=el('slCardPay');if(s&&b){b.style.display=(s.value==='Carte TAGTOA')?'block':'none';}}
+    (function(){var pnb=el('slPayNfcBtn');if(pnb&&('NDEFReader' in window)){pnb.addEventListener('click',function(){try{var r=new NDEFReader();r.scan().then(function(){r.onreading=function(e){if(e.serialNumber){el('slPayUid').value=e.serialNumber;}};}).catch(function(){});}catch(err){}});}})();
     el('pkBtn').addEventListener('click',function(){
         var code=el('pkCode').value.trim(),uid=el('pkUid').value.trim();
         var errB=el('pkErr');errB.style.display='none';el('pkOk').classList.remove('show');

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -98,6 +98,7 @@
             <a href="{{ url('/tagtoa/menu') }}" class="{{ request()->is('tagtoa/menu*') ? 'on' : '' }}"><i class="fa-solid fa-utensils"></i> {{ __('Menu') }}</a>
             <a href="{{ url('/tagtoa/store') }}" class="{{ request()->is('tagtoa/store*') ? 'on' : '' }}"><i class="fa-solid fa-bag-shopping"></i> {{ __('Boutique') }}</a>
             <a href="{{ url('/tagtoa/pay') }}" class="{{ request()->is('tagtoa/pay*') ? 'on' : '' }}"><i class="fa-solid fa-money-bill-transfer"></i> {{ __('Paiements') }}</a>
+            <a href="{{ url('/tagtoa/cards') }}" class="{{ request()->is('tagtoa/cards*') ? 'on' : '' }}"><i class="fa-solid fa-credit-card"></i> {{ __('Cartes TAGTOA') }}</a>
             <a href="{{ url('/tagtoa/loyalty') }}" class="{{ request()->is('tagtoa/loyalty*') ? 'on' : '' }}"><i class="fa-solid fa-id-card"></i> {{ __('Fidélité') }}</a>
             <a href="{{ url('/tagtoa/links') }}" class="{{ request()->is('tagtoa/links*') ? 'on' : '' }}"><i class="fa-solid fa-link"></i> {{ __('Liens') }}</a>
             <a href="{{ url('/tagtoa/event') }}" class="{{ request()->is('tagtoa/event*') ? 'on' : '' }}"><i class="fa-solid fa-ticket"></i> {{ __('Événements') }}</a>

--- a/Modules/Tagtoa/resources/views/pay/show.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/show.blade.php
@@ -63,7 +63,9 @@
         @if($page->description)<p>{{ $page->description }}</p>@endif
     </header>
 
-    @if(session('proof_submitted'))
+    @if(session('card_paid'))
+        <div class="ok"><i class="fa-solid fa-circle-check"></i><div>{{ session('card_paid') }}</div></div>
+    @elseif(session('proof_submitted'))
         <div class="ok"><i class="fa-solid fa-circle-check"></i><div>{{ __('Preuve reçue! Le bénéficiaire va vérifier.') }}</div></div>
     @endif
     @if(session('error'))
@@ -107,6 +109,21 @@
                                 <button class="btn btn-p" type="submit" style="margin-top:10px"><i class="fa-solid fa-bolt"></i> {{ __('Payer en ligne maintenant') }}</button>
                             </form>
                             <div class="sep-or" style="text-align:center;color:#9aa;margin:8px 0;font-size:13px">{{ __('ou payez manuellement ci-dessous') }}</div>
+                        @endif
+                        @if($m->type === 'tagtoa_card')
+                            <form method="POST" action="{{ route('tagtoa.pay.card.charge', $page->alias) }}" style="margin-bottom:14px" id="cardform-{{ $m->id }}">
+                                @csrf
+                                <div class="instr" style="margin-bottom:10px"><i class="fa-solid fa-id-card" style="color:var(--blue);margin-right:6px"></i>{{ __('Approchez votre carte TAGTOA du téléphone, ou saisissez son code.') }}</div>
+                                <button type="button" class="btn btn-o nfc-read" data-target="uid-{{ $m->id }}" onclick="readCard(this)" style="margin-bottom:8px"><i class="fa-solid fa-wifi"></i> {{ __('Lire la carte (NFC)') }}</button>
+                                <input class="inp" type="text" id="uid-{{ $m->id }}" name="card_uid" placeholder="{{ __('UID de la carte (auto)') }}" readonly style="margin-bottom:8px">
+                                <label class="lbl">{{ __('ou code de la carte') }}</label>
+                                <input class="inp" name="card_code" maxlength="40" placeholder="TAG..." style="text-transform:uppercase">
+                                <label class="lbl">{{ __('Code PIN') }}</label>
+                                <input class="inp" name="pin" inputmode="numeric" maxlength="6" pattern="\d*" placeholder="••••">
+                                <label class="lbl">{{ __('Montant à payer') }} ({{ $page->default_currency }}) *</label>
+                                <input class="inp" name="amount" type="number" step="0.01" min="0.01" required placeholder="0.00">
+                                <button class="btn btn-p" type="submit" style="margin-top:10px"><i class="fa-solid fa-bolt"></i> {{ __('Payer avec la carte') }}</button>
+                            </form>
                         @endif
                         @if($m->qr_url)<div class="qr"><img src="{{ $m->qr_url }}" alt="QR" loading="lazy"></div>@endif
                         @if($m->institution)<div class="kv"><span>{{ __('Institution') }}</span><b>{{ $m->institution }}</b></div>@endif
@@ -158,6 +175,10 @@ function pick(btn,id){var d=document.getElementById('det-'+id);
 function pv(i){var f=i.files[0];if(!f)return;i.parentNode.querySelector('.ftx').textContent=f.name;var img=i.closest('form').querySelector('.prev');var r=new FileReader();r.onload=function(e){img.src=e.target.result;img.style.display='block';};r.readAsDataURL(f);}
 function cp(el){var t=el.getAttribute('data-copy');navigator.clipboard&&navigator.clipboard.writeText(t);var o=el.textContent;el.textContent='{{ __('Copié!') }}';setTimeout(function(){el.textContent=o;},1400);}
 function sh(){if(navigator.share){navigator.share({title:document.title,url:location.href}).catch(function(){});}else{navigator.clipboard&&navigator.clipboard.writeText(location.href);alert('{{ __('Lien copié') }}');}}
+function readCard(btn){var out=document.getElementById(btn.getAttribute('data-target'));
+    if(!('NDEFReader' in window)){alert('{{ __('NFC non supporté sur cet appareil. Saisissez le code de la carte.') }}');return;}
+    var o=btn.innerHTML;btn.innerHTML='<i class="fa-solid fa-spinner fa-spin"></i> {{ __('Approchez la carte...') }}';
+    try{var r=new NDEFReader();r.scan().then(function(){r.onreading=function(e){if(e.serialNumber){out.value=e.serialNumber;btn.innerHTML='<i class="fa-solid fa-circle-check"></i> {{ __('Carte lue') }}';}};}).catch(function(){btn.innerHTML=o;alert('{{ __('Lecture NFC refusée. Saisissez le code.') }}');});}catch(err){btn.innerHTML=o;}}
 @if($errors->any())var b=document.querySelector('.m');if(b)b.click();@endif
 </script>
 </body>

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -36,6 +36,8 @@ use Modules\Tagtoa\App\Http\Controllers\Site\PublicController as SitePublic;
 Route::get('/', [LandingController::class, 'index'])->name('home');
 Route::get('/pay/{alias}', [PayPublic::class, 'show'])->name('tagtoa.pay.show');
 Route::get('/pay/{alias}/checkout/{method}', [PayPublic::class, 'checkout'])->name('tagtoa.pay.checkout');
+// Paiement par CARTE TAGTOA (closed-loop) : tap NFC/UID + PIN → débit instantané.
+Route::post('/pay/{alias}/card/charge', [PayPublic::class, 'cardCharge'])->middleware('throttle:20,1')->name('tagtoa.pay.card.charge');
 // Paiement en ligne via passerelle API (MonCash…). Public.
 Route::get('/pay/result', [\Modules\Tagtoa\App\Http\Controllers\Pay\CheckoutController::class, 'result'])->name('tagtoa.pay.result');
 Route::get('/pay/checkout/{gateway}/{type}/{orderId}', [\Modules\Tagtoa\App\Http\Controllers\Pay\CheckoutController::class, 'start'])->middleware('throttle:30,1')->name('tagtoa.pay.online.start');
@@ -248,6 +250,13 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
         Route::post('/{id}/feature', [\Modules\Tagtoa\App\Http\Controllers\Review\DashboardController::class, 'feature'])->name('feature');
         Route::delete('/{id}', [\Modules\Tagtoa\App\Http\Controllers\Review\DashboardController::class, 'destroy'])->name('destroy');
     });
+
+    // CARTE TAGTOA (closed-loop : émission, recharge, blocage, historique)
+    Route::get('/cards', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'index'])->name('tagtoa.cards.index');
+    Route::post('/cards', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'store'])->name('tagtoa.cards.store');
+    Route::get('/cards/{card}', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'show'])->name('tagtoa.cards.show');
+    Route::post('/cards/{card}/topup', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'topUp'])->name('tagtoa.cards.topup');
+    Route::post('/cards/{card}/status', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'setStatus'])->name('tagtoa.cards.status');
 
     // AUDIT (journal — lecture seule)
     Route::get('/audit', [\Modules\Tagtoa\App\Http\Controllers\Audit\DashboardController::class, 'index'])->name('tagtoa.audit.index');

--- a/Modules/Tagtoa/tests/Unit/CardWalletTest.php
+++ b/Modules/Tagtoa/tests/Unit/CardWalletTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Support\Card\CardWallet;
+use PHPUnit\Framework\TestCase;
+
+/** Logique pure de la carte TAGTOA closed-loop (UID, solde entier, statut, PIN). */
+class CardWalletTest extends TestCase
+{
+    public function test_uid_normalization_is_separator_and_case_insensitive(): void
+    {
+        $this->assertSame('04A21B', CardWallet::normalizeUid('04:A2:1B'));
+        $this->assertSame('04A21B', CardWallet::normalizeUid('04-a2-1b'));
+        $this->assertSame('04A21B', CardWallet::normalizeUid('  04 a2 1b '));
+        // Même carte, deux écritures → même hash.
+        $this->assertSame(CardWallet::hashUid('04:A2:1B'), CardWallet::hashUid('04a21b'));
+    }
+
+    public function test_hash_never_returns_raw_uid_and_is_salt_sensitive(): void
+    {
+        $h = CardWallet::hashUid('04A21B');
+        $this->assertSame(64, strlen($h));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $h);
+        $this->assertNotSame(CardWallet::hashUid('04A21B'), CardWallet::hashUid('04A21B', 'salt'));
+    }
+
+    public function test_mask_uid_keeps_last_four(): void
+    {
+        $this->assertSame('••••1234', CardWallet::maskUid('AABB1234'));
+        $this->assertSame('AB12', CardWallet::maskUid('AB12'));   // trop court → tel quel
+    }
+
+    public function test_spendable_only_when_active(): void
+    {
+        $this->assertTrue(CardWallet::isSpendable(CardWallet::STATUS_ACTIVE));
+        $this->assertFalse(CardWallet::isSpendable(CardWallet::STATUS_BLOCKED));
+        $this->assertFalse(CardWallet::isSpendable(CardWallet::STATUS_LOST));
+        $this->assertFalse(CardWallet::isSpendable(null));
+    }
+
+    public function test_can_charge_guards_amount_and_balance(): void
+    {
+        $this->assertTrue(CardWallet::canCharge(1000, 1000));   // solde exact
+        $this->assertTrue(CardWallet::canCharge(1000, 500));
+        $this->assertFalse(CardWallet::canCharge(1000, 1001));  // insuffisant
+        $this->assertFalse(CardWallet::canCharge(1000, 0));     // montant nul
+        $this->assertFalse(CardWallet::canCharge(1000, -50));   // montant négatif
+    }
+
+    public function test_apply_charge_and_topup_integer_math(): void
+    {
+        $this->assertSame(500, CardWallet::applyCharge(1000, 500));
+        $this->assertSame(0, CardWallet::applyCharge(1000, 1000));
+        $this->assertSame(0, CardWallet::applyCharge(1000, 5000));   // jamais négatif
+        $this->assertSame(1500, CardWallet::applyTopup(1000, 500));
+        $this->assertSame(1000, CardWallet::applyTopup(1000, -50));  // recharge négative ignorée
+    }
+
+    public function test_pin_format(): void
+    {
+        $this->assertTrue(CardWallet::isValidPinFormat('1234'));
+        $this->assertTrue(CardWallet::isValidPinFormat('123456'));
+        $this->assertTrue(CardWallet::isValidPinFormat(null));   // sans PIN autorisé
+        $this->assertTrue(CardWallet::isValidPinFormat(''));
+        $this->assertFalse(CardWallet::isValidPinFormat('12'));
+        $this->assertFalse(CardWallet::isValidPinFormat('1234567'));
+        $this->assertFalse(CardWallet::isValidPinFormat('12ab'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -26,6 +26,7 @@ require_once $base.'/Support/Gateways/MonCash.php';
 require_once $base.'/Support/Gateways/PayPal.php';
 require_once $base.'/Support/Gateways/CoinPayments.php';
 require_once $base.'/Support/Gateways/Stripe.php';
+require_once $base.'/Support/Card/CardWallet.php';
 require_once $base.'/Support/Event/Ledger.php';
 require_once $base.'/Support/Event/EventDays.php';
 require_once $base.'/Support/Money.php';


### PR DESCRIPTION
## Objectif
Ajouter la **Carte TAGTOA** : une carte NFC prépayée « closed-loop » valable chez **tous** les points de vente TAGTOA. Le client recharge son solde, puis paie partout en tapant sa carte + PIN — sans espèces, sans réseau carte externe. Demandé pour PAY **et** pour les paiements EVENT.

## Architecture
- **Cœur pur testé** — `Support/Card/CardWallet` : normalisation + hash d'UID (l'UID n'est **jamais** stocké/recherché en clair), maths de solde en **entiers** (unités mineures), statut, format PIN. Testable sans Laravel → CI.
- **Tables additives** (`tagtoa_*`, colonnes nullable) : `tagtoa_card_accounts` (solde caché) + `tagtoa_card_txns` (**grand livre immuable**, instantané de solde, `reference` unique = idempotence).
- **`CardWalletService`** : `charge` / `topUp` / `refund` **atomiques** (`lockForUpdate`) + **idempotents** (une référence ne s'applique qu'une fois) + commission plateforme. `skip_commission` quand la carte règle une vente d'un autre module qui facture déjà (ex. billet event) → pas de double comptage.

## Intégrations
- **Dashboard `/tagtoa/cards`** — émettre (tap NFC), recharger, bloquer/réactiver, historique. Scopé au marchand + **audité** (`card.issued` / `card.top_up` / `card.status`).
- **PAY public** — méthode « Carte TAGTOA » : tap NFC (Web NFC) ou code + PIN + montant → débit instantané → **preuve APPROUVÉE** au tableau de bord.
- **EVENT terminal staff** — « Carte TAGTOA » comme moyen de paiement d'un billet : débit **avant** émission (un refus annule la vente, aucun billet fantôme), commission prise une seule fois sur le billet.

## Anti-fraude
- UID hashé (sha256, jamais en clair) ; PIN bcrypt vérifié à chaque débit ; carte bloquée/perdue non dépensable ; solde en entiers (pas d'erreur de virgule) ; débits atomiques + idempotents.

## Tests
- `CardWalletTest` (7 tests) : UID insensible aux séparateurs/casse, hash ≠ UID + sel, masque, statut dépensable, garde montant/solde, maths charge/topup, format PIN.
- `ViewCompileTest` + `RouteIntegrityTest` verts (nouvelles vues + routes). Suite Unit : **115 tests OK**.

## Démo
Carte `TAGDEMO` / PIN `1234` / solde `1000 G` sur `/pay/demo` → « Carte TAGTOA ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_