### PR TITLE
EVENT: paiement d'une commande de billets en ligne par Carte TAGTOA

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Event/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/PublicController.php
@@ -99,6 +99,65 @@ class PublicController extends Controller
         return view('tagtoa::event.order', ['order' => $order, 'event' => $order->event]);
     }
 
+    /**
+     * Paiement d'une commande de billets EN LIGNE par CARTE TAGTOA (closed-loop) :
+     * l'acheteur saisit le code de sa carte + PIN, on débite le total exact, on
+     * marque la commande payée et on émet les billets. Idempotent.
+     */
+    public function cardPay(Request $request, string $reference): RedirectResponse
+    {
+        $order = Order::where('reference', $reference)->with('event')->firstOrFail();
+        $event = $order->event;
+
+        if ($order->isPaid()) {
+            return redirect()->route('tagtoa.event.order', $order->reference);
+        }
+
+        $data = $request->validate([
+            'card_code' => ['nullable', 'string', 'max:40'],
+            'card_uid'  => ['nullable', 'string', 'max:120'],
+            'pin'       => ['nullable', 'string', 'max:6'],
+        ]);
+        if (empty($data['card_code']) && empty($data['card_uid'])) {
+            return back()->with('error', __('Tapez la carte ou saisissez son code.'));
+        }
+
+        $svc = app(\Modules\Tagtoa\App\Services\Card\CardWalletService::class);
+        $card = ! empty($data['card_uid'])
+            ? $svc->resolveByUid($data['card_uid'])
+            : $svc->resolveByCode((string) $data['card_code']);
+
+        if (! $card) {
+            return back()->with('error', __('Carte TAGTOA introuvable.'));
+        }
+        if (strtoupper((string) $card->currency) !== strtoupper((string) $order->currency)) {
+            return back()->with('error', __('La devise de la carte ne correspond pas à celle de la commande.'));
+        }
+
+        $res = $svc->charge($card, (float) $order->total, $data['pin'] ?? null, [
+            'tenant_id'       => $event->tenant_id,
+            'context_type'    => 'event',
+            'context_id'      => $order->id,
+            'module'          => 'event',
+            'reference'       => 'evorder-'.$order->reference,
+            'skip_commission' => true, // la commission est prise sur la commande (event_order)
+        ]);
+
+        if (! $res['ok']) {
+            return back()->with('error', $res['message']);
+        }
+
+        // Débit accepté → on encaisse la commande + émet les billets (idempotent).
+        if (! $order->isPaid()) {
+            $this->tickets->markPaid($order, 'tagtoa_card');
+            $this->revenue->record('event_order', $order->id, 'event', (float) $order->total, $event->tenant_id, $order->currency);
+            $this->notifyBuyer($event, $order->fresh(['tickets']));
+        }
+
+        return redirect()->route('tagtoa.event.order', $order->reference)
+            ->with('card_paid', __('Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.'));
+    }
+
     public function ticket(string $code): View
     {
         $ticket = Ticket::where('code', $code)->with(['event', 'ticketType'])->firstOrFail();

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -905,5 +905,13 @@
     "Crypto (USDT/BTC…)": "Crypto (USDT/BTC…)",
     "Moyen de recharge indisponible pour cette devise.": "Top-up method unavailable for this currency.",
     "La recharge en ligne n'a pas pu démarrer. Réessayez.": "Online top-up could not start. Try again.",
-    "Lien de recharge en ligne (à partager avec le client)": "Online top-up link (share with the customer)"
+    "Lien de recharge en ligne (à partager avec le client)": "Online top-up link (share with the customer)",
+    "Payer avec ma Carte TAGTOA": "Pay with my TAGTOA Card",
+    "Tapez votre carte ou saisissez son code + PIN. Débité :": "Tap your card or enter its code + PIN. Charged:",
+    "ou code TAG…": "or TAG code…",
+    "Payer avec la carte": "Pay with the card",
+    "NFC non supporté. Saisissez le code.": "NFC not supported. Enter the code.",
+    "Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.": "Payment accepted by TAGTOA Card. Your tickets are confirmed.",
+    "La devise de la carte ne correspond pas à celle de la commande.": "The card currency does not match the order currency.",
+    "UID (auto)": "UID (auto)"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -905,5 +905,13 @@
     "Crypto (USDT/BTC…)": "Cripto (USDT/BTC…)",
     "Moyen de recharge indisponible pour cette devise.": "Medio de recarga no disponible para esta moneda.",
     "La recharge en ligne n'a pas pu démarrer. Réessayez.": "La recarga en línea no pudo iniciarse. Inténtalo de nuevo.",
-    "Lien de recharge en ligne (à partager avec le client)": "Enlace de recarga en línea (para compartir con el cliente)"
+    "Lien de recharge en ligne (à partager avec le client)": "Enlace de recarga en línea (para compartir con el cliente)",
+    "Payer avec ma Carte TAGTOA": "Pagar con mi Tarjeta TAGTOA",
+    "Tapez votre carte ou saisissez son code + PIN. Débité :": "Acerca tu tarjeta o ingresa su código + PIN. Cargo:",
+    "ou code TAG…": "o código TAG…",
+    "Payer avec la carte": "Pagar con la tarjeta",
+    "NFC non supporté. Saisissez le code.": "NFC no soportado. Ingresa el código.",
+    "Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.": "Pago aceptado con Tarjeta TAGTOA. Tus boletos están confirmados.",
+    "La devise de la carte ne correspond pas à celle de la commande.": "La moneda de la tarjeta no coincide con la del pedido.",
+    "UID (auto)": "UID (auto)"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -905,5 +905,13 @@
     "Crypto (USDT/BTC…)": "Crypto (USDT/BTC…)",
     "Moyen de recharge indisponible pour cette devise.": "Mwayen rechaj pa disponib pou deviz sa a.",
     "La recharge en ligne n'a pas pu démarrer. Réessayez.": "Rechaj an liy pa t ka kòmanse. Reeseye.",
-    "Lien de recharge en ligne (à partager avec le client)": "Lyen rechaj an liy (pou pataje ak kliyan an)"
+    "Lien de recharge en ligne (à partager avec le client)": "Lyen rechaj an liy (pou pataje ak kliyan an)",
+    "Payer avec ma Carte TAGTOA": "Peye ak Kat TAGTOA mwen",
+    "Tapez votre carte ou saisissez son code + PIN. Débité :": "Tape kat ou oswa antre kòd + PIN li. Debite :",
+    "ou code TAG…": "oswa kòd TAG…",
+    "Payer avec la carte": "Peye ak kat la",
+    "NFC non supporté. Saisissez le code.": "NFC pa sipòte. Antre kòd la.",
+    "Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.": "Peman aksepte ak Kat TAGTOA. Biyè ou yo konfime.",
+    "La devise de la carte ne correspond pas à celle de la commande.": "Deviz kat la pa koresponn ak deviz kòmand lan.",
+    "UID (auto)": "UID (otomatik)"
 }

