### PR TITLE
CARD: cartes officielles (PIN obligatoire + crédits d'activation sans envoi)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PHP 8.2
+      - name: Setup PHP 8.3
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.2"
+          # 8.3 : les dépendances de l'app (PHPUnit 12, Laravel récent) l'exigent.
+          php-version: "8.3"
           coverage: none
           tools: composer:v2
 

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000096_add_official_to_tagtoa_card_accounts.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000096_add_official_to_tagtoa_card_accounts.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA CARD — marque « officielle » : une carte devient officielle quand un
+ * marchand/organisateur autorisé (plan + crédit d'activation) l'active sur la
+ * plateforme — sans envoi physique. Colonnes additives, nullable/default.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tagtoa_card_accounts', function (Blueprint $table) {
+            $table->boolean('official')->default(false)->after('status');
+            $table->timestamp('activated_at')->nullable()->after('official');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tagtoa_card_accounts', function (Blueprint $table) {
+            $table->dropColumn(['official', 'activated_at']);
+        });
+    }
+};

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000097_create_tagtoa_card_credits_table.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000097_create_tagtoa_card_credits_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA CARD — crédits d'activation de cartes officielles (levier de revenu
+ * international, SANS envoi de matériel). Le fondateur/super-admin accorde/vend
+ * des crédits à un marchand/revendeur ; chaque activation de carte officielle
+ * au-delà du quota du forfait consomme 1 crédit. Disponible = granted - used.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tagtoa_card_credits', function (Blueprint $table) {
+            $table->id();
+            $table->string('tenant_id')->unique();
+            $table->unsignedInteger('granted')->default(0);
+            $table->unsignedInteger('used')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tagtoa_card_credits');
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
@@ -8,6 +8,8 @@ use Illuminate\Http\Request;
 use Illuminate\View\View;
 use Modules\Tagtoa\App\Models\Card\CardAccount;
 use Modules\Tagtoa\App\Services\Audit\AuditService;
+use Modules\Tagtoa\App\Services\Billing\PlanService;
+use Modules\Tagtoa\App\Services\Card\CardCreditService;
 use Modules\Tagtoa\App\Services\Card\CardWalletService;
 use Modules\Tagtoa\App\Support\Card\CardWallet;
 use Modules\Tagtoa\App\Support\EnforcesPlan;
