### PR TITLE
EVENT: partage après publication (WhatsApp, Facebook, X, Telegram…)

### DIFF
--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -956,5 +956,8 @@
     "conditions": "terms",
     "la politique de confidentialité": "the privacy policy",
     "Créer mon compte": "Create my account",
-    "Déjà un compte ?": "Already have an account?"
+    "Déjà un compte ?": "Already have an account?",
+    "Partager l'événement": "Share the event",
+    "Partager": "Share",
+    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publish the event (« Published » box below) to get the share link."
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -956,5 +956,8 @@
     "conditions": "términos",
     "la politique de confidentialité": "la política de privacidad",
     "Créer mon compte": "Crear mi cuenta",
-    "Déjà un compte ?": "¿Ya tienes cuenta?"
+    "Déjà un compte ?": "¿Ya tienes cuenta?",
+    "Partager l'événement": "Compartir el evento",
+    "Partager": "Compartir",
+    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publica el evento (casilla « Publié » abajo) para obtener el enlace para compartir."
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -956,5 +956,8 @@
     "conditions": "kondisyon yo",
     "la politique de confidentialité": "règleman konfidansyalite a",
     "Créer mon compte": "Kreye kont mwen",
-    "Déjà un compte ?": "Ou deja gen yon kont?"
+    "Déjà un compte ?": "Ou deja gen yon kont?",
+    "Partager l'événement": "Pataje evènman an",
+    "Partager": "Pataje",
+    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Pibliye evènman an (kaz « Publié » anba a) pou jwenn lyen pataj la."
 }

--- a/Modules/Tagtoa/resources/views/event/form.blade.php
+++ b/Modules/Tagtoa/resources/views/event/form.blade.php
@@ -4,6 +4,21 @@
 @section('page', $editing ? __('Modifier l\'événement') : __('Nouvel événement'))
 
 @section('content')
+@if($editing)
+    @php $eventUrl = url('/event/'.$event->alias); @endphp
+    <div class="card" style="margin-bottom:16px">
+        <div class="h-row"><h2><i class="fa-solid fa-share-nodes"></i> {{ __('Partager l\'événement') }}</h2></div>
+        @if($event->is_published)
+            <div style="display:flex;gap:8px;align-items:center;margin-bottom:12px">
+                <input class="inp" value="{{ $eventUrl }}" readonly onclick="this.select()" style="flex:1">
+                <a href="{{ $eventUrl }}" target="_blank" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-up-right-from-square"></i> {{ __('Voir') }}</a>
+            </div>
+            @include('tagtoa::partials.share-buttons', ['url' => $eventUrl, 'title' => $event->title])
+        @else
+            <div class="empty" style="padding:18px"><i class="fa-solid fa-eye-slash"></i>{{ __('Publiez l\'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.') }}</div>
+        @endif
+    </div>
+@endif
 <form method="POST" enctype="multipart/form-data" action="{{ $editing ? route('tagtoa.event.dashboard.update',$event->id) : route('tagtoa.event.dashboard.store') }}">
     @csrf @if($editing) @method('PUT') @endif
     <div class="card">

--- a/Modules/Tagtoa/resources/views/event/index.blade.php
+++ b/Modules/Tagtoa/resources/views/event/index.blade.php
@@ -23,7 +23,15 @@
                     <a href="{{ route('tagtoa.event.dashboard.checkin.report',$e->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-chart-simple"></i> {{ __('Rapport') }}</a>
                     <a href="{{ route('tagtoa.event.dashboard.badges',$e->id) }}" target="_blank" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-id-badge"></i> {{ __('Badges') }}</a>
                     <a href="{{ route('tagtoa.event.dashboard.staff',$e->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-users"></i> {{ __('Staff') }}</a>
+                    @if($e->is_published)
+                        <button type="button" class="btn btn-o btn-sm" style="flex:0" onclick="var s=document.getElementById('sh-{{ $e->id }}');s.style.display=s.style.display==='none'?'block':'none'"><i class="fa-solid fa-share-nodes"></i> {{ __('Partager') }}</button>
+                    @endif
                 </div>
