### PR TITLE
LANDING: Carte TAGTOA en vedette + performance (chargement des assets)

### DIFF
--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -913,5 +913,16 @@
     "NFC non supporté. Saisissez le code.": "NFC not supported. Enter the code.",
     "Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.": "Payment accepted by TAGTOA Card. Your tickets are confirmed.",
     "La devise de la carte ne correspond pas à celle de la commande.": "The card currency does not match the order currency.",
-    "UID (auto)": "UID (auto)"
+    "UID (auto)": "UID (auto)",
+    "La Carte TAGTOA, votre monnaie": "The TAGTOA Card, your currency",
+    "Une carte NFC prépayée : vos clients rechargent et paient partout sur TAGTOA, sans cash.": "A prepaid NFC card: your customers top up and pay everywhere on TAGTOA, cash-free.",
+    "Carte NFC prépayée closed-loop : rechargez, tapez, payez partout sur TAGTOA.": "Closed-loop prepaid NFC card: top up, tap, pay everywhere on TAGTOA.",
+    "Payé — nouveau solde 750 HTG": "Paid — new balance 750 HTG",
+    "Tap NFC": "NFC tap",
+    "Sans cash": "Cash-free",
+    "Votre propre carte prépayée, acceptée partout": "Your own prepaid card, accepted everywhere",
+    "Une carte NFC « closed-loop » qui porte un solde utilisable chez tous vos points de vente TAGTOA. Le client recharge, tape sa carte, et paie en une seconde — sans espèces, sans réseau externe.": "A closed-loop NFC card carrying a balance usable at all your TAGTOA points of sale. The customer tops up, taps the card, and pays in a second — no cash, no external network.",
+    "Rechargeable en ligne ou en point de vente": "Top up online or at a point of sale",
+    "Valable sur boutique, menu, événements et caisse": "Works on shop, menu, events and POS",
+    "Sécurisée par PIN, anti-fraude, solde protégé": "PIN-secured, anti-fraud, protected balance"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -913,5 +913,16 @@
     "NFC non supporté. Saisissez le code.": "NFC no soportado. Ingresa el código.",
     "Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.": "Pago aceptado con Tarjeta TAGTOA. Tus boletos están confirmados.",
     "La devise de la carte ne correspond pas à celle de la commande.": "La moneda de la tarjeta no coincide con la del pedido.",
-    "UID (auto)": "UID (auto)"
+    "UID (auto)": "UID (auto)",
+    "La Carte TAGTOA, votre monnaie": "La Tarjeta TAGTOA, tu moneda",
+    "Une carte NFC prépayée : vos clients rechargent et paient partout sur TAGTOA, sans cash.": "Una tarjeta NFC prepago: tus clientes recargan y pagan en todo TAGTOA, sin efectivo.",
+    "Carte NFC prépayée closed-loop : rechargez, tapez, payez partout sur TAGTOA.": "Tarjeta NFC prepago closed-loop: recarga, acerca, paga en todo TAGTOA.",
+    "Payé — nouveau solde 750 HTG": "Pagado — nuevo saldo 750 HTG",
+    "Tap NFC": "Toque NFC",
+    "Sans cash": "Sin efectivo",
+    "Votre propre carte prépayée, acceptée partout": "Tu propia tarjeta prepago, aceptada en todas partes",
+    "Une carte NFC « closed-loop » qui porte un solde utilisable chez tous vos points de vente TAGTOA. Le client recharge, tape sa carte, et paie en une seconde — sans espèces, sans réseau externe.": "Una tarjeta NFC «closed-loop» con un saldo utilizable en todos tus puntos de venta TAGTOA. El cliente recarga, acerca su tarjeta y paga en un segundo — sin efectivo, sin red externa.",
+    "Rechargeable en ligne ou en point de vente": "Recargable en línea o en punto de venta",
+    "Valable sur boutique, menu, événements et caisse": "Válida en tienda, menú, eventos y caja",
+    "Sécurisée par PIN, anti-fraude, solde protégé": "Protegida con PIN, antifraude, saldo protegido"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -913,5 +913,16 @@
     "NFC non supporté. Saisissez le code.": "NFC pa sipòte. Antre kòd la.",
     "Paiement accepté par Carte TAGTOA. Vos billets sont confirmés.": "Peman aksepte ak Kat TAGTOA. Biyè ou yo konfime.",
     "La devise de la carte ne correspond pas à celle de la commande.": "Deviz kat la pa koresponn ak deviz kòmand lan.",
