### PR TITLE
CARD: recharge en ligne de la carte TAGTOA par le titulaire

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Card/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Card/PublicController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\Card;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Models\Card\CardAccount;
+use Modules\Tagtoa\App\Services\Card\CardWalletService;
+use Modules\Tagtoa\App\Services\Pay\CheckoutService;
+use Modules\Tagtoa\App\Support\GatewayManager;
+
+/**
+ * TAGTOA CARD — recharge EN LIGNE par le titulaire (public, pas d'auth).
+ * Le titulaire saisit le code de sa carte + un montant, paie via une passerelle,
+ * et son solde est crédité à la confirmation (idempotent).
+ */
+class PublicController extends Controller
+{
+    public function recharge(Request $request): View
+    {
+        $code = strtoupper(trim((string) $request->query('code', '')));
+        $card = $code !== '' ? app(CardWalletService::class)->resolveByCode($code) : null;
+        $currency = $card?->currency ?: 'HTG';
+
+        return view('tagtoa::card.recharge', [
+            'code'     => $code,
+            'card'     => $card,
+            'gateways' => $this->availableGateways($currency),
+        ]);
+    }
+
+    public function start(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'code'    => ['required', 'string', 'max:40'],
+            'amount'  => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+            'gateway' => ['required', 'string', 'max:20'],
+        ]);
+
+        $card = app(CardWalletService::class)->resolveByCode($data['code']);
+        if (! $card) {
+            return back()->withInput()->with('error', __('Carte TAGTOA introuvable.'));
+        }
+        if (! $card->isSpendable()) {
+            return back()->withInput()->with('error', __('Carte inactive (bloquée ou perdue).'));
+        }
+
+        $gateways = $this->availableGateways($card->currency);
+        if (! array_key_exists($data['gateway'], $gateways)) {
+            return back()->withInput()->with('error', __('Moyen de recharge indisponible pour cette devise.'));
+        }
+
+        $url = app(CheckoutService::class)->startCardTopup($card, (float) $data['amount'], $data['gateway']);
+        if (! $url) {
+            return back()->withInput()->with('error', __('La recharge en ligne n\'a pas pu démarrer. Réessayez.'));
+        }
+
+        return redirect()->away($url);
+    }
+
+    /** Passerelles activées qui acceptent la devise de la carte. */
+    protected function availableGateways(string $currency): array
+    {
+        $c = strtoupper($currency);
+        $support = [
+            'moncash'      => fn () => \Modules\Tagtoa\App\Support\Gateways\MonCash::supportsCurrency($c),
+            'stripe'       => fn () => \Modules\Tagtoa\App\Support\Gateways\Stripe::supportsCurrency($c),
+            'paypal'       => fn () => \Modules\Tagtoa\App\Support\Gateways\PayPal::supportsCurrency($c),
+            'coinpayments' => fn () => $c !== 'HTG', // crypto : uniquement devises fortes
+        ];
+        $labels = [
+            'moncash' => 'MonCash', 'stripe' => __('Carte (VISA/Mastercard)'),
+            'paypal' => 'PayPal', 'coinpayments' => __('Crypto (USDT/BTC…)'),
+        ];
+
+        $out = [];
+        foreach ($support as $driver => $ok) {
+            if (GatewayManager::enabled($driver) && $ok()) {
+                $out[$driver] = $labels[$driver] ?? ucfirst($driver);
+            }
+        }
+
+        return $out;
+    }
+}

--- a/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
+++ b/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
@@ -139,6 +139,35 @@ class CheckoutService
     }
 
     /**
+     * Démarre la RECHARGE EN LIGNE d'une carte TAGTOA (le titulaire recharge son
+     * propre solde via une passerelle). Retourne l'URL de redirection, ou null.
+     */
+    public function startCardTopup(\Modules\Tagtoa\App\Models\Card\CardAccount $card, float $amount, string $gateway): ?string
+    {
+        if ($amount <= 0 || ! GatewayManager::enabled($gateway) || ! $card->isSpendable()) {
+            return null;
+        }
+        $driver = $this->driver($gateway);
+        if (! $driver) {
+            return null;
+        }
+
+        $txn = PayTransaction::create([
+            'tenant_id'  => $card->tenant_id,
+            'gateway'    => $gateway,
+            'reference'  => PayTransaction::generateReference(),
+            'order_type' => 'card_topup',
+            'order_id'   => $card->id,
+            'amount'     => $amount,
+            'currency'   => $card->currency,
+            'status'     => PayTransaction::STATUS_PENDING,
+            'meta'       => ['card_id' => $card->id, 'card_code' => $card->code],
+        ]);
+
+        return $driver->createPayment($txn);
+    }
+
+    /**
      * Démarre le paiement d'un ABONNEMENT (forfait). Retourne l'URL de
      * redirection, ou null si le forfait est gratuit / passerelle indisponible.
      */