--- a/Modules/Tagtoa/resources/views/event/order.blade.php
+++ b/Modules/Tagtoa/resources/views/event/order.blade.php
@@ -23,8 +23,31 @@
 <body>
 <div class="wrap">
     <div class="ok"><i class="fa-solid fa-circle-check"></i><h1>{{ $order->isPaid() ? __('Billets confirmés!') : __('Commande créée') }}</h1><p>{{ __('Référence') }} : <b>{{ $order->reference }}</b></p></div>
-    @if(! $order->isPaid() && $event->payPage)
-        <a class="pay" href="{{ url('/pay/'.$event->payPage->alias) }}"><i class="fa-solid fa-credit-card"></i> {{ __('Payer') }} {{ number_format($order->total,2) }} {{ $order->currency }}</a>
+    @if(session('card_paid'))
+        <div style="background:#eef9e8;border:1px solid var(--green);border-radius:14px;padding:14px;margin:14px 0;text-align:center;font-weight:600"><i class="fa-solid fa-circle-check"></i> {{ session('card_paid') }}</div>
+    @endif
+    @if(session('error'))
+        <div style="background:#fde8e8;color:#a01919;border-radius:14px;padding:12px 14px;margin:14px 0;font-size:14px"><i class="fa-solid fa-circle-exclamation"></i> {{ session('error') }}</div>
+    @endif
+    @if(! $order->isPaid())
+        @if($event->payPage)
+            <a class="pay" href="{{ url('/pay/'.$event->payPage->alias) }}"><i class="fa-solid fa-credit-card"></i> {{ __('Payer') }} {{ number_format($order->total,2) }} {{ $order->currency }}</a>
+        @endif
+        <form method="POST" action="{{ route('tagtoa.event.order.card', $order->reference) }}" style="background:rgba(44,184,9,.06);border-radius:14px;padding:16px;margin:12px 0">
+            @csrf
+            <b style="font-family:var(--fh);display:block;margin-bottom:4px"><i class="fa-solid fa-id-card" style="color:var(--green)"></i> {{ __('Payer avec ma Carte TAGTOA') }}</b>
+            <p style="color:#6b7865;font-size:13px;margin:0 0 10px">{{ __('Tapez votre carte ou saisissez son code + PIN. Débité :') }} <b>{{ number_format($order->total,2) }} {{ $order->currency }}</b></p>
+            <div style="display:flex;gap:8px;margin-bottom:8px">
+                <input id="evCardUid" name="card_uid" placeholder="{{ __('UID (auto)') }}" readonly style="flex:1;border:1px solid rgba(14,20,12,.16);border-radius:10px;padding:11px 12px;font-size:15px;background:#fbfcfa">
+                <button type="button" onclick="evReadCard()" style="flex:0;border:1px solid var(--green);background:#fff;color:var(--green);border-radius:10px;padding:0 14px;font-weight:600"><i class="fa-solid fa-wifi"></i></button>
+            </div>
+            <input name="card_code" placeholder="{{ __('ou code TAG…') }}" style="width:100%;box-sizing:border-box;border:1px solid rgba(14,20,12,.16);border-radius:10px;padding:11px 12px;font-size:15px;text-transform:uppercase;margin-bottom:8px">
+            <input name="pin" inputmode="numeric" maxlength="6" placeholder="{{ __('PIN') }}" style="width:100%;box-sizing:border-box;border:1px solid rgba(14,20,12,.16);border-radius:10px;padding:11px 12px;font-size:15px;margin-bottom:10px">
+            <button type="submit" style="width:100%;background:var(--green);color:#fff;border:0;border-radius:12px;padding:14px;font-weight:700;font-size:15px"><i class="fa-solid fa-bolt"></i> {{ __('Payer avec la carte') }}</button>
+        </form>
+        <script>
+        function evReadCard(){if(!('NDEFReader' in window)){alert('{{ __('NFC non supporté. Saisissez le code.') }}');return;}try{var r=new NDEFReader();r.scan().then(function(){r.onreading=function(e){if(e.serialNumber){document.getElementById('evCardUid').value=e.serialNumber;}};}).catch(function(){});}catch(x){}}
+        </script>
     @endif
     <div class="summary">
         <div class="kv"><span>{{ __('Acheteur') }}</span><b>{{ $order->buyer_name }}</b></div>

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -55,6 +55,8 @@ Route::get('/store/{alias}', [\Modules\Tagtoa\App\Http\Controllers\Store\PublicC
 Route::get('/events', [EventPublic::class, 'index'])->name('tagtoa.events.index');
 Route::get('/event/{alias}', [EventPublic::class, 'show'])->name('tagtoa.event.show');
 Route::get('/event/order/{reference}', [EventPublic::class, 'order'])->name('tagtoa.event.order');
+// Paiement d'une commande de billets par Carte TAGTOA (closed-loop).
+Route::post('/event/order/{reference}/card-pay', [EventPublic::class, 'cardPay'])->middleware('throttle:20,1')->name('tagtoa.event.order.card');
 Route::get('/event/ticket/{code}', [EventPublic::class, 'ticket'])->name('tagtoa.event.ticket');
 Route::get('/event/wallet/receipt/{reference}', [EventPublic::class, 'walletReceipt'])->name('tagtoa.event.wallet.receipt');
 Route::get('/book/{alias}', [BookingPublic::class, 'show'])->name('tagtoa.booking.show');


### PR DESCRIPTION
## Objectif
Permettre à un acheteur **en ligne** de régler sa commande de billets avec sa **Carte TAGTOA** (closed-loop), directement depuis la page de commande (option 1 demandée). Complète la vente par carte au terminal staff (déjà en place).

## Flux
- Sur une commande **non payée**, un formulaire « Payer avec ma Carte TAGTOA » (tap NFC via Web NFC, ou code + PIN) apparaît à côté du lien vers la page de paiement.
- `cardPay()` débite le **total exact** de la carte → `markPaid` + `RevenueService` + notification acheteur (mêmes étapes que le flux MonCash en ligne existant).

## Garanties
- **Devise** : la carte doit être dans la même devise que la commande (sinon refus clair).
- **Idempotent** : référence `evorder-<ref>` → un double envoi ne débite/paie qu'une fois ; `markPaid` re-garde sur `isPaid`.
- **Pas de double commission** : `skip_commission` sur le débit carte ; la commission est prise une seule fois sur `event_order`.
- Anti-fraude carte : statut actif, PIN bcrypt, solde suffisant (débit atomique `lockForUpdate`).

## Tests
Suite Unit : **115 tests OK** (ViewCompile compile la page commande modifiée ; RouteIntegrity valide la nouvelle route).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_