@@ -58,9 +60,16 @@ class DashboardController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        // Activation de carte NFC réservée aux forfaits supérieurs.
-        if ($r = $this->planGuard('cards')) {
-            return $r;
+        // Quota d'activation = limite du forfait (Enterprise/Revendeur/Franchise)
+        // + crédits d'activation achetés. Sans quota → on oriente vers le forfait.
+        $tid       = Tenant::id();
+        $plans     = app(PlanService::class);
+        $planLimit = $plans->limit($tid, 'cards');
+        $usage     = $plans->usage($tid, 'cards');
+        $credits   = app(CardCreditService::class)->available($tid);
+
+        if (! CardWallet::canActivate($planLimit, $credits, $usage)) {
+            return redirect()->route('tagtoa.plan.index')->with('error', __('Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d\'activation.'));
         }
 
         $data = $request->validate([
@@ -83,6 +92,15 @@ class DashboardController extends Controller
             'pin'          => $data['pin'] ?? null,
         ]);
 
+        // Carte nouvellement activée → officielle + consomme un crédit si l'on
+        // dépasse le quota de base du forfait (idempotent : re-tap = pas de doublon).
+        if ($card->wasRecentlyCreated) {
+            if (CardWallet::consumesCredit($planLimit, $usage)) {
+                app(CardCreditService::class)->consume($tid, 1);
+            }
+            $card->update(['official' => true, 'activated_at' => now()]);
+        }
+
         if (! empty($data['initial_amount']) && (float) $data['initial_amount'] > 0) {
             $svc->topUp($card, (float) $data['initial_amount'], [
                 'tenant_id' => Tenant::id(), 'context_type' => 'issue', 'meta' => ['reason' => 'initial'],
@@ -91,7 +109,7 @@ class DashboardController extends Controller
 
         app(AuditService::class)->log('card.issued', $card, $card->masked_code);
 
-        return back()->with('success', __('Carte émise : :code', ['code' => $card->code]));
+        return back()->with('success', __('Carte officielle activée : :code', ['code' => $card->code]));
     }
 
     public function topUp(Request $request, CardAccount $card): RedirectResponse
@@ -131,6 +149,19 @@ class DashboardController extends Controller
         $txns = $card->txns()->paginate(40);
 
         return view('tagtoa::card.show', compact('card', 'txns'));
+    }
+
+    /**
+     * Carte physique imprimable, brandée TAGTOA (à imprimer/coller localement —
+     * la marque voyage numériquement, sans envoi de matériel). QR vers la recharge.
+     */
+    public function printCard(CardAccount $card): View
+    {
+        $this->authorizeCard($card);
+        $rechargeUrl = route('tagtoa.card.recharge').'?code='.urlencode($card->code);
+        $qr = \Modules\Tagtoa\App\Support\Qr::svg($rechargeUrl, 200);
+
+        return view('tagtoa::card.print', compact('card', 'rechargeUrl', 'qr'));
     }
 
     protected function authorizeCard(CardAccount $card): void

--- a/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Card/DashboardController.php
@@ -68,7 +68,9 @@ class DashboardController extends Controller
             'holder_name'    => ['nullable', 'string', 'max:120'],
             'holder_phone'   => ['nullable', 'string', 'max:40'],
             'currency'       => ['required', 'string', 'size:3'],
-            'pin'            => ['nullable', 'regex:/^\d{4,6}$/'],
+            // PIN OBLIGATOIRE : une carte de paiement porte de l'argent → un UID
+            // cloné seul reste inutilisable sans le PIN (anti-clone des tags simples).
+            'pin'            => ['required', 'regex:/^\d{4,6}$/'],
             'initial_amount' => ['nullable', 'numeric', 'min:0', 'max:99999999'],
         ]);
 

--- a/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/CardCreditController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/SuperAdmin/CardCreditController.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Modules\Tagtoa\App\Http\Controllers\SuperAdmin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+use Modules\Tagtoa\App\Models\Card\CardCredit;
+use Modules\Tagtoa\App\Services\Audit\AuditService;
+use Modules\Tagtoa\App\Services\Card\CardCreditService;
+
+/**
+ * TAGTOA SUPER-ADMIN — accorder/vendre des crédits d'activation de cartes
+ * officielles aux marchands/revendeurs (modèle international sans envoi de matériel).
+ */
+class CardCreditController extends Controller
+{
+    public function index(): View
+    {
+        $credits = CardCredit::orderByDesc('granted')->paginate(50);
+
+        return view('tagtoa::superadmin.card-credits', compact('credits'));
+    }
+
+    public function grant(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'tenant_id' => ['required', 'string', 'max:191'],
+            'qty'       => ['required', 'integer', 'min:1', 'max:1000000'],
+        ]);
+
+        $balance = app(CardCreditService::class)->grant($data['tenant_id'], (int) $data['qty']);
+        app(AuditService::class)->log('card.credits_granted', null, $data['tenant_id'].' +'.$data['qty'].' → '.$balance);
+
+        return back()->with('success', __('Crédits accordés. Nouveau solde : :n', ['n' => $balance]));
+    }
+}

--- a/Modules/Tagtoa/app/Models/Card/CardAccount.php
+++ b/Modules/Tagtoa/app/Models/Card/CardAccount.php
@@ -18,11 +18,14 @@ class CardAccount extends Model
 
     protected $fillable = [
         'tenant_id', 'uid_hash', 'uid_enc', 'code', 'holder_name', 'holder_phone',
-        'currency', 'balance_minor', 'pin_hash', 'status', 'issued_at', 'last_used_at',
+        'currency', 'balance_minor', 'pin_hash', 'status', 'official', 'activated_at',
+        'issued_at', 'last_used_at',
     ];
 
     protected $casts = [
         'balance_minor' => 'integer',
+        'official'      => 'boolean',
+        'activated_at'  => 'datetime',
         'issued_at'     => 'datetime',
         'last_used_at'  => 'datetime',
     ];