@@ -194,6 +223,20 @@ class CheckoutService
 
         if ($txn->order_type === 'pay_page') {
             $this->applyPayPagePaid($txn);
+
+            return;
+        }
+
+        if ($txn->order_type === 'card_topup') {
+            $card = \Modules\Tagtoa\App\Models\Card\CardAccount::find((int) $txn->order_id);
+            if ($card) {
+                // Idempotent : la référence de la transaction verrouille la recharge.
+                app(\Modules\Tagtoa\App\Services\Card\CardWalletService::class)->topUp(
+                    $card,
+                    (float) $txn->amount,
+                    ['reference' => 'topup-'.$txn->reference, 'context_type' => 'online_topup', 'meta' => ['gateway' => $txn->gateway]]
+                );
+            }
 
             return;
         }

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -893,5 +893,17 @@
     "à synchroniser": "to sync",
     "— Aucun —": "— None —",
     "— Aucune —": "— None —",
-    "Aller sur TAGTOA": "Go to TAGTOA"
+    "Aller sur TAGTOA": "Go to TAGTOA",
+    "Recharger ma carte": "Top up my card",
+    "Rechargez le solde de votre carte TAGTOA en ligne. Utilisable partout sur TAGTOA.": "Top up your TAGTOA card balance online. Usable everywhere on TAGTOA.",
+    "Solde actuel": "Current balance",
+    "Code de la carte": "Card code",
+    "Montant à recharger": "Amount to top up",
+    "Moyen de recharge": "Top-up method",
+    "Recharger maintenant": "Top up now",
+    "Aucun moyen de recharge en ligne n'est disponible pour le moment. Rechargez auprès d'un point de vente TAGTOA.": "No online top-up method is available right now. Top up at a TAGTOA point of sale.",
+    "Crypto (USDT/BTC…)": "Crypto (USDT/BTC…)",
+    "Moyen de recharge indisponible pour cette devise.": "Top-up method unavailable for this currency.",
+    "La recharge en ligne n'a pas pu démarrer. Réessayez.": "Online top-up could not start. Try again.",
+    "Lien de recharge en ligne (à partager avec le client)": "Online top-up link (share with the customer)"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -893,5 +893,17 @@
     "à synchroniser": "por sincronizar",
     "— Aucun —": "— Ninguno —",
     "— Aucune —": "— Ninguna —",
-    "Aller sur TAGTOA": "Ir a TAGTOA"
+    "Aller sur TAGTOA": "Ir a TAGTOA",
+    "Recharger ma carte": "Recargar mi tarjeta",
+    "Rechargez le solde de votre carte TAGTOA en ligne. Utilisable partout sur TAGTOA.": "Recarga el saldo de tu tarjeta TAGTOA en línea. Utilizable en todo TAGTOA.",
+    "Solde actuel": "Saldo actual",
+    "Code de la carte": "Código de la tarjeta",
+    "Montant à recharger": "Monto a recargar",
+    "Moyen de recharge": "Medio de recarga",
+    "Recharger maintenant": "Recargar ahora",
+    "Aucun moyen de recharge en ligne n'est disponible pour le moment. Rechargez auprès d'un point de vente TAGTOA.": "No hay medio de recarga en línea disponible por ahora. Recarga en un punto de venta TAGTOA.",
+    "Crypto (USDT/BTC…)": "Cripto (USDT/BTC…)",
+    "Moyen de recharge indisponible pour cette devise.": "Medio de recarga no disponible para esta moneda.",
+    "La recharge en ligne n'a pas pu démarrer. Réessayez.": "La recarga en línea no pudo iniciarse. Inténtalo de nuevo.",
+    "Lien de recharge en ligne (à partager avec le client)": "Enlace de recarga en línea (para compartir con el cliente)"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -893,5 +893,17 @@
     "à synchroniser": "pou senkronize",
     "— Aucun —": "— Okenn —",
     "— Aucune —": "— Pa gen —",
