### PR TITLE
PAY: prix fixe optionnel sur les liens de paiement (avec ou sans prix)

### DIFF
--- a/Modules/Tagtoa/Database/migrations/2026_06_19_000099_add_amount_to_tagtoa_payment_pages.php
+++ b/Modules/Tagtoa/Database/migrations/2026_06_19_000099_add_amount_to_tagtoa_payment_pages.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TAGTOA PAY — prix FIXE optionnel sur une page/lien de paiement.
+ * `amount` NULL = montant libre (le client saisit) ; sinon montant imposé
+ * (côté serveur = anti-fraude). Colonne additive, nullable.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tagtoa_payment_pages', function (Blueprint $table) {
+            $table->decimal('amount', 14, 2)->nullable()->after('default_currency');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tagtoa_payment_pages', function (Blueprint $table) {
+            $table->dropColumn('amount');
+        });
+    }
+};

--- a/Modules/Tagtoa/app/Http/Controllers/Pay/DashboardController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pay/DashboardController.php
@@ -143,6 +143,7 @@ $data = $this->validatePage($request);
                                    'unique:tagtoa_payment_pages,alias'.($ignoreId ? ','.$ignoreId : '')],
             'description'      => ['nullable', 'string', 'max:1000'],
             'default_currency' => ['nullable', 'string', 'max:10'],
+            'amount'           => ['nullable', 'numeric', 'min:0', 'max:99999999'], // prix fixe (vide = libre)
             'is_active'        => ['nullable', 'boolean'],
         ]);
     }

--- a/Modules/Tagtoa/app/Http/Controllers/Pay/PublicController.php
+++ b/Modules/Tagtoa/app/Http/Controllers/Pay/PublicController.php
@@ -37,7 +37,8 @@ class PublicController extends Controller
         $m = $page->activeMethods()->whereKey($method)->firstOrFail();
 
         $gateway = \Modules\Tagtoa\App\Support\PaymentGateway::driver($m->type);
-        $amount = round((float) $request->input('amount', 0), 2);
+        // Prix fixe → imposé côté serveur (anti-fraude) ; sinon le payeur choisit.
+        $amount = $page->hasFixedAmount() ? (float) $page->amount : round((float) $request->input('amount', 0), 2);
 
         // Passerelle non branchée/non configurée ou montant absent → repli manuel propre.
         if (! $gateway || ! \Modules\Tagtoa\App\Support\GatewayManager::enabled($gateway) || $amount <= 0) {
@@ -71,8 +72,14 @@ class PublicController extends Controller
             'card_uid'  => ['nullable', 'string', 'max:120'],
             'card_code' => ['nullable', 'string', 'max:40'],
             'pin'       => ['nullable', 'string', 'max:6'],
-            'amount'    => ['required', 'numeric', 'min:0.01', 'max:99999999'],
+            'amount'    => ['nullable', 'numeric', 'min:0.01', 'max:99999999'],
         ]);
+
+        // Prix fixe → imposé côté serveur (anti-fraude).
+        $amount = $page->hasFixedAmount() ? (float) $page->amount : (float) ($data['amount'] ?? 0);
+        if ($amount <= 0) {
+            return back()->withInput()->with('error', __('Montant invalide.'));
+        }
 
         if (empty($data['card_uid']) && empty($data['card_code'])) {
             return back()->withInput()->with('error', __('Tapez la carte ou saisissez son code.'));
@@ -87,7 +94,7 @@ class PublicController extends Controller
             return back()->withInput()->with('error', __('Carte TAGTOA introuvable.'));
         }
 