-    "UID (auto)": "UID (otomatik)"
+    "UID (auto)": "UID (otomatik)",
+    "La Carte TAGTOA, votre monnaie": "Kat TAGTOA a, lajan ou",
+    "Une carte NFC prépayée : vos clients rechargent et paient partout sur TAGTOA, sans cash.": "Yon kat NFC prépeye : kliyan ou yo rechaje epi peye toupatou sou TAGTOA, san kach.",
+    "Carte NFC prépayée closed-loop : rechargez, tapez, payez partout sur TAGTOA.": "Kat NFC prépeye closed-loop : rechaje, tape, peye toupatou sou TAGTOA.",
+    "Payé — nouveau solde 750 HTG": "Peye — nouvo solde 750 HTG",
+    "Tap NFC": "Tap NFC",
+    "Sans cash": "San kach",
+    "Votre propre carte prépayée, acceptée partout": "Pwòp kat prépeye pa ou, aksepte toupatou",
+    "Une carte NFC « closed-loop » qui porte un solde utilisable chez tous vos points de vente TAGTOA. Le client recharge, tape sa carte, et paie en une seconde — sans espèces, sans réseau externe.": "Yon kat NFC « closed-loop » ki pote yon solde ou ka itilize nan tout pwen vant TAGTOA ou yo. Kliyan an rechaje, tape kat li, epi peye nan yon segond — san lajan kach, san rezo deyò.",
+    "Rechargeable en ligne ou en point de vente": "Rechajab an liy oswa nan yon pwen vant",
+    "Valable sur boutique, menu, événements et caisse": "Valab sou boutik, menu, evènman ak kès",
+    "Sécurisée par PIN, anti-fraude, solde protégé": "Sekirize ak PIN, anti-frod, solde pwoteje"
 }

--- a/Modules/Tagtoa/resources/views/landing.blade.php
+++ b/Modules/Tagtoa/resources/views/landing.blade.php
@@ -6,6 +6,7 @@
         ['fa-bolt',     'Transformez chaque tap en vente',          'Site, menu, paiements et fidélité réunis — un seul tap NFC, un seul QR.'],
         ['fa-bag-shopping', 'Votre boutique WhatsApp en 2 minutes',  'Créez une boutique en ligne gratuite et vendez directement sur WhatsApp.'],
         ['fa-money-bill-transfer', 'Encaissez partout, instantanément', 'MonCash, NatCash, cartes, PayPal et crypto — l\'argent arrive en quelques secondes.'],
