### PR TITLE
ADMIN: bouton flottant « TAGTOA » sur les pages sadmin Biztap

### DIFF
--- a/Modules/Tagtoa/app/Http/Middleware/InjectTagtoaLauncher.php
+++ b/Modules/Tagtoa/app/Http/Middleware/InjectTagtoaLauncher.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * TAGTOA — injecte un bouton flottant « TAGTOA » dans les pages d'admin Biztap
+ * (/sadmin…) pour offrir un accès direct au hub TAGTOA (/tagtoa/home).
+ *
+ * Non invasif : n'édite AUCUNE vue du cœur Biztap (qui n'est pas dans le dépôt).
+ * On post-traite la réponse HTML et on insère un lien avant `</body>`. Tolérant :
+ * toute condition non remplie → la réponse passe intacte.
+ */
+class InjectTagtoaLauncher
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        try {
+            if (! $this->shouldInject($request, $response)) {
+                return $response;
+            }
+
+            $html = $response->getContent();
+            if (! is_string($html) || stripos($html, '</body>') === false) {
+                return $response;
+            }
+            if (str_contains($html, 'tagtoa-launcher')) {
+                return $response; // déjà injecté
+            }
+
+            $response->setContent(str_ireplace('</body>', $this->button().'</body>', $html));
+        } catch (\Throwable $e) {
+            // jamais casser une page d'admin pour un bouton
+        }
+
+        return $response;
+    }
+
+    /** N'injecte que sur les pages HTML d'admin Biztap, pour un utilisateur connecté. */
+    protected function shouldInject(Request $request, Response $response): bool
+    {
+        if ($request->ajax() || $request->wantsJson()) {
+            return false;
+        }
+        if ($response->getStatusCode() !== 200) {
+            return false;
+        }
+        if (! str_contains((string) $response->headers->get('Content-Type'), 'text/html')) {
+            return false;
+        }
+        if (! ($request->is('sadmin') || $request->is('sadmin/*') || $request->is('admin') || $request->is('admin/*'))) {
+            return false;
+        }
+
+        return auth()->check();
+    }
+
+    /** Le bouton flottant (styles inline pour ne dépendre d'aucun CSS du cœur). */
+    protected function button(): string
+    {
+        $url = e(url('/tagtoa/home'));
+        $label = e(__('Aller sur TAGTOA'));
+
+        return <<<HTML
+<a id="tagtoa-launcher" href="{$url}" title="{$label}"
+   style="position:fixed;right:18px;bottom:18px;z-index:2147483000;display:inline-flex;align-items:center;gap:8px;
+          background:#2cb809;color:#fff;font:600 14px/1 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+          text-decoration:none;padding:12px 16px;border-radius:999px;box-shadow:0 6px 20px rgba(0,0,0,.22)">
+   <span style="font-size:16px">&#8734;</span><span>TAGTOA</span>
+</a>
+HTML;
+    }
+}

--- a/Modules/Tagtoa/app/Providers/TagtoaServiceProvider.php
+++ b/Modules/Tagtoa/app/Providers/TagtoaServiceProvider.php
@@ -16,8 +16,22 @@ class TagtoaServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->overrideAuthViews();
+        $this->registerAdminLauncher();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/migrations'));
         $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'resources/lang'));
+    }
+
+    /**
+     * Ajoute un bouton flottant « TAGTOA » sur les pages d'admin Biztap (/sadmin)
+     * pour accéder au hub TAGTOA. Non invasif (aucune vue du cœur modifiée).
+     */
+    protected function registerAdminLauncher(): void
+    {
+        try {
+            $this->app['router']->pushMiddlewareToGroup('web', \Modules\Tagtoa\App\Http\Middleware\InjectTagtoaLauncher::class);
+        } catch (\Throwable $e) {
+            // sans le bouton, l'admin reste accessible via /tagtoa/home
+        }
     }
 
     /**

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -892,5 +892,6 @@
     "Événements": "Events",
     "à synchroniser": "to sync",
     "— Aucun —": "— None —",
-    "— Aucune —": "— None —"
+    "— Aucune —": "— None —",
+    "Aller sur TAGTOA": "Go to TAGTOA"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -892,5 +892,6 @@
     "Événements": "Eventos",
     "à synchroniser": "por sincronizar",
     "— Aucun —": "— Ninguno —",
-    "— Aucune —": "— Ninguna —"
+    "— Aucune —": "— Ninguna —",
+    "Aller sur TAGTOA": "Ir a TAGTOA"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -892,5 +892,6 @@
     "Événements": "Evènman",
     "à synchroniser": "pou senkronize",
     "— Aucun —": "— Okenn —",
-    "— Aucune —": "— Pa gen —"
+    "— Aucune —": "— Pa gen —",
+    "Aller sur TAGTOA": "Ale sou TAGTOA"
 }


### PR DESCRIPTION
## Problème
Depuis `/sadmin` (admin plateforme Biztap), il n'y a **aucun lien pour aller sur TAGTOA**. La barre latérale `/sadmin` est rendue par le cœur Biztap, dont les vues **ne sont pas dans le dépôt** — on ne peut pas éditer le menu directement.

## Solution (non invasive)
Un **middleware** post-traite la réponse HTML des pages d'admin (`/sadmin*`, `/admin*`) et insère un bouton flottant « TAGTOA » avant `</body>`, pointant vers le hub `/tagtoa/home`. Aucune vue du cœur n'est modifiée ; totalement réversible.

- `InjectTagtoaLauncher` : tolérant (HTML 200 non-AJAX, utilisateur connecté, pages admin uniquement), idempotent, **styles inline** (aucune dépendance au CSS du thème), n'échoue jamais une page d'admin (try/catch).
- Enregistré dans le groupe `web` par `TagtoaServiceProvider` (comme l'override du login).
- Traductions `en/ht/es` pour « Aller sur TAGTOA ».

## Tests
Suite Unit : **115 tests OK** (lint + ViewCompile + RouteIntegrity verts).

## Note
Le founder utilise `/sadmin` pour la gestion plateforme (abonnements, plans, users Biztap) ; le bouton donne un accès rapide au hub marchand TAGTOA sans se déconnecter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_