-        $res = $svc->charge($card, (float) $data['amount'], $data['pin'] ?? null, [
+        $res = $svc->charge($card, $amount, $data['pin'] ?? null, [
             'tenant_id'    => $page->tenant_id,
             'context_type' => 'pay_page',
             'context_id'   => $page->id,
@@ -105,7 +112,7 @@ class PublicController extends Controller
                 'payment_method_id' => $page->activeMethods()->where('type', 'tagtoa_card')->value('id'),
                 'payer_name'        => $card->holder_name ?: __('Carte TAGTOA'),
                 'payer_phone'       => $card->holder_phone,
-                'amount'            => (float) $data['amount'],
+                'amount'            => $amount,
                 'currency'          => $card->currency,
                 'status'            => \Modules\Tagtoa\App\Models\Pay\PaymentProof::STATUS_APPROVED,
                 'note'              => __('Payé par Carte TAGTOA').' ('.$card->masked_code.')',
@@ -150,7 +157,7 @@ class PublicController extends Controller
             'payment_method_id' => $method->id,
             'payer_name'        => $data['payer_name'],
             'payer_phone'       => $data['payer_phone'] ?? null,
-            'amount'            => $data['amount'] ?? null,
+            'amount'            => $page->hasFixedAmount() ? (float) $page->amount : ($data['amount'] ?? null),
             'currency'          => $page->default_currency,
             'reference'         => $data['reference'] ?? null,
             'proof_path'        => $path,

--- a/Modules/Tagtoa/app/Models/Pay/PaymentPage.php
+++ b/Modules/Tagtoa/app/Models/Pay/PaymentPage.php
@@ -17,10 +17,16 @@ class PaymentPage extends Model
 
     protected $fillable = [
         'vcard_id', 'tenant_id', 'title', 'alias', 'description',
-        'default_currency', 'is_active', 'views',
+        'default_currency', 'amount', 'is_active', 'views',
     ];
 
-    protected $casts = ['is_active' => 'boolean', 'views' => 'integer'];
+    protected $casts = ['is_active' => 'boolean', 'views' => 'integer', 'amount' => 'decimal:2'];
+
+    /** Prix fixe imposé ? (montant renseigné et > 0). */
+    public function hasFixedAmount(): bool
+    {
+        return $this->amount !== null && (float) $this->amount > 0;
+    }
 
     /** Méthodes supportées : label + icône (classe FA complète) + région (groupe UI). */
     public const METHODS = [

--- a/Modules/Tagtoa/resources/lang/en.json
+++ b/Modules/Tagtoa/resources/lang/en.json
@@ -967,5 +967,9 @@
     "Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d'activation.": "Card quota reached. Upgrade to a Reseller/Franchise plan or get activation credits.",
     "Crédits d'activation": "Activation credits",
     "Crédits d'activation de cartes": "Card activation credits",
-    "Accorder des crédits": "Grant credits"
+    "Accorder des crédits": "Grant credits",
+    "Prix fixe": "Fixed price",
+    "vide = le client choisit le montant": "empty = the customer chooses the amount",
+    "Montant libre": "Open amount",
+    "Montant invalide.": "Invalid amount."
 }

--- a/Modules/Tagtoa/resources/lang/es.json
+++ b/Modules/Tagtoa/resources/lang/es.json
@@ -967,5 +967,9 @@
     "Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d'activation.": "Cuota de tarjetas alcanzada. Pasa a un plan Revendedor/Franquicia u obtén créditos de activación.",
     "Crédits d'activation": "Créditos de activación",
     "Crédits d'activation de cartes": "Créditos de activación de tarjetas",
-    "Accorder des crédits": "Otorgar créditos"
+    "Accorder des crédits": "Otorgar créditos",
+    "Prix fixe": "Precio fijo",
+    "vide = le client choisit le montant": "vacío = el cliente elige el monto",
+    "Montant libre": "Monto libre",
+    "Montant invalide.": "Monto inválido."
 }

--- a/Modules/Tagtoa/resources/lang/ht.json
+++ b/Modules/Tagtoa/resources/lang/ht.json
@@ -967,5 +967,9 @@
     "Quota de cartes atteint. Passez à un forfait Revendeur/Franchise ou obtenez des crédits d'activation.": "Kota kat rive. Monte sou yon fòfè Revandè/Franchise oswa jwenn kredi aktivasyon.",
     "Crédits d'activation": "Kredi aktivasyon",
     "Crédits d'activation de cartes": "Kredi aktivasyon kat",
-    "Accorder des crédits": "Bay kredi"
+    "Accorder des crédits": "Bay kredi",
+    "Prix fixe": "Pri fiks",
+    "vide = le client choisit le montant": "vid = kliyan an chwazi montan an",
+    "Montant libre": "Montan lib",
+    "Montant invalide.": "Montan pa valab."
 }

--- a/Modules/Tagtoa/resources/views/pay/dashboard/form.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/dashboard/form.blade.php
@@ -10,6 +10,7 @@
         <div class="row">
             <div><label class="lbl">{{ __('Titre') }}</label><input class="inp" name="title" value="{{ old('title',$page->title) }}" placeholder="{{ __('Payez Jean Baptiste') }}"></div>
             <div><label class="lbl">{{ __('Devise') }}</label><select class="sel" name="default_currency">@foreach(\Modules\Tagtoa\App\Support\Money::options() as $code=>$label)<option value="{{ $code }}" @selected(old('default_currency',$page->default_currency ?: 'HTG')===$code)>{{ $label }}</option>@endforeach</select></div>
+            <div><label class="lbl">{{ __('Prix fixe') }} <span style="font-weight:400;color:var(--muted)">({{ __('vide = le client choisit le montant') }})</span></label><input class="inp" name="amount" type="number" step="0.01" min="0" value="{{ old('amount',$page->amount) }}" placeholder="{{ __('Montant libre') }}"></div>
         </div>
         <label class="lbl">{{ __('Alias (URL)') }}</label>
         <div style="display:flex;align-items:center;gap:8px"><span style="color:var(--muted);font-size:14px">tagtoa.com/pay/</span><input class="inp" name="alias" value="{{ old('alias',$page->alias) }}" placeholder="{{ __('auto si vide') }}"></div>

--- a/Modules/Tagtoa/resources/views/pay/show.blade.php
+++ b/Modules/Tagtoa/resources/views/pay/show.blade.php
@@ -57,10 +57,17 @@
 <body>
 <div style="position:fixed;top:12px;right:12px;z-index:50">@include('tagtoa::partials.lang')</div>
 <div class="wrap">
+    @php $fixed = $page->hasFixedAmount(); $fixedVal = $fixed ? number_format((float) $page->amount, 2, '.', '') : ''; @endphp
     <header class="hd">
         <span class="badge"><i class="fa-solid fa-wifi"></i> TAGTOA PAY</span>
         <h1>{{ $page->title ?: __('Effectuer un paiement') }}</h1>
         @if($page->description)<p>{{ $page->description }}</p>@endif
+        @if($fixed)
+            <div style="position:relative;margin-top:12px;display:inline-flex;align-items:baseline;gap:6px;background:rgba(255,255,255,.12);padding:8px 16px;border-radius:12px">
+                <span style="font-size:12px;opacity:.8">{{ __('Montant à payer') }}</span>
+                <b style="font-family:var(--fh);font-size:22px">{{ \Modules\Tagtoa\App\Support\Money::format((float) $page->amount, $page->default_currency) }}</b>
+            </div>
+        @endif
     </header>
 
     @if(session('card_paid'))
@@ -101,7 +108,7 @@
                         @if($m->onlineAvailable())
                             <form method="GET" action="{{ route('tagtoa.pay.checkout', [$page->alias, $m->id]) }}" style="margin-bottom:14px">
                                 <label class="lbl">{{ __('Montant à payer') }} ({{ $page->default_currency }}) *</label>
-                                <input class="inp" name="amount" type="number" step="0.01" min="1" required placeholder="0.00">
+                                <input class="inp" name="amount" type="number" step="0.01" min="1" required placeholder="0.00" value="{{ $fixedVal }}" @readonly($fixed)>
                                 <label class="lbl">{{ __('Votre nom') }}</label>
                                 <input class="inp" name="payer_name" maxlength="120" placeholder="{{ __('Optionnel') }}">
                                 <label class="lbl">{{ __('Téléphone (WhatsApp)') }}</label>
@@ -121,7 +128,7 @@
                                 <label class="lbl">{{ __('Code PIN') }}</label>
                                 <input class="inp" name="pin" inputmode="numeric" maxlength="6" pattern="\d*" placeholder="••••">
                                 <label class="lbl">{{ __('Montant à payer') }} ({{ $page->default_currency }}) *</label>
-                                <input class="inp" name="amount" type="number" step="0.01" min="0.01" required placeholder="0.00">
+                                <input class="inp" name="amount" type="number" step="0.01" min="0.01" required placeholder="0.00" value="{{ $fixedVal }}" @readonly($fixed)>
                                 <button class="btn btn-p" type="submit" style="margin-top:10px"><i class="fa-solid fa-bolt"></i> {{ __('Payer avec la carte') }}</button>
                             </form>
                         @endif
@@ -139,7 +146,7 @@
                             <label class="lbl">{{ __('Téléphone (WhatsApp)') }}</label>
                             <input class="inp" name="payer_phone" maxlength="40" value="{{ old('payer_phone') }}" placeholder="+509 ...">
                             <label class="lbl">{{ __('Montant') }} ({{ $page->default_currency }})</label>
-                            <input class="inp" name="amount" type="number" step="0.01" min="0" value="{{ old('amount') }}" placeholder="0.00">
+                            <input class="inp" name="amount" type="number" step="0.01" min="0" value="{{ $fixed ? $fixedVal : old('amount') }}" placeholder="0.00" @readonly($fixed)>
                             <label class="lbl">{{ __('Référence / N° transaction') }}</label>
                             <input class="inp" name="reference" maxlength="120" value="{{ old('reference') }}" placeholder="{{ __('Optionnel') }}">
                             <label class="lbl">{{ __('Preuve (capture)') }} {{ $m->requires_proof ? '*' : '' }}</label>


### PR DESCRIPTION
## Objectif
Permettre à un marchand de créer un **lien de paiement avec un prix fixe OU sans prix (montant libre)** et de le partager n'importe où.

## Changements
- **Colonne `amount`** (nullable) sur `tagtoa_payment_pages` : `NULL` = montant libre (le client saisit) ; renseigné = **prix imposé**.
- **Formulaire dashboard** : champ « Prix fixe (vide = le client choisit) ».
- **Page publique `/pay/{alias}`** : le prix fixe s'affiche en évidence, et les **3 parcours** (paiement en ligne, Carte TAGTOA, preuve manuelle) verrouillent/affichent le montant.
- **Anti-fraude** : le montant fixe est **toujours imposé côté serveur** (checkout en ligne, débit carte, preuve) — la valeur saisie côté client est ignorée.
- Partage déjà en place (boutons WhatsApp/Facebook/… ajoutés précédemment au tableau de bord PAY).

## Tests
Suite TAGTOA : **119 tests OK** (ViewCompile compile la page + le formulaire).

## PAY — état / ce qui restait
Déjà présent : pages multi-méthodes (24 moyens), checkout en ligne (MonCash/PayPal/CoinPayments/Stripe), Carte TAGTOA, preuves manuelles, commission, partage. **Manquait : le prix fixe optionnel** → ajouté ici. Le « lien » = l'URL `/pay/{alias}` (partageable partout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B

---
_Generated by [Claude Code](https://claude.ai/code/session_0164tGtdppVcyVtURSRLMZ8B)_