--- a/Modules/Tagtoa/app/Models/Card/CardCredit.php
+++ b/Modules/Tagtoa/app/Models/Card/CardCredit.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\Tagtoa\App\Models\Card;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * TAGTOA CARD — solde de crédits d'activation de cartes officielles d'un tenant.
+ * Disponible = granted - used.
+ */
+class CardCredit extends Model
+{
+    protected $table = 'tagtoa_card_credits';
+
+    protected $fillable = ['tenant_id', 'granted', 'used'];
+
+    protected $casts = ['granted' => 'integer', 'used' => 'integer'];
+
+    public function getAvailableAttribute(): int
+    {
+        return max(0, (int) $this->granted - (int) $this->used);
+    }
+}

--- a/Modules/Tagtoa/app/Services/Audit/AuditService.php
+++ b/Modules/Tagtoa/app/Services/Audit/AuditService.php
@@ -35,6 +35,7 @@ class AuditService
         'card.top_up'       => 'Recharge carte TAGTOA',
         'card.charged'      => 'Paiement par carte TAGTOA',
         'card.status'       => 'Statut carte TAGTOA modifié',
+        'card.credits_granted' => 'Crédits carte accordés',
     ];
 
     /** Libellé lisible d'une action (repli = action brute). LOGIQUE PURE. */

--- a/Modules/Tagtoa/app/Services/Card/CardCreditService.php
+++ b/Modules/Tagtoa/app/Services/Card/CardCreditService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\Tagtoa\App\Services\Card;
+
+use Illuminate\Support\Facades\DB;
+use Modules\Tagtoa\App\Models\Card\CardCredit;
+
+/**
+ * TAGTOA CARD — crédits d'activation de cartes officielles.
+ *
+ * Le fondateur/super-admin accorde (vend) des crédits à un tenant ;
+ * l'activation d'une carte officielle au-delà du quota du forfait en consomme un.
+ * Tout est atomique et tolérant (table absente → 0 crédit).
+ */
+class CardCreditService
+{
+    /** Crédits achetés disponibles (granted - used). Tolérant. */
+    public function available(?string $tenantId): int
+    {
+        try {
+            $row = CardCredit::where('tenant_id', (string) $tenantId)->first();
+
+            return $row ? (int) $row->available : 0;
+        } catch (\Throwable $e) {
+            return 0;
+        }
+    }
+
+    /** Accorde (ajoute) des crédits à un tenant. Retourne le nouveau solde. */
+    public function grant(?string $tenantId, int $qty): int
+    {
+        $qty = max(1, $qty);
+
+        return DB::transaction(function () use ($tenantId, $qty) {
+            $row = CardCredit::firstOrCreate(['tenant_id' => (string) $tenantId], ['granted' => 0, 'used' => 0]);
+            $row = CardCredit::whereKey($row->id)->lockForUpdate()->first();
+            $row->update(['granted' => (int) $row->granted + $qty]);
+
+            return (int) $row->fresh()->available;
+        });
+    }
+
+    /** Consomme un crédit (activation). Retourne true si consommé, false si épuisé. */
+    public function consume(?string $tenantId, int $qty = 1): bool
+    {
+        $qty = max(1, $qty);
+
+        return (bool) DB::transaction(function () use ($tenantId, $qty) {
+            $row = CardCredit::where('tenant_id', (string) $tenantId)->lockForUpdate()->first();
+            if (! $row || $row->available < $qty) {
+                return false;
+            }
+            $row->update(['used' => (int) $row->used + $qty]);
+
+            return true;
+        });
+    }
+}