-    "Aller sur TAGTOA": "Ale sou TAGTOA"
+    "Aller sur TAGTOA": "Ale sou TAGTOA",
+    "Recharger ma carte": "Rechaje kat mwen",
+    "Rechargez le solde de votre carte TAGTOA en ligne. Utilisable partout sur TAGTOA.": "Rechaje solde kat TAGTOA ou an liy. Itilizab toupatou sou TAGTOA.",
+    "Solde actuel": "Solde aktyèl",
+    "Code de la carte": "Kòd kat la",
+    "Montant à recharger": "Montan pou rechaje",
+    "Moyen de recharge": "Mwayen rechaj",
+    "Recharger maintenant": "Rechaje kounye a",
+    "Aucun moyen de recharge en ligne n'est disponible pour le moment. Rechargez auprès d'un point de vente TAGTOA.": "Pa gen mwayen rechaj an liy pou kounye a. Rechaje nan yon pwen vant TAGTOA.",
+    "Crypto (USDT/BTC…)": "Crypto (USDT/BTC…)",
+    "Moyen de recharge indisponible pour cette devise.": "Mwayen rechaj pa disponib pou deviz sa a.",
+    "La recharge en ligne n'a pas pu démarrer. Réessayez.": "Rechaj an liy pa t ka kòmanse. Reeseye.",
+    "Lien de recharge en ligne (à partager avec le client)": "Lyen rechaj an liy (pou pataje ak kliyan an)"
 }

