### PR TITLE
FIX: 500 à la création d'événement (clé alias absente)

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Event/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/DashboardController.php
@@ -43,7 +43,7 @@ class DashboardController extends Controller
 $data = $this->validateEvent($request);
         $event = new Event($data);
         $event->tenant_id = Tenant::id();
-        $event->alias = $data['alias'] ?: Event::generateAlias($data['title']);
+        $event->alias = ($data['alias'] ?? null) ?: Event::generateAlias($data['title']);
         if ($request->hasFile('cover')) {
             $event->cover_path = $request->file('cover')->store('tagtoa/event-covers', 'public');
         }
@@ -64,7 +64,7 @@ $data = $this->validateEvent($request);
     {
         $event = $this->own($id);
         $data = $this->validateEvent($request, $event->id);
-        $data['alias'] = $data['alias'] ?: $event->alias;
+        $data['alias'] = ($data['alias'] ?? null) ?: $event->alias;
         if ($request->hasFile('cover')) {
             $data['cover_path'] = $request->file('cover')->store('tagtoa/event-covers', 'public');
         }


### PR DESCRIPTION
## Problème
`https://tagtoa.com/tagtoa/event` renvoyait **500** à la création d'un événement.

## Cause (log de production, via diagnose.yml)
```
production.ERROR: Undefined array key "alias"
at Modules/Tagtoa/app/Http/Controllers/Event/DashboardController.php:46
```
`alias` est `nullable` dans la validation. Quand le champ est laissé **vide ou absent**, `$request->validate()` **ne renvoie pas la clé** → `$data['alias']` déclenche une `ErrorException` → 500.

## Correctif
- `store()` et `update()` accèdent désormais via `($data['alias'] ?? null)`. Si l'alias est absent, il est **auto-généré depuis le titre** (`Event::generateAlias`). Plus de 500 — la création fonctionne avec ou sans alias saisi.

## Tests
Suite Unit : **115 tests OK**. Cause confirmée par le log prod ; correctif défensif minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_