--- a/Modules/Tagtoa/app/Support/Card/CardWallet.php
+++ b/Modules/Tagtoa/app/Support/Card/CardWallet.php
@@ -94,4 +94,40 @@ class CardWallet
     {
         return 'CARD-'.strtoupper(bin2hex(random_bytes(5)));
     }
+
+    /**
+     * Quota effectif d'activation de cartes officielles : limite du forfait
+     * (null = illimité) + crédits d'activation achetés. PUR.
+     *
+     * @return int|null null = illimité
+     */
+    public static function effectiveQuota($planLimit, int $credits): ?int
+    {
+        if ($planLimit === null) {
+            return null; // forfait illimité
+        }
+
+        return max(0, (int) $planLimit) + max(0, $credits);
+    }
+
+    /** Peut-on activer une carte de plus ? (quota null = illimité). PUR. */
+    public static function canActivate($planLimit, int $credits, int $usage): bool
+    {
+        $quota = self::effectiveQuota($planLimit, $credits);
+
+        return $quota === null || $usage < $quota;
+    }
+
+    /**
+     * Une activation consomme-t-elle un crédit acheté ? Oui seulement quand
+     * l'usage dépasse le quota de base du forfait (les crédits complètent). PUR.
+     */
+    public static function consumesCredit($planLimit, int $usage): bool
+    {
+        if ($planLimit === null) {
+            return false; // illimité → jamais de crédit
+        }
+
+        return $usage >= max(0, (int) $planLimit);
+    }
 }

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -959,5 +959,6 @@
     "Déjà un compte ?": "Already have an account?",
     "Partager l'événement": "Share the event",
     "Partager": "Share",
-    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publish the event (« Published » box below) to get the share link."
+    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publish the event (« Published » box below) to get the share link.",
+    "Obligatoire — sécurise la carte": "Required — secures the card"
 }

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -960,5 +960,12 @@
     "Partager l'événement": "Share the event",
     "Partager": "Share",
     "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publish the event (« Published » box below) to get the share link.",
-    "Obligatoire — sécurise la carte": "Required — secures the card"
+    "Obligatoire — sécurise la carte": "Required — secures the card",
+    "Crédits cartes": "Card credits",
+    "Imprimer la carte": "Print the card",
+    "Carte officielle activée : :code": "Official card activated: :code",
+    "Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d'activation.": "Card quota reached. Upgrade to a Reseller/Franchise plan or get activation credits.",
+    "Crédits d'activation": "Activation credits",
+    "Crédits d'activation de cartes": "Card activation credits",
+    "Accorder des crédits": "Grant credits"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -959,5 +959,6 @@
     "Déjà un compte ?": "¿Ya tienes cuenta?",
     "Partager l'événement": "Compartir el evento",
     "Partager": "Compartir",
-    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publica el evento (casilla « Publié » abajo) para obtener el enlace para compartir."
+    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publica el evento (casilla « Publié » abajo) para obtener el enlace para compartir.",
+    "Obligatoire — sécurise la carte": "Obligatorio — protege la tarjeta"
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -960,5 +960,12 @@
     "Partager l'événement": "Compartir el evento",
     "Partager": "Compartir",
     "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Publica el evento (casilla « Publié » abajo) para obtener el enlace para compartir.",
-    "Obligatoire — sécurise la carte": "Obligatorio — protege la tarjeta"
+    "Obligatoire — sécurise la carte": "Obligatorio — protege la tarjeta",
+    "Crédits cartes": "Créditos de tarjetas",
+    "Imprimer la carte": "Imprimir la tarjeta",
+    "Carte officielle activée : :code": "Tarjeta oficial activada: :code",
+    "Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d'activation.": "Cuota de tarjetas alcanzada. Pasa a un plan Revendedor/Franquicia u obtén créditos de activación.",
+    "Crédits d'activation": "Créditos de activación",
+    "Crédits d'activation de cartes": "Créditos de activación de tarjetas",
+    "Accorder des crédits": "Otorgar créditos"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -959,5 +959,6 @@
     "Déjà un compte ?": "Ou deja gen yon kont?",
     "Partager l'événement": "Pataje evènman an",
     "Partager": "Pataje",
