### PR TITLE
CARD SEC #3: NTAG424 prêt à activer + CI cible réellement la suite TAGTOA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install dev tools (phpunit)
         run: composer install --no-interaction --no-progress --prefer-dist
 
-      - name: Unit tests (pure logic)
-        run: vendor/bin/phpunit --testdox --testsuite Unit
+      - name: Unit tests (pure logic TAGTOA)
+        # La racine appartient à l'app GOVIBE (phpunit.xml + tests/Unit à elle).
+        # On cible explicitement la suite TAGTOA avec son bootstrap pur, en
+        # ignorant la configuration racine (--no-configuration).
+        run: vendor/bin/phpunit --no-configuration --bootstrap tests/bootstrap.php --testdox Modules/Tagtoa/tests/Unit

--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000098_add_nfc_security_to_tagtoa_card_accounts.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000098_add_nfc_security_to_tagtoa_card_accounts.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA CARD — sécurité NTAG424 (dormante jusqu'au provisionnement des clés) :
+ * `nfc_secure` marque une carte cryptographique (SUN/SDM), `nfc_last_counter`
+ * stocke le dernier compteur validé (anti-rejeu). Colonnes additives.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tagtoa_card_accounts', function (Blueprint $table) {
+            $table->boolean('nfc_secure')->default(false)->after('official');
+            $table->unsignedInteger('nfc_last_counter')->nullable()->after('nfc_secure');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tagtoa_card_accounts', function (Blueprint $table) {
+            $table->dropColumn(['nfc_secure', 'nfc_last_counter']);
+        });
+    }
+};

--- a/Modules/Tagtoa/app/Models/Card/CardAccount.php
+++ b/Modules/Tagtoa/app/Models/Card/CardAccount.php
@@ -19,13 +19,15 @@ class CardAccount extends Model
     protected $fillable = [
         'tenant_id', 'uid_hash', 'uid_enc', 'code', 'holder_name', 'holder_phone',
         'currency', 'balance_minor', 'pin_hash', 'status', 'official', 'activated_at',
-        'issued_at', 'last_used_at',
+        'nfc_secure', 'nfc_last_counter', 'issued_at', 'last_used_at',
     ];
 
     protected $casts = [
-        'balance_minor' => 'integer',
-        'official'      => 'boolean',
-        'activated_at'  => 'datetime',
+        'balance_minor'    => 'integer',
+        'official'         => 'boolean',
+        'nfc_secure'       => 'boolean',
+        'nfc_last_counter' => 'integer',
+        'activated_at'     => 'datetime',
         'issued_at'     => 'datetime',
         'last_used_at'  => 'datetime',
     ];

--- a/Modules/Tagtoa/app/Support/Nfc/SunVerifier.php
+++ b/Modules/Tagtoa/app/Support/Nfc/SunVerifier.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Modules\Tagtoa\App\Support\Nfc;
+
+/**
+ * TAGTOA — vérificateur de tap NTAG424 (SUN/SDM) : combine la vérification du
+ * CMAC (Ntag424) et l'anti-rejeu (compteur strictement croissant).
+ *
+ * Cœur PUR (clé passée en paramètre) → testable. Le wrapper de config reste
+ * DORMANT tant que `tagtoa.nfc.ntag424` n'a pas de clé (aucun risque).
+ * ⚠️ Ne câbler dans l'encaissement/check-in qu'après validation sur un vrai tag.
+ */
+class SunVerifier
+{
+    /**
+     * Vérifie un tap : CMAC valide ET compteur plus récent que le dernier vu. PUR.
+     *
+     * @param  string    $key         clé maître AES-128 (binaire, 16 octets)
+     * @param  string    $uid         UID (binaire)
+     * @param  string    $ctr         compteur de lecture (binaire, comme Ntag424)
+     * @param  string    $cmac        CMAC fourni par le tag (même format que Ntag424::verify)
+     * @param  int|null  $lastCounter dernier compteur validé (null = première fois)
+     * @return array{ok:bool,counter:int}
+     */
+    public static function verifyTap(string $key, string $uid, string $ctr, string $cmac, ?int $lastCounter): array
+    {
+        $counter = Ntag424::counterValue($ctr);
+
+        $macOk = Ntag424::verify($key, $uid, $ctr, $cmac);
+        $fresh = Ntag424::isFresh($lastCounter, $counter);
+
+        return ['ok' => $macOk && $fresh, 'counter' => $counter];
+    }
+
+    /** NTAG424 activé (clé fournie) ? Tolérant. */
+    public static function enabled(): bool
+    {
+        if (! function_exists('config')) {
+            return false;
+        }
+        $cfg = (array) config('tagtoa.nfc.ntag424', []);
+
+        return ! empty($cfg['enabled']) && ! empty($cfg['key']);
+    }
+
+    /** Clé maître (binaire) depuis la config hex, ou null si absente. Tolérant. */
+    public static function configKey(): ?string
+    {
+        if (! function_exists('config')) {
+            return null;
+        }
+        $hex = (string) config('tagtoa.nfc.ntag424.key', '');
+        if ($hex === '' || ! ctype_xdigit($hex)) {
+            return null;
+        }
+
+        return hex2bin($hex);
+    }
+}