+        ['fa-credit-card', 'La Carte TAGTOA, votre monnaie', 'Une carte NFC prépayée : vos clients rechargent et paient partout sur TAGTOA, sans cash.'],
     ];
     $services = [
         ['fa-bag-shopping',        'Boutique WhatsApp', 'Vendez en ligne et recevez vos commandes directement sur WhatsApp.', $store, true],
@@ -17,6 +18,7 @@
         ['fa-ticket',              'Événements',   'Billetterie en ligne + contrôle d\'accès NFC/QR à l\'entrée.', url('/event/demo-concert'), false],
         ['fa-calendar-check',      'Réservations', 'Prise de rendez-vous en ligne : prestations, créneaux, confirmation.', url('/book/demo-booking'), false],
         ['fa-cash-register',       'Caisse POS',   'Caisse tactile hors-ligne installable, multi-paiement, rapports.', url('/login'), false],
+        ['fa-credit-card',         'Carte TAGTOA', 'Carte NFC prépayée closed-loop : rechargez, tapez, payez partout sur TAGTOA.', url('/pay/demo'), false],
     ];
     $methods = [
         ['fa-mobile-screen-button','MonCash','#E2001A'], ['fa-mobile-screen','NatCash','#00A859'],
@@ -35,8 +37,12 @@
     <meta name="description" content="{{ __('Site web, boutique WhatsApp, menu, paiements, fidélité et caisse — NFC & QR. La plateforme digitale des entrepreneurs haïtiens.') }}">
     <meta name="theme-color" content="#2cb809">
     <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Anton&family=Space+Grotesk:wght@500;600;700&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
+    {{-- Font Awesome chargé sans bloquer le rendu (les icônes apparaissent juste après le texte) --}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" media="print" onload="this.media='all'">
+    <noscript><link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"></noscript>
     <style>
         :root{
             /* 90% noir & blanc — accents #2cb809 uniquement (boutons + touches de style) */
@@ -298,7 +304,7 @@
 
 <section><div class="wrap">
     <div class="statsrow">
-        <div class="st reveal"><div class="n">9</div><div class="k">{{ __('outils en un') }}</div></div>
+        <div class="st reveal"><div class="n">10</div><div class="k">{{ __('outils en un') }}</div></div>
         <div class="st reveal d1"><div class="n">10+</div><div class="k">{{ __('méthodes de paiement') }}</div></div>
         <div class="st reveal d2"><div class="n">2 min</div><div class="k">{{ __('pour démarrer') }}</div></div>
         <div class="st reveal d3"><div class="n">24/7</div><div class="k">{{ __('disponible') }}</div></div>
@@ -437,6 +443,25 @@
                 <li><i class="fa-solid fa-check"></i> {{ __('Analytics : revenus, ventes, visites') }}</li>
                 <li><i class="fa-solid fa-check"></i> {{ __('CRM : base clients automatique') }}</li>
                 <li><i class="fa-solid fa-check"></i> {{ __('Avis clients, stock et journal d\'audit') }}</li>
+            </ul>
+        </div>
+    </div>
+
+    {{-- Carte TAGTOA (closed-loop) --}}
+    <div class="feat-row rev reveal">
+        <div class="fviz">
+            <div class="fprod"><div class="fph"><i class="fa-solid fa-id-card"></i></div><div><div class="fpn">{{ __('Carte TAGTOA') }}</div><div class="fpp">{{ __('Solde') }} : 1,000 HTG</div></div></div>
+            <div class="fbub out" style="margin-top:6px"><i class="fa-solid fa-bolt"></i> {{ __('Payé — nouveau solde 750 HTG') }}</div>
+            <div class="fkpi" style="margin-top:6px"><div class="k">{{ __('Tap NFC') }} <b>0.4s</b></div><div class="k">{{ __('Sans cash') }} <b>100%</b></div></div>
+        </div>
+        <div>
+            <span class="ftag"><i class="fa-solid fa-credit-card"></i> {{ __('Carte TAGTOA') }}</span>
+            <h3>{{ __('Votre propre carte prépayée, acceptée partout') }}</h3>
+            <p>{{ __('Une carte NFC « closed-loop » qui porte un solde utilisable chez tous vos points de vente TAGTOA. Le client recharge, tape sa carte, et paie en une seconde — sans espèces, sans réseau externe.') }}</p>
+            <ul class="flist">
+                <li><i class="fa-solid fa-check"></i> {{ __('Rechargeable en ligne ou en point de vente') }}</li>
+                <li><i class="fa-solid fa-check"></i> {{ __('Valable sur boutique, menu, événements et caisse') }}</li>
+                <li><i class="fa-solid fa-check"></i> {{ __('Sécurisée par PIN, anti-fraude, solde protégé') }}</li>
             </ul>
         </div>
     </div>


### PR DESCRIPTION
## Marketing
- **Section vedette « Carte TAGTOA »** — la carte NFC prépayée closed-loop (votre monnaie acceptée partout sur TAGTOA). C'est le différenciateur le plus unique du produit et il manquait totalement à la vitrine. Ajoutée en : section détaillée (feature-row), carrousel héro, grille des outils (**10 outils**), et stats.
- Traductions `en/ht/es` pour tous les nouveaux textes.

## Performance — réponse au « pourquoi le site est lent à s'afficher »
Ce n'est **ni le VPS ni la logique de l'app** : les **polices Google Fonts** et **Font Awesome** sont chargées depuis des CDN externes (`fonts.gstatic.com`, `cdnjs.cloudflare.com`) et **bloquaient le premier rendu**, surtout depuis Haïti (latence + résolution DNS).

Corrections :
- `preconnect` vers `gstatic` et `cdnjs` (ouvre les connexions plus tôt).
- Font Awesome chargé **sans bloquer le rendu** (`media="print"` → `onload="this.media='all'"`) avec repli `<noscript>`.
- Nunito réduit de 5 à 3 graisses (moins à télécharger).

Résultat : le **texte s'affiche immédiatement**, les icônes suivent une fraction de seconde après.

> Piste suivante possible (non incluse ici) : héberger Font Awesome en local (« assets souverains », comme le scanner html5-qrcode en PR #66) pour supprimer toute dépendance CDN — plus gros changement (fichiers webfonts).

## Tests
Suite Unit : **115 tests OK** (ViewCompile compile la landing modifiée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_