-    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Pibliye evènman an (kaz « Publié » anba a) pou jwenn lyen pataj la."
+    "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Pibliye evènman an (kaz « Publié » anba a) pou jwenn lyen pataj la.",
+    "Obligatoire — sécurise la carte": "Obligatwa — sekirize kat la"
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -960,5 +960,12 @@
     "Partager l'événement": "Pataje evènman an",
     "Partager": "Pataje",
     "Publiez l'événement (case « Publié » ci-dessous) pour obtenir le lien de partage.": "Pibliye evènman an (kaz « Publié » anba a) pou jwenn lyen pataj la.",
-    "Obligatoire — sécurise la carte": "Obligatwa — sekirize kat la"
+    "Obligatoire — sécurise la carte": "Obligatwa — sekirize kat la",
+    "Crédits cartes": "Kredi kat",
+    "Imprimer la carte": "Enprime kat la",
+    "Carte officielle activée : :code": "Kat ofisyèl aktive : :code",
+    "Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d'activation.": "Kota kat rive. Monte sou yon fòfè Revandè/Franchise oswa jwenn kredi aktivasyon.",
+    "Crédits d'activation": "Kredi aktivasyon",
+    "Crédits d'activation de cartes": "Kredi aktivasyon kat",
+    "Accorder des crédits": "Bay kredi"
 }

--- a/Modules/Tagtoa/resources/views/card/index.blade.php
+++ b/Modules/Tagtoa/resources/views/card/index.blade.php
@@ -42,7 +42,7 @@
                     @endforeach
                 </select>
             </div>
-            <div><label class="lbl">{{ __('PIN (4-6 chiffres)') }}</label><input class="inp" name="pin" inputmode="numeric" maxlength="6" pattern="\d{4,6}" value="{{ old('pin') }}" placeholder="{{ __('Optionnel') }}"></div>
+            <div><label class="lbl">{{ __('PIN (4-6 chiffres)') }} *</label><input class="inp" name="pin" inputmode="numeric" maxlength="6" pattern="\d{4,6}" value="{{ old('pin') }}" placeholder="{{ __('Obligatoire — sécurise la carte') }}" required></div>
             <div><label class="lbl">{{ __('Recharge initiale') }}</label><input class="inp" name="initial_amount" type="number" step="0.01" min="0" value="{{ old('initial_amount') }}" placeholder="0.00"></div>
         </div>
         <button class="btn btn-p" type="submit" style="margin-top:14px"><i class="fa-solid fa-plus"></i> {{ __('Émettre la carte') }}</button>

