### PR TITLE
PLANS: Revendeur & Franchise + activation carte gated + devises internationales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,12 @@ Hub dashboard: `/tagtoa/home` (PA `/tagtoa` — li antre an konfli ak vcard `{al
   (free/pro/enterprise, limit pa modil), `PlanService` (limit/usage/canCreate),
   trait `EnforcesPlan` (guard nan store() tout modil), paj `/tagtoa/plan` (usage +
   chanjman fòfè self-service). Peman fòfè otomatik = ap vini ak pasrèl PAY.
+  - Plan yo **editab an dirèk** (pri+limit) via `/tagtoa/admin/plans` (super_admin):
+    tab `tagtoa_plans` sipèchaje config la (`PlanService::effectivePlans()`, tolerab).
+  - Plan entènasyonal: **free/pro/enterprise/reseller(Revendeur)/franchise**. Kle limit
+    `cards` = aktivasyon kat NFC (free/pro=0, enterprise/reseller/franchise=∞) → gate nan
+    `Card\DashboardController::store` (EnforcesPlan). Deviz elaji (15: +GBP/XOF/XAF/NGN/…).
+    Modèl biznis NFC: logisyèl-dabò (BYOC), maj kat via revandè/franchise, +% komisyon.
 - **Faz 4 — Eksperyans machann** 🔨 AN KOU:
   - ✅ QR & Partage (`/tagtoa/qr`): QR pa resous piblik (Site/Menu/Pay/Links/Event),
     telechaje SVG, afich enprimab (`Support/Qr` simple-qrcode + fallback qrserver).

--- a/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
@@ -10,15 +10,20 @@ use Modules\Tagtoa\App\Models\Card\CardAccount;
 use Modules\Tagtoa\App\Services\Audit\AuditService;
 use Modules\Tagtoa\App\Services\Card\CardWalletService;
 use Modules\Tagtoa\App\Support\Card\CardWallet;
+use Modules\Tagtoa\App\Support\EnforcesPlan;
 use Modules\Tagtoa\App\Support\Money;
 use Modules\Tagtoa\App\Support\Tenant;
 
 /**
  * TAGTOA CARD — gestion des cartes NFC prépayées closed-loop (émission,
  * recharge, blocage, historique). Scopé au marchand courant.
+ * L'émission/activation de cartes est réservée aux forfaits qui l'autorisent
+ * (Enterprise / Revendeur / Franchise) via EnforcesPlan.
  */
 class DashboardController extends Controller
 {
+    use EnforcesPlan;
+
     public function index(Request $request): View
     {
         $q = trim((string) $request->query('q', ''));
@@ -53,6 +58,11 @@ class DashboardController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
+        // Activation de carte NFC réservée aux forfaits supérieurs.
+        if ($r = $this->planGuard('cards')) {
+            return $r;
+        }
+
         $data = $request->validate([
             'card_uid'       => ['required', 'string', 'max:120'],
             'holder_name'    => ['nullable', 'string', 'max:120'],

--- a/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/PlanController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/PlanController.php
@@ -17,7 +17,7 @@ use Modules\Tagtoa\App\Services\Billing\PlanService;
 class PlanController extends Controller
 {
     /** Fonctionnalités limitables (clés de `limits`). */
-    protected const FEATURES = ['site', 'menu', 'pay', 'links', 'loyalty', 'event', 'pos', 'booking', 'staff', 'store'];
+    protected const FEATURES = ['site', 'menu', 'pay', 'links', 'loyalty', 'event', 'pos', 'booking', 'staff', 'store', 'cards'];
 
     public function index(): View
     {

--- a/Modules/Tagtoa/app/Services/Billing/PlanService.php
+++ b/Modules/Tagtoa/app/Services/Billing/PlanService.php
@@ -27,6 +27,7 @@ class PlanService
         'event'   => Event::class,
         'pos'     => Terminal::class,
         'booking' => BookingPage::class,
+        'cards'   => \Modules\Tagtoa\App\Models\Card\CardAccount::class,
     ];
 
     /** Cache des forfaits effectifs pour la durée de la requête. */

--- a/Modules/Tagtoa/config/config.php
+++ b/Modules/Tagtoa/config/config.php
@@ -25,21 +25,35 @@ return [
     'default_plan' => env('TAGTOA_DEFAULT_PLAN', 'free'),
 
     'plans' => [
+        // `cards` = émission/activation de cartes NFC TAGTOA (closed-loop). Réservé
+        // aux forfaits payants supérieurs (Enterprise/Revendeur/Franchise).
         'free' => [
             'label'  => 'Gratuit',
             'price'  => 0,
-            'limits' => ['site' => 1, 'menu' => 1, 'pay' => 1, 'links' => 1, 'loyalty' => 0, 'event' => 0, 'pos' => 0, 'booking' => 0, 'staff' => 0, 'store' => 1],
+            'limits' => ['site' => 1, 'menu' => 1, 'pay' => 1, 'links' => 1, 'loyalty' => 0, 'event' => 0, 'pos' => 0, 'booking' => 0, 'staff' => 0, 'store' => 1, 'cards' => 0],
         ],
         'pro' => [
             'label'  => 'Pro',
             'price'  => 1500,
             // `staff` = nombre max de comptes staff PAR ÉVÉNEMENT (terrain, PIN).
-            'limits' => ['site' => null, 'menu' => null, 'pay' => null, 'links' => null, 'loyalty' => null, 'event' => null, 'pos' => null, 'booking' => null, 'staff' => 10, 'store' => null],
+            'limits' => ['site' => null, 'menu' => null, 'pay' => null, 'links' => null, 'loyalty' => null, 'event' => null, 'pos' => null, 'booking' => null, 'staff' => 10, 'store' => null, 'cards' => 0],
         ],
         'enterprise' => [
             'label'  => 'Enterprise',
             'price'  => null, // sur devis
-            'limits' => ['site' => null, 'menu' => null, 'pay' => null, 'links' => null, 'loyalty' => null, 'event' => null, 'pos' => null, 'booking' => null, 'staff' => null, 'store' => null],
+            'limits' => ['site' => null, 'menu' => null, 'pay' => null, 'links' => null, 'loyalty' => null, 'event' => null, 'pos' => null, 'booking' => null, 'staff' => null, 'store' => null, 'cards' => null],
+        ],
+        // Revendeur : active/émet des cartes NFC, revend localement (marge matériel).
+        'reseller' => [
+            'label'  => 'Revendeur',
+            'price'  => 5000,
+            'limits' => ['site' => null, 'menu' => null, 'pay' => null, 'links' => null, 'loyalty' => null, 'event' => null, 'pos' => null, 'booking' => null, 'staff' => null, 'store' => null, 'cards' => null],
+        ],
+        // Franchise : déploiement pays/marque, tout illimité (sur devis).
+        'franchise' => [
+            'label'  => 'Franchise',
+            'price'  => null, // sur devis
+            'limits' => ['site' => null, 'menu' => null, 'pay' => null, 'links' => null, 'loyalty' => null, 'event' => null, 'pos' => null, 'booking' => null, 'staff' => null, 'store' => null, 'cards' => null],
         ],
     ],
 
@@ -155,5 +169,16 @@ return [
         'EUR' => ['symbol' => '€',   'name' => 'Euro',              'decimals' => 2, 'position' => 'after'],
         'DOP' => ['symbol' => 'RD$', 'name' => 'Peso dominicain',   'decimals' => 2, 'position' => 'before'],
         'CAD' => ['symbol' => 'C$',  'name' => 'Dollar canadien',   'decimals' => 2, 'position' => 'before'],
+        // International (plateforme mondiale)
+        'GBP' => ['symbol' => '£',    'name' => 'Livre sterling',        'decimals' => 2, 'position' => 'before'],
+        'MXN' => ['symbol' => 'MX$',  'name' => 'Peso mexicain',         'decimals' => 2, 'position' => 'before'],
+        'BRL' => ['symbol' => 'R$',   'name' => 'Real brésilien',        'decimals' => 2, 'position' => 'before'],
+        'XOF' => ['symbol' => 'CFA',  'name' => 'Franc CFA (UEMOA)',     'decimals' => 0, 'position' => 'after'],
+        'XAF' => ['symbol' => 'FCFA', 'name' => 'Franc CFA (CEMAC)',     'decimals' => 0, 'position' => 'after'],
+        'NGN' => ['symbol' => '₦',    'name' => 'Naira nigérian',        'decimals' => 2, 'position' => 'before'],
+        'GHS' => ['symbol' => 'GH₵',  'name' => 'Cedi ghanéen',          'decimals' => 2, 'position' => 'before'],
+        'KES' => ['symbol' => 'KSh',  'name' => 'Shilling kényan',       'decimals' => 2, 'position' => 'before'],
+        'ZAR' => ['symbol' => 'R',    'name' => 'Rand sud-africain',     'decimals' => 2, 'position' => 'before'],
+        'COP' => ['symbol' => 'CO$',  'name' => 'Peso colombien',        'decimals' => 2, 'position' => 'before'],
     ],
 ];


### PR DESCRIPTION
## Modèle NFC international (votre affinement)
Pour activer/émettre des cartes NFC, le marchand doit avoir un **forfait supérieur** (Enterprise / Revendeur / Franchise) ; sinon la plateforme monétise via **commission %** (déjà en place). Devises extensibles pour l'international.

## Changements
- **Nouveaux forfaits** : **Revendeur** (revend des cartes localement — marge matériel) et **Franchise** (déploiement pays/marque, sur devis). `free/pro/enterprise` conservés.
- **Nouvelle limite `cards`** sur chaque forfait : `free/pro = 0`, `enterprise/reseller/franchise = illimité`.
  - `PlanService::MODELS` compte les `CardAccount` (usage réel).
  - L'émission de cartes (`Card\DashboardController::store`) passe par **`EnforcesPlan('cards')`** → un forfait sans droit est redirigé vers `/tagtoa/plan`.
- **Éditeur admin des forfaits** (`/tagtoa/admin/plans`) : `cards` ajouté aux limites modifiables (+ les nouveaux forfaits apparaissent automatiquement).
- **Devises internationales** ajoutées : GBP, MXN, BRL, XOF, XAF, NGN, GHS, KES, ZAR, COP (au-delà de HTG/USD/EUR/DOP/CAD).

## Notes
- Les prix des forfaits (Revendeur = 5000 par défaut, Franchise = sur devis) sont **éditables** dans l'admin sans toucher au code.
- La commission `%` sur les ventes reste active en parallèle (RevenueService) — les deux modèles coexistent, comme demandé.

## Tests
Suite Unit : **115 tests OK**. Config validée (5 forfaits, 15 devises, `cards` gate actif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_