### PR TITLE
UX: lien vCard dans la sidebar TAGTOA + diagnostic register/vCard

### DIFF
--- a/.github/workflows/diagnose.yml
+++ b/.github/workflows/diagnose.yml
@@ -138,6 +138,28 @@ jobs:
           cat "$L/resources/views/auth/login.blade.php" 2>/dev/null || echo "absent"
           echo "::endgroup::"
 
+          echo "::group::INSCRIPTION (register) — champs attendus"
+          echo "== fichiers register (vues) =="
+          find "$L/resources/views" -maxdepth 4 -iname 'register*.blade.php' 2>/dev/null | head
+          echo "== champs name= dans register.blade.php =="
+          RV=$(find "$L/resources/views" -maxdepth 4 -iname 'register.blade.php' 2>/dev/null | head -1)
+          echo "fichier: ${RV:-introuvable}"
+          [ -n "$RV" ] && grep -oE 'name="[^"]+"' "$RV" | sort -u
+          echo "== route(s) register (web.php) =="
+          grep -nE "register|Register" "$L/routes/web.php" 2>/dev/null | head -10
+          echo "== RegisterController (règles de validation) =="
+          RC=$(find "$L/app" -iname 'RegisterController.php' 2>/dev/null | head -1)
+          echo "fichier: ${RC:-introuvable}"
+          [ -n "$RC" ] && sed -n '1,140p' "$RC" | grep -nE "required|rules|validator|redirectTo|create\(|'name'|'email'|'first_name'|'last_name'|'username'|'phone'|'mobile'|'password'" | head -40
+          echo "::endgroup::"
+
+          echo "::group::vCARD — tableau de bord & routes (pour lien sidebar)"
+          echo "== routes contenant vcard/dashboard/create (web.php) =="
+          grep -nE "vcard|Vcard|VCard|dashboard|create-vcard|user/dashboard" "$L/routes/web.php" 2>/dev/null | head -30
+          echo "== RouteServiceProvider HOME =="
+          grep -rnE "const HOME|public const HOME|protected \\\$redirectTo|redirectTo =" "$L/app/Providers" 2>/dev/null | head
+          echo "::endgroup::"
+
           echo "::group::laravel.log — messages d'ERREUR (secrets redactés)"
           LOG="$L/storage/logs/laravel.log"
           if [ -f "$LOG" ]; then

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -944,5 +944,6 @@
     "vide = sur devis": "empty = on quote",
     "Limites": "Limits",
     "Enregistrer les forfaits": "Save plans",
-    "Forfaits mis à jour.": "Plans updated."
+    "Forfaits mis à jour.": "Plans updated.",
+    "Ma carte de visite": "My business card"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -944,5 +944,6 @@
     "vide = sur devis": "vacío = a cotizar",
     "Limites": "Límites",
     "Enregistrer les forfaits": "Guardar planes",
-    "Forfaits mis à jour.": "Planes actualizados."
+    "Forfaits mis à jour.": "Planes actualizados.",
+    "Ma carte de visite": "Mi tarjeta de visita"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -944,5 +944,6 @@
     "vide = sur devis": "vid = sou devi",
     "Limites": "Limit yo",
     "Enregistrer les forfaits": "Anrejistre fòfè yo",
-    "Forfaits mis à jour.": "Fòfè yo mete ajou."
+    "Forfaits mis à jour.": "Fòfè yo mete ajou.",
+    "Ma carte de visite": "Kat vizit mwen"
 }

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -93,6 +93,7 @@
         <div class="brand"><span class="logo">⚡</span><b>TAGTOA</b></div>
         <nav class="nav">
             <a href="{{ url('/tagtoa/home') }}" class="{{ request()->is('tagtoa/home') ? 'on' : '' }}"><i class="fa-solid fa-grip"></i> {{ __('Accueil') }}</a>
+            <a href="{{ url('/dashboard') }}"><i class="fa-solid fa-address-card"></i> {{ __('Ma carte de visite') }}</a>
             <span class="sep">{{ __('Modules') }}</span>
             <a href="{{ url('/tagtoa/site') }}" class="{{ request()->is('tagtoa/site*') ? 'on' : '' }}"><i class="fa-solid fa-globe"></i> {{ __('Site web') }}</a>
             <a href="{{ url('/tagtoa/menu') }}" class="{{ request()->is('tagtoa/menu*') ? 'on' : '' }}"><i class="fa-solid fa-utensils"></i> {{ __('Menu') }}</a>


### PR DESCRIPTION
## Changements
- **Lien « Ma carte de visite »** dans la sidebar TAGTOA → `/dashboard` (gestion vCard Biztap). Le client atteint sa carte depuis le shell unifié TAGTOA.
- **diagnose.yml** : bloc d'inspection lecture-seule (champs register, contrôleur, routes vCard) pour construire l'UX sans deviner. Réutilisable pour de futurs diagnostics.

## Ce que le diagnostic a confirmé (cœur Biztap)
- **Inscription déjà minimale** : `first_name`, `last_name`, `email`, `password`, `password_confirmation`, case CGU (+ reCAPTCHA conditionnel, `referral_code` optionnel).
- **`RouteServiceProvider::HOME = '/'`** → après inscription/connexion, l'utilisateur va sur `/` → redirigé vers `/tagtoa/home`. **L'inscription atterrit donc déjà dans le hub unifié.**
- Tableau de bord vCard = `/dashboard`.

## Sur la simplification du formulaire d'inscription
Le formulaire est **déjà minimal** et atterrit déjà dans le hub. Le surcharger pour le rebrander TAGTOA est faisable **mais risqué** : s'il inclut un **reCAPTCHA** validé côté serveur, un override qui l'omet **casserait l'inscription**. Je recommande donc de confirmer d'abord si reCAPTCHA est activé avant de rebrander la page — sinon on garde l'inscription Biztap actuelle (fonctionnelle).

## À signaler (cœur Biztap, hors dépôt)
Le log montre une erreur de boot `BladeUI Icons: "heroicons" set don't have a prefix defined` (04:21). À surveiller — potentiellement liée à une dépendance blade-icons de Biztap. Détails dans le fil.

## Tests
Suite Unit : **115 tests OK** (ViewCompile vert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_