--- a/Modules/Tagtoa/resources/views/card/print.blade.php
+++ b/Modules/Tagtoa/resources/views/card/print.blade.php
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_','-',app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ __('Carte TAGTOA') }} {{ $card->code }}</title>
+    <style>
+        *{box-sizing:border-box;margin:0;padding:0}
+        body{font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;background:#eceee9;color:#0d140c;display:grid;place-items:center;min-height:100vh;padding:24px}
+        .sheet{text-align:center}
+        /* Format carte bancaire 85.6 × 54 mm */
+        .card{width:340px;height:214px;border-radius:18px;background:linear-gradient(135deg,#0d140c 0%,#14361f 60%,#2cb809 130%);color:#fff;padding:20px;position:relative;overflow:hidden;box-shadow:0 16px 40px rgba(0,0,0,.25);margin:0 auto}
+        .card .brand{display:flex;align-items:center;gap:8px;font-weight:800;font-size:20px;letter-spacing:.03em}
+        .card .brand .b{width:30px;height:30px;border-radius:8px;background:#2cb809;display:flex;align-items:center;justify-content:center;font-size:16px}
+        .card .chip{width:42px;height:32px;border-radius:6px;background:linear-gradient(135deg,#e9d9a0,#c9a94e);margin:18px 0 10px}
+        .card .code{font-family:ui-monospace,monospace;font-size:20px;letter-spacing:.14em;font-weight:700}
+        .card .lbl{font-size:10px;opacity:.7;text-transform:uppercase;letter-spacing:.12em;margin-top:12px}
+        .card .qr{position:absolute;right:16px;bottom:16px;background:#fff;border-radius:8px;padding:5px;width:74px;height:74px}
+        .card .qr svg{width:100%;height:100%;display:block}
+        .card .nfc{position:absolute;right:18px;top:18px;font-size:18px;opacity:.85}
+        .hint{max-width:340px;margin:16px auto 0;color:#566;font-size:13px;line-height:1.5}
+        .btns{margin-top:18px;display:flex;gap:8px;justify-content:center}
+        .btn{border:0;border-radius:10px;padding:11px 18px;font-weight:700;font-size:14px;cursor:pointer;text-decoration:none;display:inline-block}
+        .btn-p{background:#2cb809;color:#fff}.btn-o{background:#fff;border:1px solid #ccd;color:#0d140c}
+        @media print{body{background:#fff}.btns,.hint{display:none}.card{box-shadow:none;border:1px solid #ddd}}
+    </style>
+</head>
+<body>
+    <div class="sheet">
+        <div class="card">
+            <div class="brand"><span class="b">⚡</span> TAGTOA</div>
+            <div class="chip"></div>
+            <div class="lbl">{{ __('Carte') }}</div>
+            <div class="code">{{ $card->code }}</div>
+            <div class="lbl">{{ $card->holder_name ?: __('Carte prépayée') }}</div>
+            <span class="nfc">))) </span>
+            <div class="qr">{!! $qr !!}</div>
+        </div>
+        <p class="hint">{{ __('Imprimez et collez sur votre carte NFC vierge. Le client tape la carte (ou scanne le QR) pour recharger et payer partout sur TAGTOA.') }}</p>
+        <div class="btns">
+            <button class="btn btn-p" onclick="window.print()"><i></i>{{ __('Imprimer') }}</button>
+            <a class="btn btn-o" href="{{ route('tagtoa.cards.show', $card->id) }}">{{ __('Retour') }}</a>
+        </div>
+    </div>
+</body>
+</html>

--- a/Modules/Tagtoa/resources/views/card/show.blade.php
+++ b/Modules/Tagtoa/resources/views/card/show.blade.php
@@ -7,6 +7,7 @@
 <div class="card" style="margin-bottom:18px">
     <div class="h-row">
         <h2><i class="fa-solid fa-credit-card"></i> {{ $card->code }}</h2>
+        <a href="{{ route('tagtoa.cards.print', $card->id) }}" target="_blank" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-print"></i> {{ __('Imprimer la carte') }}</a>
         <a href="{{ route('tagtoa.cards.index') }}" class="btn btn-o btn-sm" style="flex:0"><i class="fa-solid fa-arrow-left"></i> {{ __('Retour') }}</a>
     </div>
     <div style="display:flex;flex-wrap:wrap;gap:24px;align-items:center">

--- a/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
+++ b/Modules/Tagtoa/resources/views/layouts/dashboard.blade.php
@@ -121,6 +121,7 @@
             @if($isSuper)
                 <span class="sep">{{ __('Plateforme') }}</span>
                 <a href="{{ url('/tagtoa/admin/plans') }}" class="{{ request()->is('tagtoa/admin/plans*') ? 'on' : '' }}"><i class="fa-solid fa-layer-group"></i> {{ __('Forfaits TAGTOA') }}</a>
+                <a href="{{ url('/tagtoa/admin/card-credits') }}" class="{{ request()->is('tagtoa/admin/card-credits*') ? 'on' : '' }}"><i class="fa-solid fa-coins"></i> {{ __('Crédits cartes') }}</a>
                 <a href="{{ url('/sadmin/dashboard') }}"><i class="fa-solid fa-shield-halved"></i> {{ __('Super Admin') }}</a>
             @endif
         </nav>

--- a/Modules/Tagtoa/resources/views/superadmin/card-credits.blade.php
+++ b/Modules/Tagtoa/resources/views/superadmin/card-credits.blade.php
@@ -1,0 +1,50 @@
+@extends('tagtoa::layouts.dashboard')
+@section('title', __('Crédits d\'activation'))
+@section('page', __('Crédits d\'activation de cartes'))
+
+@section('content')
+
+<div class="card" style="margin-bottom:18px">
+    <div class="h-row"><h2><i class="fa-solid fa-coins"></i> {{ __('Accorder des crédits') }}</h2></div>
+    <p style="color:var(--muted);margin:0 0 14px">{{ __('Vendez/accordez des crédits d\'activation de cartes officielles TAGTOA à un marchand ou revendeur (par tenant_id). Chaque activation de carte au-delà du quota du forfait consomme 1 crédit — sans envoi de matériel.') }}</p>
+    <form method="POST" action="{{ route('tagtoa.superadmin.credits.grant') }}" style="display:flex;gap:10px;flex-wrap:wrap;align-items:end">
+        @csrf
+        <div style="flex:1;min-width:200px">
+            <label class="lbl">{{ __('Tenant (marchand/revendeur)') }}</label>
+            <input class="inp" name="tenant_id" placeholder="tenant_id" required>
+        </div>
+        <div style="width:160px">
+            <label class="lbl">{{ __('Nombre de crédits') }}</label>
+            <input class="inp" name="qty" type="number" min="1" max="1000000" value="50" required>
+        </div>
+        <button class="btn btn-p" type="submit"><i class="fa-solid fa-plus"></i> {{ __('Accorder') }}</button>
+    </form>
+</div>
+
+<div class="card">
+    <div class="h-row"><h2>{{ __('Soldes par tenant') }}</h2></div>
+    @if($credits->isEmpty())
+        <div class="empty"><i class="fa-solid fa-coins"></i>{{ __('Aucun crédit accordé pour le moment.') }}</div>
+    @else
+        <table>
+            <thead><tr>
+                <th>{{ __('Tenant') }}</th>
+                <th>{{ __('Accordés') }}</th>
+                <th>{{ __('Utilisés') }}</th>
+                <th>{{ __('Disponibles') }}</th>
+            </tr></thead>
+            <tbody>
+            @foreach($credits as $c)
+                <tr>
+                    <td><code>{{ $c->tenant_id }}</code></td>
+                    <td>{{ $c->granted }}</td>
+                    <td>{{ $c->used }}</td>
+                    <td><b>{{ $c->available }}</b></td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+        <div style="margin-top:16px">{{ $credits->links() }}</div>
+    @endif
+</div>
+@endsection

--- a/Modules/Tagtoa/routes/web.php
+++ b/Modules/Tagtoa/routes/web.php
@@ -260,6 +260,7 @@ Route::middleware(['auth', 'valid.user', 'role:admin|super_admin', 'multi_tenant
     Route::get('/cards', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'index'])->name('tagtoa.cards.index');
     Route::post('/cards', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'store'])->name('tagtoa.cards.store');
     Route::get('/cards/{card}', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'show'])->name('tagtoa.cards.show');
+    Route::get('/cards/{card}/print', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'printCard'])->name('tagtoa.cards.print');
     Route::post('/cards/{card}/topup', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'topUp'])->name('tagtoa.cards.topup');
     Route::post('/cards/{card}/status', [\Modules\Tagtoa\App\Http\Controllers\Card\DashboardController::class, 'setStatus'])->name('tagtoa.cards.status');
 
@@ -294,4 +295,7 @@ Route::middleware(['auth', 'valid.user', 'role:super_admin'])->prefix('tagtoa/ad
     // Édition des forfaits TAGTOA (prix + limites) — fondateur.
     Route::get('/plans', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\PlanController::class, 'index'])->name('tagtoa.superadmin.plans');
     Route::put('/plans', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\PlanController::class, 'update'])->name('tagtoa.superadmin.plans.update');
+    // Crédits d'activation de cartes officielles (accorder/vendre aux revendeurs).
+    Route::get('/card-credits', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\CardCreditController::class, 'index'])->name('tagtoa.superadmin.credits');
+    Route::post('/card-credits', [\Modules\Tagtoa\App\Http\Controllers\SuperAdmin\CardCreditController::class, 'grant'])->name('tagtoa.superadmin.credits.grant');
 });

--- a/Modules/Tagtoa/tests/Unit/CardWalletTest.php
+++ b/Modules/Tagtoa/tests/Unit/CardWalletTest.php
@@ -57,6 +57,25 @@ class CardWalletTest extends TestCase
         $this->assertSame(1000, CardWallet::applyTopup(1000, -50));  // recharge négative ignorée
     }
 