--- a/Modules/Tagtoa/resources/views/card/recharge.blade.php
+++ b/Modules/Tagtoa/resources/views/card/recharge.blade.php
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_','-',app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ __('Recharger ma carte') }} · TAGTOA</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <style>
+        body{margin:0;font-family:system-ui,-apple-system,'Segoe UI',sans-serif;background:#f5f7f3;color:#0e140c;min-height:100vh;display:grid;place-items:center;padding:24px}
+        .box{background:#fff;border:1px solid rgba(14,20,12,.1);border-radius:20px;padding:30px 26px;max-width:420px;width:100%;box-shadow:0 12px 40px rgba(0,0,0,.06)}
+        .badge{display:inline-flex;align-items:center;gap:6px;background:rgba(44,184,9,.1);color:#2cb809;font-weight:700;font-size:12px;padding:6px 12px;border-radius:999px;margin-bottom:14px}
+        h1{font-size:21px;margin:0 0 6px}
+        .sub{color:#6b7865;font-size:14px;margin:0 0 20px}
+        label{display:block;font-size:13px;font-weight:600;margin:14px 0 6px}
+        .inp{width:100%;box-sizing:border-box;border:1px solid rgba(14,20,12,.16);border-radius:12px;padding:13px 14px;font-size:16px;background:#fbfcfa}
+        .card-info{background:#f4f6f2;border-radius:12px;padding:12px 14px;margin-bottom:6px;font-size:14px}
+        .gw{display:flex;align-items:center;gap:10px;border:1px solid rgba(14,20,12,.14);border-radius:12px;padding:12px 14px;margin-top:8px;cursor:pointer}
+        .gw input{accent-color:#2cb809}
+        .btn{width:100%;margin-top:18px;background:#2cb809;color:#fff;border:0;border-radius:12px;padding:15px;font-size:16px;font-weight:700;cursor:pointer}
+        .err{background:#fde8e8;color:#a01919;border-radius:12px;padding:12px 14px;font-size:14px;margin-bottom:16px}
+        .none{background:#fff7e8;color:#8a5a00;border-radius:12px;padding:14px;font-size:14px;text-align:center}
+        a.home{display:block;text-align:center;margin-top:16px;color:#6b7865;font-size:13px}
+    </style>
+</head>
+<body>
+    <div class="box">
+        <span class="badge"><i class="fa-solid fa-credit-card"></i> TAGTOA CARD</span>
+        <h1>{{ __('Recharger ma carte') }}</h1>
+        <p class="sub">{{ __('Rechargez le solde de votre carte TAGTOA en ligne. Utilisable partout sur TAGTOA.') }}</p>
+
+        @if(session('error'))<div class="err"><i class="fa-solid fa-circle-exclamation"></i> {{ session('error') }}</div>@endif
+
+        @if($card)
+            <div class="card-info">
+                <b>{{ $card->code }}</b> — {{ __('Solde actuel') }} : <b>{{ $card->balance_label }}</b>
+            </div>
+        @endif
+
+        <form method="POST" action="{{ route('tagtoa.card.recharge.start') }}">
+            @csrf
+            <label>{{ __('Code de la carte') }} *</label>
+            <input class="inp" name="code" value="{{ old('code', $code) }}" placeholder="TAG..." style="text-transform:uppercase" required @if($card) readonly @endif>
+
+            <label>{{ __('Montant à recharger') }} ({{ $card?->currency ?: 'HTG' }}) *</label>
+            <input class="inp" name="amount" type="number" step="0.01" min="0.01" value="{{ old('amount') }}" placeholder="0.00" required>
+
+            @if(count($gateways) > 0)
+                <label>{{ __('Moyen de recharge') }} *</label>
+                @foreach($gateways as $driver => $lbl)
+                    <label class="gw"><input type="radio" name="gateway" value="{{ $driver }}" @checked($loop->first)> {{ $lbl }}</label>
+                @endforeach
+                <button class="btn" type="submit"><i class="fa-solid fa-bolt"></i> {{ __('Recharger maintenant') }}</button>
+            @else
+                <div class="none" style="margin-top:16px"><i class="fa-solid fa-circle-info"></i> {{ __('Aucun moyen de recharge en ligne n\'est disponible pour le moment. Rechargez auprès d\'un point de vente TAGTOA.') }}</div>
+            @endif
+        </form>
+
+        <a class="home" href="{{ url('/') }}">{{ __('Retour à l\'accueil') }}</a>
+    </div>
+</body>
+</html>

--- a/Modules/Tagtoa/resources/views/card/show.blade.php
+++ b/Modules/Tagtoa/resources/views/card/show.blade.php
@@ -25,6 +25,14 @@
             @else<span class="pill n" style="opacity:.7">{{ __('Perdue') }}</span>@endif
         </div>
     </div>
+    @php $rechargeUrl = route('tagtoa.card.recharge').'?code='.urlencode($card->code); @endphp
+    <div style="margin-top:16px;padding-top:14px;border-top:1px solid var(--line,#eee)">
+        <div style="font-size:12px;color:var(--muted);margin-bottom:6px">{{ __('Lien de recharge en ligne (à partager avec le client)') }}</div>
+        <div style="display:flex;gap:8px;align-items:center">
+            <input class="inp" value="{{ $rechargeUrl }}" readonly onclick="this.select()" style="flex:1">
+            <a href="{{ $rechargeUrl }}" target="_blank" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-up-right-from-square"></i></a>
+        </div>
+    </div>
 </div>
 
 <div class="card">

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -38,6 +38,9 @@ Route::get('/pay/{alias}', [PayPublic::class, 'show'])->name('tagtoa.pay.show');
 Route::get('/pay/{alias}/checkout/{method}', [PayPublic::class, 'checkout'])->name('tagtoa.pay.checkout');
 // Paiement par CARTE TAGTOA (closed-loop) : tap NFC/UID + PIN → débit instantané.
 Route::post('/pay/{alias}/card/charge', [PayPublic::class, 'cardCharge'])->middleware('throttle:20,1')->name('tagtoa.pay.card.charge');
+// Recharge EN LIGNE d'une carte TAGTOA par le titulaire (public).
+Route::get('/card/recharge', [\Modules\Tagtoa\App\Http\Controllers\Card\PublicController::class, 'recharge'])->name('tagtoa.card.recharge');
+Route::post('/card/recharge', [\Modules\Tagtoa\App\Http\Controllers\Card\PublicController::class, 'start'])->middleware('throttle:20,1')->name('tagtoa.card.recharge.start');
 // Paiement en ligne via passerelle API (MonCash…). Public.
 Route::get('/pay/result', [\Modules\Tagtoa\App\Http\Controllers\Pay\CheckoutController::class, 'result'])->name('tagtoa.pay.result');
 Route::get('/pay/checkout/{gateway}/{type}/{orderId}', [\Modules\Tagtoa\App\Http\Controllers\Pay\CheckoutController::class, 'start'])->middleware('throttle:30,1')->name('tagtoa.pay.online.start');


### PR DESCRIPTION
## Objectif
Permettre au **titulaire** de recharger lui-même le solde de sa carte TAGTOA **en ligne** (option 2 demandée).

## Flux
1. `/card/recharge?code=TAGxxx` — le titulaire saisit le code de sa carte + un montant, choisit une passerelle.
2. `startCardTopup()` crée une transaction `card_topup` et redirige vers la passerelle.
3. À la confirmation (return/webhook générique existant), `applyPaid('card_topup')` crédite le solde via `CardWalletService::topUp` **idempotent** (référence `topup-<txn>` → jamais de double crédit).

## Détails
- **Passerelles filtrées par devise** : MonCash → HTG ; Stripe/PayPal → devises fortes ; crypto → non-HTG. N'affiche que les passerelles **activées** (identifiants présents). Si aucune → message clair (recharge en point de vente).
- **Page publique autonome** (styles inline, multilingue), badge TAGTOA CARD, solde actuel affiché si le code est reconnu.
- **Dashboard carte** : lien de recharge partageable (`/card/recharge?code=…`) à imprimer/envoyer au client.
- Traductions `en/ht/es`.

## Tests
Suite Unit : **115 tests OK** (ViewCompile compile la nouvelle page ; RouteIntegrity valide les nouvelles routes).

## Note
Pour l'instant, la recharge en ligne concrète nécessite une passerelle activée (MonCash pour les cartes HTG). Sans identifiants, la page invite à recharger en point de vente — aucun échec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_