### PR TITLE
FIX: 503 sur /plan/subscribe (passerelles fail-fast + GET défensif)

### DIFF
--- a/Modules/Tagtoa/app/Support/Gateways/CoinPaymentsDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/CoinPaymentsDriver.php
@@ -81,7 +81,7 @@ class CoinPaymentsDriver implements GatewayDriver
     protected function call(array $payload): ?array
     {
         try {
-            $res = Http::asForm()->acceptJson()->timeout(20)
+            $res = Http::asForm()->acceptJson()->connectTimeout(5)->timeout(10)
                 ->withHeaders(['HMAC' => CoinPayments::sign($payload, $this->privateKey)])
                 ->post(CoinPayments::API_URL, $payload);
 

--- a/Modules/Tagtoa/app/Support/Gateways/MonCashDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/MonCashDriver.php
@@ -41,7 +41,7 @@ class MonCashDriver implements GatewayDriver
 
         try {
             $res = Http::withToken($token)->acceptJson()->asJson()
-                ->timeout(20)
+                ->connectTimeout(5)->timeout(10)
                 ->post(MonCash::apiBase($this->mode).'/v1/CreatePayment', [
                     'amount'  => MonCash::amount($txn->amount),
                     'orderId' => $txn->reference,
@@ -71,7 +71,7 @@ class MonCashDriver implements GatewayDriver
 
         try {
             $res = Http::withToken($token)->acceptJson()->asJson()
-                ->timeout(20)
+                ->connectTimeout(5)->timeout(10)
                 ->post(MonCash::apiBase($this->mode).'/v1/RetrieveTransactionPayment', [
                     'orderId' => $txn->reference,
                 ]);
@@ -104,7 +104,7 @@ class MonCashDriver implements GatewayDriver
 
         try {
             $res = Http::withBasicAuth($this->clientId, $this->secret)
-                ->asForm()->acceptJson()->timeout(20)
+                ->asForm()->acceptJson()->connectTimeout(5)->timeout(10)
                 ->post(MonCash::apiBase($this->mode).'/oauth/token', [
                     'scope'      => 'read,write',
                     'grant_type' => 'client_credentials',

--- a/Modules/Tagtoa/app/Support/Gateways/PayPalDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/PayPalDriver.php
@@ -38,7 +38,7 @@ class PayPalDriver implements GatewayDriver
         }
 
         try {
-            $res = Http::withToken($token)->acceptJson()->asJson()->timeout(20)
+            $res = Http::withToken($token)->acceptJson()->asJson()->connectTimeout(5)->timeout(10)
                 ->post(PayPal::apiBase($this->mode).'/v2/checkout/orders', [
                     'intent'         => 'CAPTURE',
                     'purchase_units' => [[
@@ -82,13 +82,13 @@ class PayPalDriver implements GatewayDriver
         $base = PayPal::apiBase($this->mode);
 
         try {
-            $res = Http::withToken($token)->acceptJson()->timeout(20)
+            $res = Http::withToken($token)->acceptJson()->connectTimeout(5)->timeout(10)
                 ->get($base.'/v2/checkout/orders/'.$txn->gateway_ref);
             $status = $res->json('status');
 
             // Approuvé par le payeur → on capture pour encaisser.
             if (strtoupper((string) $status) === 'APPROVED') {
-                $cap = Http::withToken($token)->acceptJson()->asJson()->timeout(20)
+                $cap = Http::withToken($token)->acceptJson()->asJson()->connectTimeout(5)->timeout(10)
                     ->post($base.'/v2/checkout/orders/'.$txn->gateway_ref.'/capture', new \stdClass);
                 $status = $cap->json('status', $status);
             }
@@ -127,7 +127,7 @@ class PayPalDriver implements GatewayDriver
 
         try {
             $res = Http::withBasicAuth($this->clientId, $this->secret)
-                ->asForm()->acceptJson()->timeout(20)
+                ->asForm()->acceptJson()->connectTimeout(5)->timeout(10)
                 ->post(PayPal::apiBase($this->mode).'/v1/oauth2/token', [
                     'grant_type' => 'client_credentials',
                 ]);

--- a/Modules/Tagtoa/app/Support/Gateways/StripeDriver.php
+++ b/Modules/Tagtoa/app/Support/Gateways/StripeDriver.php
@@ -49,7 +49,7 @@ class StripeDriver implements GatewayDriver
         ];
 
         try {
-            $res = Http::withToken($this->secret)->asForm()->acceptJson()->timeout(20)
+            $res = Http::withToken($this->secret)->asForm()->acceptJson()->connectTimeout(5)->timeout(10)
                 ->post(Stripe::API_BASE.'/v1/checkout/sessions', $params);
 
             $id = $res->json('id');
@@ -75,7 +75,7 @@ class StripeDriver implements GatewayDriver
         }
 
         try {
-            $res = Http::withToken($this->secret)->acceptJson()->timeout(20)
+            $res = Http::withToken($this->secret)->acceptJson()->connectTimeout(5)->timeout(10)
                 ->get(Stripe::API_BASE.'/v1/checkout/sessions/'.$txn->gateway_ref);
 
             if (! $res->successful()) {

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -277,6 +277,8 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
     // PLAN / ABONNEMENT
     Route::get('/plan', [\Modules\Tagtoa\App\Http\Controllers\Billing\PlanController::class, 'index'])->name('tagtoa.plan.index');
     Route::post('/plan/subscribe', [\Modules\Tagtoa\App\Http\Controllers\Billing\PlanController::class, 'subscribe'])->name('tagtoa.plan.subscribe');
+    // Un GET direct/périmé sur l'action POST → redirige proprement vers la page plan (pas d'erreur 405/503).
+    Route::get('/plan/subscribe', fn () => redirect()->route('tagtoa.plan.index'));
 
     // BILLING
     Route::get('/billing', [BillingController::class, 'index'])->name('tagtoa.billing.index');


### PR DESCRIPTION
## Problème
`https://tagtoa.com/tagtoa/plan/subscribe` renvoyait **503 Service Unavailable**.

## Causes traitées
1. **Appel passerelle bloquant (cause la plus probable du 503).** Souscrire un forfait **payant** déclenche un appel synchrone à la passerelle. Le driver MonCash enchaîne 2 appels HTTP (jeton puis paiement) à `->timeout(20)` **sans `connectTimeout`** → jusqu'à ~40s. Si la passerelle est lente/mal configurée/injoignable, on dépasse le timeout backend de LiteSpeed → **503**.
   - **Fix** : tous les drivers (MonCash, PayPal, Stripe, CoinPayments) passent à `connectTimeout(5)` + `timeout(10)`. Une passerelle injoignable **échoue vite** → retour propre (« paiement pas encore activé ») au lieu d'un 503.
2. **Accès GET sur une action POST.** `/plan/subscribe` est POST-only (le bouton du forfait POST correctement). Un GET direct (URL tapée, lien périmé, bookmark) renvoyait une erreur.
   - **Fix** : route `GET /plan/subscribe` → redirige vers `/tagtoa/plan`.

## Note
Le déploiement précédent a réussi (le site n'était pas en maintenance). Ces deux correctifs couvrent les deux déclencheurs plausibles du 503 et durcissent le flux de paiement en général.

## Tests
Suite Unit : **115 tests OK** (RouteIntegrity + ViewCompile verts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_