+    public function test_effective_quota_and_activation(): void
+    {
+        // Forfait illimité (null) → illimité, aucun crédit consommé.
+        $this->assertNull(CardWallet::effectiveQuota(null, 50));
+        $this->assertTrue(CardWallet::canActivate(null, 0, 999999));
+        $this->assertFalse(CardWallet::consumesCredit(null, 100));
+
+        // Forfait = 0 (bloqué), + 5 crédits achetés → quota effectif 5.
+        $this->assertSame(5, CardWallet::effectiveQuota(0, 5));
+        $this->assertTrue(CardWallet::canActivate(0, 5, 4));
+        $this->assertFalse(CardWallet::canActivate(0, 5, 5)); // quota atteint
+        $this->assertTrue(CardWallet::consumesCredit(0, 0));  // dès la 1re, on puise dans les crédits
+
+        // Forfait = 10, 3 crédits → 13. Les crédits ne se consomment qu'après 10.
+        $this->assertSame(13, CardWallet::effectiveQuota(10, 3));
+        $this->assertFalse(CardWallet::consumesCredit(10, 9));  // encore dans le quota forfait
+        $this->assertTrue(CardWallet::consumesCredit(10, 10));  // au-delà → crédit
+    }
+
     public function test_pin_format(): void
     {
         $this->assertTrue(CardWallet::isValidPinFormat('1234'));


### PR DESCRIPTION
## Modèle : rendre une carte « officielle » SANS envoyer de matériel
Le marchand/revendeur achète des tags NFC **vierges localement** ; la carte devient **officielle TAGTOA** quand il l'active sur la plateforme contre un **crédit d'activation** que vous vendez. La marque et l'autorisation voyagent **numériquement**.

## #1 — Sécurité : PIN obligatoire
Les cartes de paiement (closed-loop) exigent désormais un **PIN 4-6 chiffres** à l'émission → un UID cloné seul reste inutilisable (anti-clone des tags simples NTAG213/216).

## #2 — Cartes officielles via crédits d'activation
- Colonnes `official` + `activated_at` ; table `tagtoa_card_credits` (granted/used/available) + `CardCreditService` (atomique, tolérant).
- **Quota d'activation = limite `cards` du forfait + crédits achetés**. Helpers **PURS testés** (`effectiveQuota` / `canActivate` / `consumesCredit`). L'émission consomme un crédit au-delà du quota de base ; la carte est marquée **officielle**.
- **Super-admin `/tagtoa/admin/card-credits`** : accorder/vendre des crédits par tenant (revendeur) — le levier de revenu international.
- **Carte imprimable brandée TAGTOA** (`/tagtoa/cards/{id}/print`) avec QR de recharge → **la marque sans envoi de matériel** (imprimer/coller localement).

## Autorisation internationale (récap)
Plan (Revendeur/Franchise) = accès · Crédits = quota vendu · Impression brandée = marque · PIN/NTAG424 = sécurité. Aucun envoi physique nécessaire.

## Tests
Suite Unit : **116 tests OK** (nouveaux tests de quota purs ; ViewCompile + RouteIntegrity verts).

## Reste (#3)
Activation NTAG424 (crypto anti-clone) pour cartes premium pré-provisionnées — PR suivante (nécessite provisionnement de clés côté fondateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_