+                @if($e->is_published)
+                    <div id="sh-{{ $e->id }}" style="display:none;margin-top:12px;padding-top:12px;border-top:1px solid var(--bd,#eee)">
+                        @include('tagtoa::partials.share-buttons', ['url' => url('/event/'.$e->alias), 'title' => $e->title])
+                    </div>
+                @endif
             </div>
         @endforeach
     </div>

--- a/Modules/Tagtoa/resources/views/partials/share-buttons.blade.php
+++ b/Modules/Tagtoa/resources/views/partials/share-buttons.blade.php
@@ -1,0 +1,20 @@
+{{-- TAGTOA — boutons de partage réutilisables (dashboard).
+     Paramètres : $url (lien public), $title (texte). --}}
+@php
+    $shareUrl   = $url ?? '';
+    $shareTitle = $title ?? 'TAGTOA';
+    $enc     = urlencode($shareUrl);
+    $encText = urlencode($shareTitle.' — '.$shareUrl);
+    $encTtl  = urlencode($shareTitle);
+@endphp
+<div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center">
+    <a class="btn btn-o btn-sm" style="flex:0" target="_blank" rel="noopener" href="https://wa.me/?text={{ $encText }}"><i class="fa-brands fa-whatsapp" style="color:#25D366"></i> WhatsApp</a>
+    <a class="btn btn-o btn-sm" style="flex:0" target="_blank" rel="noopener" href="https://www.facebook.com/sharer/sharer.php?u={{ $enc }}"><i class="fa-brands fa-facebook" style="color:#1877F2"></i> Facebook</a>
+    <a class="btn btn-o btn-sm" style="flex:0" target="_blank" rel="noopener" href="https://twitter.com/intent/tweet?text={{ $encTtl }}&url={{ $enc }}"><i class="fa-brands fa-x-twitter"></i> X</a>
+    <a class="btn btn-o btn-sm" style="flex:0" target="_blank" rel="noopener" href="https://t.me/share/url?url={{ $enc }}&text={{ $encTtl }}"><i class="fa-brands fa-telegram" style="color:#0088cc"></i> Telegram</a>
+    <a class="btn btn-o btn-sm" style="flex:0" href="mailto:?subject={{ $encTtl }}&body={{ $encText }}"><i class="fa-solid fa-envelope"></i> {{ __('E-mail') }}</a>
+    <button type="button" class="btn btn-o btn-sm" style="flex:0" data-copy="{{ $shareUrl }}"
+            onclick="var u=this.getAttribute('data-copy');if(navigator.clipboard)navigator.clipboard.writeText(u);var o=this.innerHTML;var b=this;this.innerHTML='<i class=&quot;fa-solid fa-check&quot;></i>';setTimeout(function(){b.innerHTML=o},1200)">
+        <i class="fa-solid fa-copy"></i> {{ __('Copier') }}
+    </button>
+</div>


### PR DESCRIPTION
## Objectif
Après avoir **publié** un événement, l'organisateur doit pouvoir le **partager** (WhatsApp, Facebook, etc.).

## Changements
- **Partial réutilisable** `partials/share-buttons` : WhatsApp, Facebook, X, Telegram, e-mail, et « Copier le lien » — pointant vers l'URL publique `/event/{alias}`.
- **Page d'édition événement** : carte « Partager l'événement » avec le lien public + les boutons de partage (si publié) ; sinon une invite à publier d'abord.
- **Liste des événements** : bouton « Partager » par événement publié (dépliant inline).
- Traductions `en/ht/es`.

## Tests
Suite Unit : **115 tests OK** (ViewCompile compile les vues + le partial ; RouteIntegrity vert).

## Note
Le partial est générique — réutilisable ensuite pour partager d'autres ressources publiques (menu, boutique, page de paiement, liens) si souhaité.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_