### PR TITLE
PLANS: édition des forfaits TAGTOA depuis l'admin (prix + limites)

### DIFF
--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000095_create_tagtoa_plans_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000095_create_tagtoa_plans_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA — définitions de forfaits éditables (prix + limites) qui SURCHARGENT
+ * la config `tagtoa.plans`. Vide par défaut → on retombe sur la config (sûr).
+ * Permet au fondateur de modifier prix/limites depuis l'admin, sans toucher au code.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_plans', function (Blueprint $table) {
+            $table->id();
+            $table->string('plan_key', 32)->unique();     // free | pro | enterprise
+            $table->string('label')->nullable();
+            $table->decimal('price', 12, 2)->nullable();   // null = sur devis
+            $table->json('limits')->nullable();            // {site:1, menu:1, …} null = illimité
+            $table->unsignedInteger('sort')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_plans');
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Billing/PlanController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Billing/PlanController.php
@@ -31,7 +31,7 @@ class PlanController extends Controller
         }
 
         return view('tagtoa::billing.plan', [
-            'plans'   => (array) config('tagtoa.plans', []),
+            'plans'   => PlanService::effectivePlans(),
             'current' => $current,
             'usage'   => $usage,
         ]);
@@ -39,11 +39,12 @@ class PlanController extends Controller
 
     public function subscribe(Request $request): RedirectResponse
     {
+        $plans = PlanService::effectivePlans();
         $data = $request->validate([
-            'plan' => ['required', Rule::in(array_keys((array) config('tagtoa.plans', [])))],
+            'plan' => ['required', Rule::in(array_keys($plans))],
         ]);
         $plan = $data['plan'];
-        $price = (float) (config('tagtoa.plans.'.$plan.'.price') ?? 0);
+        $price = (float) ($plans[$plan]['price'] ?? 0);
 
         // Forfait PAYANT + passerelle active → paiement avant activation.
         if ($price > 0) {

--- a/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/PlanController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/PlanController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Models\Billing\PlanDefinition;
+use Modules\Tagtoa\App\Services\Audit\AuditService;
+use Modules\Tagtoa\App\Services\Billing\PlanService;
+
+/**
+ * TAGTOA SUPER-ADMIN — édition des forfaits (prix + limites), fondateur uniquement.
+ * Les valeurs saisies surchargent la config `tagtoa.plans` (table tagtoa_plans).
+ */
+class PlanController extends Controller
+{
+    /** Fonctionnalités limitables (clés de `limits`). */
+    protected const FEATURES = ['site', 'menu', 'pay', 'links', 'loyalty', 'event', 'pos', 'booking', 'staff', 'store'];
+
+    public function index(): View
+    {
+        return view('tagtoa::superadmin.plans', [
+            'plans'    => PlanService::effectivePlans(),
+            'features' => self::FEATURES,
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'plans'                  => ['required', 'array'],
+            'plans.*.label'          => ['nullable', 'string', 'max:60'],
+            'plans.*.price'          => ['nullable', 'numeric', 'min:0', 'max:9999999'],
+            'plans.*.limits'         => ['nullable', 'array'],
+            'plans.*.limits.*'       => ['nullable', 'integer', 'min:0', 'max:100000'],
+        ]);
+
+        $sort = 0;
+        foreach ($data['plans'] as $key => $row) {
+            $key = preg_replace('/[^a-z0-9_]/', '', strtolower((string) $key));
+            if ($key === '') {
+                continue;
+            }
+
+            // Limites : champ vide => null (illimité) ; "0" => bloqué ; N => max.
+            $limits = [];
+            foreach (self::FEATURES as $f) {
+                $v = $row['limits'][$f] ?? null;
+                $limits[$f] = ($v === null || $v === '') ? null : (int) $v;
+            }
+
+            PlanDefinition::updateOrCreate(
+                ['plan_key' => $key],
+                [
+                    'label'     => ($row['label'] ?? '') !== '' ? $row['label'] : ucfirst($key),
+                    'price'     => ($row['price'] ?? '') === '' ? null : (float) $row['price'],
+                    'limits'    => $limits,
+                    'sort'      => $sort++,
+                    'is_active' => true,
+                ]
+            );
+        }
+
+        PlanService::flush();
+        app(AuditService::class)->log('plan.config_updated', null, implode(', ', array_keys($data['plans'])));
+
+        return back()->with('success', __('Forfaits mis à jour.'));
+    }
+}

--- a/Modules/Tagtoa/app/Models/Billing/PlanDefinition.php
+++ b/Modules/Tagtoa/app/Models/Billing/PlanDefinition.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Billing;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * TAGTOA — définition de forfait éditable (surcharge la config `tagtoa.plans`).
+ */
+class PlanDefinition extends Model
+{
+    protected $table = 'tagtoa_plans';
+
+    protected $fillable = ['plan_key', 'label', 'price', 'limits', 'sort', 'is_active'];
+
+    protected $casts = [
+        'price'     => 'decimal:2',
+        'limits'    => 'array',
+        'is_active' => 'boolean',
+        'sort'      => 'integer',
+    ];
+}

--- a/Modules/Tagtoa/app/Services/Audit/AuditService.php
+++ b/Modules/Tagtoa/app/Services/Audit/AuditService.php
@@ -26,6 +26,7 @@ class AuditService
         'billing.settled'   => 'Commissions réglées',
         'billing.updated'   => 'Réglages de revenu modifiés',
         'plan.changed'      => 'Forfait modifié',
+        'plan.config_updated' => 'Forfaits (prix/limites) modifiés',
         'wallet.top_up'     => 'Recharge wallet',
         'wallet.purchase'   => 'Achat wallet',
         'wallet.refund'     => 'Remboursement wallet',

--- a/Modules/Tagtoa/app/Services/Billing/PlanService.php
+++ b/Modules/Tagtoa/app/Services/Billing/PlanService.php
@@ -29,15 +29,60 @@ class PlanService
         'booking' => BookingPage::class,
     ];
 
+    /** Cache des forfaits effectifs pour la durée de la requête. */
+    private static ?array $effective = null;
+
     public function planKey(?string $tenantId): string
     {
         return Subscription::planFor($tenantId);
     }
 
+    /**
+     * Forfaits EFFECTIFS = config `tagtoa.plans` surchargée par la table
+     * `tagtoa_plans` (édition fondateur). Tolérant : si la table n'existe pas
+     * ou est vide, on retombe intégralement sur la config.
+     */
+    public static function effectivePlans(): array
+    {
+        if (self::$effective !== null) {
+            return self::$effective;
+        }
+
+        $plans = (array) config('tagtoa.plans', []);
+
+        try {
+            foreach (\Modules\Tagtoa\App\Models\Billing\PlanDefinition::all() as $row) {
+                $key = $row->plan_key;
+                if (! isset($plans[$key])) {
+                    $plans[$key] = [];
+                }
+                if ($row->label !== null && $row->label !== '') {
+                    $plans[$key]['label'] = $row->label;
+                }
+                // price : la valeur DB fait foi (y compris null = sur devis)
+                $plans[$key]['price'] = $row->price === null ? null : (float) $row->price;
+                if (is_array($row->limits)) {
+                    $plans[$key]['limits'] = array_merge($plans[$key]['limits'] ?? [], $row->limits);
+                }
+                $plans[$key]['is_active'] = (bool) $row->is_active;
+            }
+        } catch (\Throwable $e) {
+            // table absente / DB indisponible → config seule
+        }
+
+        return self::$effective = $plans;
+    }
+
+    /** Réinitialise le cache (après une édition des forfaits). */
+    public static function flush(): void
+    {
+        self::$effective = null;
+    }
+
     public function plan(?string $tenantId): array
     {
         $key = $this->planKey($tenantId);
-        $cfg = (array) config('tagtoa.plans.'.$key, []);
+        $cfg = (array) (self::effectivePlans()[$key] ?? []);
         $cfg['key'] = $key;
 
         return $cfg;
@@ -46,7 +91,7 @@ class PlanService
     /** Limite d'une feature (null = illimité, 0 = bloqué). */
     public function limit(?string $tenantId, string $feature)
     {
-        $limits = (array) config('tagtoa.plans.'.$this->planKey($tenantId).'.limits', []);
+        $limits = (array) (self::effectivePlans()[$this->planKey($tenantId)]['limits'] ?? []);
 
         return array_key_exists($feature, $limits) ? $limits[$feature] : null;
     }

--- a/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
+++ b/Modules/Tagtoa/app/Services/Pay/CheckoutService.php
@@ -173,7 +173,7 @@ class CheckoutService
      */
     public function startSubscription(?string $tenantId, string $plan, string $gateway = 'moncash'): ?string
     {
-        $price = (float) (config('tagtoa.plans.'.$plan.'.price') ?? 0);
+        $price = (float) (\Modules\Tagtoa\App\Services\Billing\PlanService::effectivePlans()[$plan]['price'] ?? 0);
         if ($price <= 0 || ! GatewayManager::enabled($gateway)) {
             return null;
         }
@@ -211,7 +211,7 @@ class CheckoutService
         if ($txn->order_type === 'subscription') {
             $plan = $txn->meta['plan'] ?? null;
             $tenantId = $txn->meta['tenant_id'] ?? $txn->tenant_id;
-            if ($plan && array_key_exists($plan, (array) config('tagtoa.plans', []))) {
+            if ($plan && array_key_exists($plan, \Modules\Tagtoa\App\Services\Billing\PlanService::effectivePlans())) {
                 \Modules\Tagtoa\App\Models\Billing\Subscription::updateOrCreate(
                     ['tenant_id' => $tenantId],
                     ['plan' => $plan, 'status' => 'active', 'started_at' => now(), 'expires_at' => now()->addMonth()]

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -935,5 +935,14 @@
     "Boutiques & vente": "Shops & retail",
     "Un seul lien pour MonCash, NatCash et cartes — simple pour vous, simple pour vos clients.": "One link for MonCash, NatCash and cards — simple for you, simple for your customers.",
     "Événements & clubs": "Events & clubs",
-    "Billetterie, carte NFC prépayée et contrôle d'accès — encaissez vite, sans cash à l'entrée.": "Ticketing, prepaid NFC card and access control — get paid fast, no cash at the door."
+    "Billetterie, carte NFC prépayée et contrôle d'accès — encaissez vite, sans cash à l'entrée.": "Ticketing, prepaid NFC card and access control — get paid fast, no cash at the door.",
+    "Forfaits TAGTOA": "TAGTOA plans",
+    "Prix & limites des forfaits": "Plan prices & limits",
+    "Modifiez ici les prix et les limites de chaque forfait TAGTOA. Ces valeurs remplacent la configuration par défaut. Limite vide = illimité · 0 = bloqué.": "Edit each TAGTOA plan's prices and limits here. These values override the default config. Empty limit = unlimited · 0 = blocked.",
+    "Nom affiché": "Display name",
+    "Prix / mois": "Price / month",
+    "vide = sur devis": "empty = on quote",
+    "Limites": "Limits",
+    "Enregistrer les forfaits": "Save plans",
+    "Forfaits mis à jour.": "Plans updated."
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -935,5 +935,14 @@
     "Boutiques & vente": "Tiendas y ventas",
     "Un seul lien pour MonCash, NatCash et cartes — simple pour vous, simple pour vos clients.": "Un solo enlace para MonCash, NatCash y tarjetas — simple para ti, simple para tus clientes.",
     "Événements & clubs": "Eventos y clubes",
-    "Billetterie, carte NFC prépayée et contrôle d'accès — encaissez vite, sans cash à l'entrée.": "Boletería, tarjeta NFC prepago y control de acceso — cobra rápido, sin efectivo en la entrada."
+    "Billetterie, carte NFC prépayée et contrôle d'accès — encaissez vite, sans cash à l'entrée.": "Boletería, tarjeta NFC prepago y control de acceso — cobra rápido, sin efectivo en la entrada.",
+    "Forfaits TAGTOA": "Planes TAGTOA",
+    "Prix & limites des forfaits": "Precios y límites de los planes",
+    "Modifiez ici les prix et les limites de chaque forfait TAGTOA. Ces valeurs remplacent la configuration par défaut. Limite vide = illimité · 0 = bloqué.": "Edita aquí los precios y límites de cada plan TAGTOA. Estos valores anulan la configuración por defecto. Límite vacío = ilimitado · 0 = bloqueado.",
+    "Nom affiché": "Nombre visible",
+    "Prix / mois": "Precio / mes",
+    "vide = sur devis": "vacío = a cotizar",
+    "Limites": "Límites",
+    "Enregistrer les forfaits": "Guardar planes",
+    "Forfaits mis à jour.": "Planes actualizados."
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -935,5 +935,14 @@
     "Boutiques & vente": "Boutik & vant",
     "Un seul lien pour MonCash, NatCash et cartes — simple pour vous, simple pour vos clients.": "Yon sèl lyen pou MonCash, NatCash ak kat — senp pou ou, senp pou kliyan ou.",
     "Événements & clubs": "Evènman & club",
-    "Billetterie, carte NFC prépayée et contrôle d'accès — encaissez vite, sans cash à l'entrée.": "Biyè, kat NFC prépeye ak kontwòl aksè — ankese vit, san kach nan pòt la."
+    "Billetterie, carte NFC prépayée et contrôle d'accès — encaissez vite, sans cash à l'entrée.": "Biyè, kat NFC prépeye ak kontwòl aksè — ankese vit, san kach nan pòt la.",
+    "Forfaits TAGTOA": "Fòfè TAGTOA",
+    "Prix & limites des forfaits": "Pri & limit fòfè yo",
+    "Modifiez ici les prix et les limites de chaque forfait TAGTOA. Ces valeurs remplacent la configuration par défaut. Limite vide = illimité · 0 = bloqué.": "Modifye pri ak limit chak fòfè TAGTOA la. Valè sa yo ranplase konfigirasyon default la. Limit vid = san limit · 0 = bloke.",
+    "Nom affiché": "Non ki afiche",
+    "Prix / mois": "Pri / mwa",
+    "vide = sur devis": "vid = sou devi",
+    "Limites": "Limit yo",
+    "Enregistrer les forfaits": "Anrejistre fòfè yo",
+    "Forfaits mis à jour.": "Fòfè yo mete ajou."
 }

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -119,6 +119,7 @@
             @endphp
             @if($isSuper)
                 <span class="sep">{{ __('Plateforme') }}</span>
+                <a href="{{ url('/tagtoa/admin/plans') }}" class="{{ request()->is('tagtoa/admin/plans*') ? 'on' : '' }}"><i class="fa-solid fa-layer-group"></i> {{ __('Forfaits TAGTOA') }}</a>
                 <a href="{{ url('/sadmin/dashboard') }}"><i class="fa-solid fa-shield-halved"></i> {{ __('Super Admin') }}</a>
             @endif
         </nav>

--- a/Modules/Tagtoa/resources/views/superadmin/plans.blade.php
+++ b/Modules/Tagtoa/resources/views/superadmin/plans.blade.php
@@ -1,0 +1,38 @@
+@extends('tagtoa::layouts.dashboard')
+@section('title', __('Forfaits TAGTOA'))
+@section('page', __('Forfaits TAGTOA'))
+
+@section('content')
+
+<div class="card" style="margin-bottom:18px">
+    <div class="h-row"><h2><i class="fa-solid fa-layer-group"></i> {{ __('Prix & limites des forfaits') }}</h2></div>
+    <p style="color:var(--muted);margin:0">{{ __('Modifiez ici les prix et les limites de chaque forfait TAGTOA. Ces valeurs remplacent la configuration par défaut. Limite vide = illimité · 0 = bloqué.') }}</p>
+</div>
+
+<form method="POST" action="{{ route('tagtoa.superadmin.plans.update') }}">
+    @csrf
+    @method('PUT')
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:16px">
+        @foreach($plans as $key => $p)
+            <div class="card">
+                <div class="h-row"><h2 style="text-transform:capitalize">{{ $key }}</h2></div>
+                <input type="hidden" name="plans[{{ $key }}][_k]" value="{{ $key }}">
+                <label class="lbl">{{ __('Nom affiché') }}</label>
+                <input class="inp" name="plans[{{ $key }}][label]" value="{{ $p['label'] ?? ucfirst($key) }}" maxlength="60">
+                <label class="lbl">{{ __('Prix / mois') }} ({{ __('vide = sur devis') }})</label>
+                <input class="inp" name="plans[{{ $key }}][price]" type="number" step="0.01" min="0" value="{{ $p['price'] ?? '' }}" placeholder="{{ __('Sur devis') }}">
+
+                <div style="margin-top:14px;font-size:12px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)">{{ __('Limites') }}</div>
+                @foreach($features as $f)
+                    @php $lim = $p['limits'][$f] ?? null; @endphp
+                    <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:8px">
+                        <span style="font-size:14px;text-transform:capitalize">{{ $f }}</span>
+                        <input class="inp" style="width:110px" name="plans[{{ $key }}][limits][{{ $f }}]" type="number" min="0" max="100000" value="{{ $lim === null ? '' : $lim }}" placeholder="∞">
+                    </div>
+                @endforeach
+            </div>
+        @endforeach
+    </div>
+    <button class="btn btn-p" type="submit" style="margin-top:18px"><i class="fa-solid fa-floppy-disk"></i> {{ __('Enregistrer les forfaits') }}</button>
+</form>
+@endsection

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -291,4 +291,7 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
 // Hors du groupe multi_tenant : la vue plateforme agrège TOUS les tenants.
 Route::middleware(['auth', 'valid.user', 'role:super_admin'])->prefix('tagtoa/admin')->group(function () {
     Route::get('/', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\DashboardController::class, 'index'])->name('tagtoa.superadmin.index');
+    // Édition des forfaits TAGTOA (prix + limites) — fondateur.
+    Route::get('/plans', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\PlanController::class, 'index'])->name('tagtoa.superadmin.plans');
+    Route::put('/plans', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\PlanController::class, 'update'])->name('tagtoa.superadmin.plans.update');
 });


### PR DESCRIPTION
## Contexte (clarification demandée)
Il y a **deux systèmes de forfaits distincts** :
- `/sadmin` → **Plans / Subscribed Plans** = forfaits **vCard Biztap** (cœur Biztap, hors dépôt). N'affectent pas TAGTOA.
- **Forfaits TAGTOA** (free/pro/enterprise) = limites des modules TAGTOA. Étaient **uniquement en config** (code) — donc pas gérables depuis l'admin.

Cette PR ajoute la **gestion des forfaits TAGTOA dans la sidebar admin TAGTOA** (fondateur), pour éditer prix et limites **sans toucher au code** et sans passer par le sadmin Biztap.

## Changements
- **Table `tagtoa_plans`** (additive) : surcharge éditable de `config('tagtoa.plans')`. Vide → on retombe intégralement sur la config (sûr, aucune régression).
- **`PlanService::effectivePlans()`** : config **surchargée par la DB**, tolérant (table absente → config) et caché par requête. Branché partout où le prix/les limites étaient lus : `PlanService` (limit/plan), `PlanController` (index/subscribe) et `CheckoutService` (prix abonnement + validité).
- **Page super-admin `/tagtoa/admin/plans`** (`role:super_admin`) : édite le nom, le prix (vide = sur devis) et chaque limite (vide = illimité, `0` = bloqué). **Auditée** (`plan.config_updated`).
- **Lien « Forfaits TAGTOA »** dans la sidebar (visible fondateur uniquement).
- Traductions `en/ht/es`.

## Tests
Suite Unit : **115 tests OK** (ViewCompile compile la nouvelle page ; RouteIntegrity valide les nouvelles routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_