--- a/Modules/Tagtoa/config/config.php
+++ b/Modules/Tagtoa/config/config.php
@@ -24,6 +24,22 @@ return [
     */
     'default_plan' => env('TAGTOA_DEFAULT_PLAN', 'free'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Sécurité NFC — NTAG424 DNA (SUN/SDM, anti-clone/anti-rejeu)
+    |--------------------------------------------------------------------------
+    | DORMANT tant que la clé n'est pas fournie. Pour les cartes PREMIUM
+    | (paiement/event) : chaque tap produit un CMAC signé + un compteur → clone
+    | impossible. Activer : fournir TAGTOA_NTAG424_KEY (clé maître AES-128 hex)
+    | et valider contre un vrai tag AVANT de câbler dans l'encaissement.
+    */
+    'nfc' => [
+        'ntag424' => [
+            'enabled' => env('TAGTOA_NTAG424_ENABLE', false),
+            'key'     => env('TAGTOA_NTAG424_KEY'), // clé maître AES-128 (32 hex), jamais en clair ici
+        ],
+    ],
+
     'plans' => [
         // `cards` = émission/activation de cartes NFC TAGTOA (closed-loop). Réservé
         // aux forfaits payants supérieurs (Enterprise/Revendeur/Franchise).

--- a/Modules/Tagtoa/tests/Unit/SunVerifierTest.php
+++ b/Modules/Tagtoa/tests/Unit/SunVerifierTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Modules\Tagtoa\Tests\Unit;
+
+use Modules\Tagtoa\App\Support\Nfc\Ntag424;
+use Modules\Tagtoa\App\Support\Nfc\SunVerifier;
+use PHPUnit\Framework\TestCase;
+
+/** Vérificateur de tap NTAG424 (CMAC + anti-rejeu), logique pure. */
+class SunVerifierTest extends TestCase
+{
+    private const KEY = '00112233445566778899aabbccddeeff';
+    private const UID = '04a2b3c4d5e680';
+    private const CTR = '050000'; // LE => 5
+
+    private function parts(): array
+    {
+        $key = hex2bin(self::KEY);
+        $uid = hex2bin(self::UID);
+        $ctr = hex2bin(self::CTR);
+
+        return [$key, $uid, $ctr, Ntag424::expectedMac($key, $uid, $ctr)];
+    }
+
+    public function test_valid_fresh_tap_passes(): void
+    {
+        [$key, $uid, $ctr, $cmac] = $this->parts();
+        $r = SunVerifier::verifyTap($key, $uid, $ctr, $cmac, null);
+        $this->assertTrue($r['ok']);
+        $this->assertSame(5, $r['counter']);
+    }
+
+    public function test_replay_is_rejected(): void
+    {
+        [$key, $uid, $ctr, $cmac] = $this->parts();
+        // Compteur déjà vu (5) → rejeu refusé même si le CMAC est correct.
+        $r = SunVerifier::verifyTap($key, $uid, $ctr, $cmac, 5);
+        $this->assertFalse($r['ok']);
+    }
+
+    public function test_bad_cmac_is_rejected(): void
+    {
+        [$key, $uid, $ctr] = $this->parts();
+        $r = SunVerifier::verifyTap($key, $uid, $ctr, 'badmac00', null);
+        $this->assertFalse($r['ok']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,3 +33,4 @@ require_once $base.'/Support/Money.php';
 require_once $base.'/Support/Dev/RouteNames.php';
 require_once $base.'/Support/Nfc/AesCmac.php';
 require_once $base.'/Support/Nfc/Ntag424.php';
+require_once $base.'/Support/Nfc/SunVerifier.php';


### PR DESCRIPTION
## #3 — NTAG424 (SUN/SDM) : anti-clone / anti-rejeu, prêt à activer
Pour les cartes **premium** (paiement/event) : chaque tap produit un CMAC signé + un compteur → **clone impossible**. Le cœur crypto (`AesCmac`, `Ntag424`) existait déjà (prouvé vs vecteurs RFC). Cette PR ajoute :
- **Config** `tagtoa.nfc.ntag424` (clé maître via `TAGTOA_NTAG424_KEY`, **désactivé par défaut** → dormant, aucun risque).
- Colonnes `nfc_secure` + `nfc_last_counter` (anti-rejeu) sur les cartes.
- **`SunVerifier`** : cœur **PUR testé** — un tap est accepté seulement si le **CMAC est valide ET** le **compteur strictement croissant** (anti-rejeu). 3 tests.
- **Non câblé** dans l'encaissement/check-in : activation = fournir la clé + **valider sur un vrai tag** (règle projet) puis brancher. Action fondateur.

## Correctif CI important
La racine du dépôt appartient désormais à l'**app GOVIBE** (elle a son propre `phpunit.xml` + `tests/Unit/ExampleTest`). La CI exécutait donc l'ExampleTest de l'app — **pas la suite TAGTOA**. Corrigé : la CI cible explicitement la suite TAGTOA avec son bootstrap pur → **119 tests réellement validés** (au lieu de 1).

## Tests
Suite TAGTOA : **119 tests OK** (nouveau `SunVerifierTest` inclus).

## Récap sécurité cartes (les 3)
1. ✅ PIN obligatoire (anti-clone tags simples). 2. ✅ Cartes officielles via crédits d'activation (marque + contrôle sans envoi). 3. ✅ NTAG424 prêt à activer (crypto premium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_