### PR TITLE
SHARE: partage sur menu/boutique/liens/paiements + terminal staff en FR

### DIFF
--- a/Modules/Tagtoa/app/Http/Controllers/Event/StaffTerminalController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Event/StaffTerminalController.php
@@ -32,6 +32,10 @@ class StaffTerminalController extends Controller
 
     public function terminal(string $alias): View
     {
+        // Le terminal staff terrain est en FRANÇAIS uniquement (personnel sur place),
+        // même si le reste de la plateforme est multilingue.
+        app()->setLocale('fr');
+
         $event = $this->eventByAlias($alias);
         $staff = $this->currentStaff($event);
 

--- a/Modules/Tagtoa/resources/views/links/index.blade.php
+++ b/Modules/Tagtoa/resources/views/links/index.blade.php
@@ -19,7 +19,9 @@
                 <div class="row" style="margin-top:14px;gap:8px">
                     <a href="{{ route('tagtoa.links.dashboard.edit',$p->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-pen"></i> {{ __('Modifier') }}</a>
                     <form method="POST" action="{{ route('tagtoa.links.dashboard.destroy',$p->id) }}" onsubmit="return confirm('{{ __('Supprimer?') }}')" style="flex:0">@csrf @method('DELETE')<button class="btn btn-o btn-sm" style="color:var(--red)"><i class="fa-solid fa-trash"></i></button></form>
+                    <button type="button" class="btn btn-o btn-sm" style="flex:0" onclick="var b=document.getElementById('sh-links-{{ $p->id }}');b.style.display=b.style.display==='none'?'block':'none'"><i class="fa-solid fa-share-nodes"></i> {{ __('Partager') }}</button>
                 </div>
+                <div id="sh-links-{{ $p->id }}" style="display:none;margin-top:12px">@include('tagtoa::partials.share-buttons', ['url' => url('/links/'.$p->alias), 'title' => $p->title ?? $p->alias])</div>
             </div>
         @endforeach
     </div>

--- a/Modules/Tagtoa/resources/views/menu/index.blade.php
+++ b/Modules/Tagtoa/resources/views/menu/index.blade.php
@@ -41,7 +41,9 @@
                     <a href="{{ route('tagtoa.menu.dashboard.edit',$m->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-pen"></i> {{ __('Modifier') }}</a>
                     <a href="{{ url('/menu/'.$m->alias) }}" target="_blank" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-eye"></i> {{ __('Voir') }}</a>
                     <form method="POST" action="{{ route('tagtoa.menu.dashboard.destroy',$m->id) }}" onsubmit="return confirm('{{ __('Supprimer ce menu ?') }}')" style="flex:0">@csrf @method('DELETE')<button class="btn btn-o btn-sm" style="color:var(--red)"><i class="fa-solid fa-trash"></i></button></form>
+                    <button type="button" class="btn btn-o btn-sm" style="flex:0" onclick="var s=document.getElementById('sh-menu-{{ $m->id }}');s.style.display=s.style.display==='none'?'block':'none'"><i class="fa-solid fa-share-nodes"></i> {{ __('Partager') }}</button>
                 </div>
+                <div id="sh-menu-{{ $m->id }}" style="display:none;margin-top:12px">@include('tagtoa::partials.share-buttons', ['url' => url('/menu/'.$m->alias), 'title' => $m->title ?? $m->alias])</div>
             </div>
         @endforeach
     </div>

--- a/Modules/Tagtoa/resources/views/pay/dashboard/index.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/dashboard/index.blade.php
@@ -30,7 +30,9 @@
                     <form method="POST" action="{{ route('tagtoa.pay.dashboard.destroy',$p->id) }}" onsubmit="return confirm('{{ __('Supprimer?') }}')" style="flex:0">
                         @csrf @method('DELETE')<button class="btn btn-o btn-sm" style="color:var(--red)"><i class="fa-solid fa-trash"></i></button>
                     </form>
+                    <button type="button" class="btn btn-o btn-sm" style="flex:0" onclick="var b=document.getElementById('sh-pay-{{ $p->id }}');b.style.display=b.style.display==='none'?'block':'none'"><i class="fa-solid fa-share-nodes"></i> {{ __('Partager') }}</button>
                 </div>
+                <div id="sh-pay-{{ $p->id }}" style="display:none;margin-top:12px">@include('tagtoa::partials.share-buttons', ['url' => url('/pay/'.$p->alias), 'title' => $p->title ?? $p->alias])</div>
             </div>
         @endforeach
     </div>

--- a/Modules/Tagtoa/resources/views/store/index.blade.php
+++ b/Modules/Tagtoa/resources/views/store/index.blade.php
@@ -27,7 +27,9 @@
                     <a href="{{ route('tagtoa.store.dashboard.edit',$s->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-pen"></i> {{ __('Modifier') }}</a>
                     <a href="{{ route('tagtoa.store.dashboard.orders',$s->id) }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-receipt"></i> {{ __('Commandes') }}</a>
                     <a href="{{ url('/store/'.$s->alias) }}" target="_blank" class="btn btn-d btn-sm" style="flex:0"><i class="fa-solid fa-arrow-up-right-from-square"></i> {{ __('Voir') }}</a>
+                    <button type="button" class="btn btn-o btn-sm" style="flex:0" onclick="var b=document.getElementById('sh-store-{{ $s->id }}');b.style.display=b.style.display==='none'?'block':'none'"><i class="fa-solid fa-share-nodes"></i> {{ __('Partager') }}</button>
                 </div>
+                <div id="sh-store-{{ $s->id }}" style="display:none;margin-top:12px">@include('tagtoa::partials.share-buttons', ['url' => url('/store/'.$s->alias), 'title' => $s->name ?? $s->alias])</div>
             </div>
         @endforeach
     </div>


### PR DESCRIPTION
## Changements
- **Boutons de partage** (WhatsApp, Facebook, X, Telegram, e-mail, copier le lien) ajoutés aux tableaux de bord **Menu, Boutique, Liens et Paiements** — chaque page publique se partage en un clic (partial réutilisable `partials/share-buttons`, déjà utilisé pour les événements).
- **Terminal staff terrain en FRANÇAIS uniquement** (`app()->setLocale('fr')`) : le reste de la plateforme reste multilingue, mais le terminal sur place (personnel) est forcé en français, comme demandé.

## Tests
Suite Unit : **115 tests OK** (ViewCompile compile les 4 tableaux de bord ; RouteIntegrity vert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_